### PR TITLE
Add project_api_key, improve errors

### DIFF
--- a/posthog/client.py
+++ b/posthog/client.py
@@ -32,13 +32,13 @@ class Client(object):
     def __init__(self, api_key=None, host=None, debug=False,
                  max_queue_size=10000, send=True, on_error=None, flush_at=100,
                  flush_interval=0.5, gzip=False, max_retries=3,
-                 sync_mode=False, timeout=15, thread=1, poll_interval=30, personal_api_key=None):
+                 sync_mode=False, timeout=15, thread=1, poll_interval=30, personal_api_key=None, project_api_key=None):
         require('api_key', api_key, string_types)
 
         self.queue = queue.Queue(max_queue_size)
         
         # api_key: This should be the Team API Key (token), public
-        self.api_key = api_key
+        self.api_key = api_key or project_api_key
         self.on_error = on_error
         self.debug = debug
         self.send = send

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -240,6 +240,11 @@ class Client(object):
                     'To use feature flags, please set a personal_api_key ' \
                     'More information: https://posthog.com/docs/api/overview'
                 )
+            else:
+                raise APIError(
+                    status=e.status, 
+                    message=e.message
+                )
         except Exception as e:
             self.log.warning('[FEATURE FLAGS] Fetching feature flags failed with following error. We will retry in %s seconds.' % self.poll_interval)
             self.log.warning(e)

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -33,12 +33,14 @@ class Client(object):
                  max_queue_size=10000, send=True, on_error=None, flush_at=100,
                  flush_interval=0.5, gzip=False, max_retries=3,
                  sync_mode=False, timeout=15, thread=1, poll_interval=30, personal_api_key=None, project_api_key=None):
-        require('api_key', api_key, string_types)
 
         self.queue = queue.Queue(max_queue_size)
         
         # api_key: This should be the Team API Key (token), public
         self.api_key = api_key or project_api_key
+
+        require('api_key', self.api_key, string_types)
+
         self.on_error = on_error
         self.debug = debug
         self.send = send

--- a/posthog/request.py
+++ b/posthog/request.py
@@ -46,13 +46,13 @@ def post(api_key, host=None, path=None, gzip=False, timeout=15, **kwargs):
         return res
 
 
-def _process_response(res, success_message):
+def _process_response(res, success_message, return_json=True):
     log = logging.getLogger('posthog')
     if not res:
         raise APIError('N/A', 'Error when fetching PostHog API, please make sure you are using your public project token/key and not a private API key.')
     if res.status_code == 200:
         log.debug(success_message)
-        return res.json()
+        return res.json() if return_json else res
     try:
         payload = res.json()
         log.debug('received response: %s', payload)
@@ -69,7 +69,7 @@ def decide(api_key, host=None, gzip=False, timeout=15, **kwargs):
 def batch_post(api_key, host=None, gzip=False, timeout=15, **kwargs):
     """Post the `kwargs` to the batch API endpoint for events"""
     res = post(api_key, host, '/batch/', gzip, timeout, **kwargs)
-    return _process_response(res, success_message='data uploaded successfully')
+    return _process_response(res, success_message='data uploaded successfully', return_json=False)
 
 
 def get(api_key, url, host=None, timeout=None):


### PR DESCRIPTION
- Add a `project_api_key` config param to be used instead of `api_key` help minimize confusion on the type of key to use. This is backwards compatible with `api_key` and the docs will be updated accordingly
- Consolidate repeated code
- Handle a case when response is equal to `None`, leading to errors that aren't helpful such as:

```
error uploading: 'NoneType' object has no attribute 'status_code'
```