### PR TITLE
Default to False if the feature flag key does not exist. None is confusing

### DIFF
--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -104,7 +104,7 @@ def alias(
 def feature_enabled(
     key, # type: str,
     distinct_id, # type: str,
-    default=False, # type: Optional[Any]
+    default=False, # type: bool 
     ):
     # type: (...) -> bool
     """

--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -104,7 +104,7 @@ def alias(
 def feature_enabled(
     key, # type: str,
     distinct_id, # type: str,
-    default=None, # type: Optional[Any]
+    default=False, # type: Optional[Any]
     ):
     # type: (...) -> bool
     """


### PR DESCRIPTION
Currently we have two defaults set in the chain. At the top it defaults the flag to None. Later we default to False even though we always pass None in making that default moot.

