### PR TITLE
Revert UUID test change

### DIFF
--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -183,7 +183,7 @@ class TestClient(unittest.TestCase):
 
     def test_basic_page_distinct_uuid(self):
         client = self.client
-        distinct_id = str(uuid4())
+        distinct_id = uuid4()
         success, msg = client.page(distinct_id, url="https://posthog.com/contact")
         self.assertFalse(self.failed)
         client.flush()


### PR DESCRIPTION
Test wasn't passing because set_once branch wasn't uptodate with master. Now ID_TYPES includes UUID. Refer to #26 and #25 