### PR TITLE
Fix typo in identify() docstring

### DIFF
--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -48,7 +48,7 @@ def identify(distinct_id: str, properties: Optional[Dict]=None, context: Optiona
 
     For example:
     ```python
-    posthog.capture('distinct id', {
+    posthog.identify('distinct id', {
         'email': 'dwayne@gmail.com',
         'name': 'Dwayne Johnson'
     })


### PR DESCRIPTION
Just had a first look into the package and stumbled upon this lil typo.