### PR TITLE
fix: Add distinct id to $create_alias event

### DIFF
--- a/posthog/client.py
+++ b/posthog/client.py
@@ -151,6 +151,7 @@ class Client(object):
             "timestamp": timestamp,
             "context": context,
             "event": "$create_alias",
+            "distinct_id": previous_id,
         }
 
         return self._enqueue(msg)

--- a/posthog/consumer.py
+++ b/posthog/consumer.py
@@ -117,7 +117,7 @@ class Consumer(Thread):
         return items
 
     def request(self, batch):
-        """Attempt to upload the batch and retry before raising an error """
+        """Attempt to upload the batch and retry before raising an error"""
 
         def fatal_exception(exc):
             if isinstance(exc, APIError):


### PR DESCRIPTION
Alias event generated by the current code looks like this:

```{
'properties': {'distinct_id': 'anon-6666666666666', 'alias': 'public-2', '$lib': 'posthog-python', '$lib_version': '1.2.1'}, 'timestamp': '2021-05-07T05:41:05.037966+00:00', 'context': {}, 'event': '$create_alias', 'messageId': 'daab4896-44d5-4c13-8ea5-9d9490be6145', 'distinct_id': None}
```
And since `distinct_id` is none it does not work as expected.
This patch tries to fix that problem by adding `distinct_id` to the event.