### PR TITLE
Allow passing in UUID as property

### DIFF
--- a/posthog/test/utils.py
+++ b/posthog/test/utils.py
@@ -1,5 +1,6 @@
 from datetime import date, datetime, timedelta
 from decimal import Decimal
+from uuid import UUID
 import unittest
 
 from dateutil.tz import tzutc
@@ -49,6 +50,9 @@ class TestUtils(unittest.TestCase):
 
         utils.clean(combined)
         self.assertEqual(combined.keys(), pre_clean_keys)
+
+        # test UUID separately, as the UUID object doesn't equal its string representation according to Python
+        self.assertEqual(utils.clean(UUID('12345678123456781234567812345678')), '12345678-1234-5678-1234-567812345678')
 
     def test_clean_with_dates(self):
         dict_with_dates = {

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -1,6 +1,7 @@
 from dateutil.tz import tzlocal, tzutc
 from datetime import date, datetime
 from decimal import Decimal
+from uuid import UUID
 import logging
 import numbers
 
@@ -47,6 +48,8 @@ def remove_trailing_slash(host):
 def clean(item):
     if isinstance(item, Decimal):
         return float(item)
+    if isinstance(item, UUID):
+        return str(item)
     elif isinstance(item, (six.string_types, bool, numbers.Number, datetime,
                            date, type(None))):
         return item


### PR DESCRIPTION
This should handle UUIDs by converting them to strings instead of crashing the analytics request. Proper fix to PostHog/posthog#2199.