### PR TITLE
Add condition for rollout-percentage

### DIFF
--- a/posthog/client.py
+++ b/posthog/client.py
@@ -296,7 +296,7 @@ class Client(object):
             except IndexError:
                 return default
 
-            if feature_flag.get("is_simple_flag"):
+            if feature_flag.get("is_simple_flag") and feature_flag.get("rollout_percentage"):
                 response = _hash(key, distinct_id) <= (feature_flag["rollout_percentage"] / 100)
             else:
                 try:


### PR DESCRIPTION
Quick patch for [this sentry error](https://sentry.io/organizations/posthog/issues/2178357897/?project=1899813) so the request will just be sent to the decide endpoint.
Need further investigation as to why that field isn't populated