### PR TITLE
Add UUID to ID_TYPES

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ dist/
 MANIFEST
 build/
 .eggs/
-.coverage/
+.coverage
 .vscode/
 env/
 venv/

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -3,9 +3,8 @@ import hashlib
 import logging
 import numbers
 from datetime import datetime, timedelta
-from uuid import uuid4
+from uuid import UUID, uuid4
 
-import requests
 from dateutil.tz import tzutc
 from six import string_types
 
@@ -21,7 +20,7 @@ except ImportError:
     import Queue as queue
 
 
-ID_TYPES = (numbers.Number, string_types)
+ID_TYPES = (numbers.Number, string_types, UUID)
 __LONG_SCALE__ = float(0xFFFFFFFFFFFFFFF)
 
 

--- a/posthog/test/client.py
+++ b/posthog/test/client.py
@@ -1,6 +1,7 @@
 import time
 import unittest
 from datetime import date, datetime
+from uuid import uuid4
 
 import mock
 import six
@@ -120,6 +121,16 @@ class TestClient(unittest.TestCase):
         client.flush()
         self.assertTrue(success)
         self.assertEqual(msg["distinct_id"], "distinct_id")
+        self.assertEqual(msg["properties"]["$current_url"], "https://posthog.com/contact")
+
+    def test_basic_page_distinct_uuid(self):
+        client = self.client
+        distinct_id = uuid4()
+        success, msg = client.page(distinct_id, url="https://posthog.com/contact")
+        self.assertFalse(self.failed)
+        client.flush()
+        self.assertTrue(success)
+        self.assertEqual(msg["distinct_id"], str(distinct_id))
         self.assertEqual(msg["properties"]["$current_url"], "https://posthog.com/contact")
 
     def test_advanced_page(self):


### PR DESCRIPTION
Makes `UUID` an accepted ID type. No changed in processing code needed, as `stringify_id` already `str()`-casts IDs. Resolves #25.