### PR TITLE
Add support for project_api_key. 

### DIFF
--- a/example.py
+++ b/example.py
@@ -6,8 +6,8 @@ import time
 import posthog
 
 # You can find this key on the /setup page in PostHog
-posthog.project_api_key = "LXP6nQXvo-2TCqGVrWvPah8uJIyVykoMmhnEkEBi5PA"
-posthog.personal_api_key = "PU18e4m2KOcc3iNjpKBBz439B8jyL0IYlvg3jcWptJk"
+posthog.project_api_key = ""
+posthog.personal_api_key = ""
 
 # Where you host PostHog, with no trailing /.
 # You can remove this line if you're using posthog.com

--- a/example.py
+++ b/example.py
@@ -6,8 +6,8 @@ import time
 import posthog
 
 # You can find this key on the /setup page in PostHog
-posthog.api_key = ""
-posthog.personal_api_key = ""
+posthog.project_api_key = "LXP6nQXvo-2TCqGVrWvPah8uJIyVykoMmhnEkEBi5PA"
+posthog.personal_api_key = "PU18e4m2KOcc3iNjpKBBz439B8jyL0IYlvg3jcWptJk"
 
 # Where you host PostHog, with no trailing /.
 # You can remove this line if you're using posthog.com

--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -14,7 +14,7 @@ send = True  # type: bool
 sync_mode = False  # type: bool
 disabled = False  # type: bool
 personal_api_key = None  # type: str
-project_api_key = None # type: str
+project_api_key = None  # type: str
 
 default_client = None
 

--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -14,13 +14,14 @@ send = True  # type: bool
 sync_mode = False  # type: bool
 disabled = False  # type: bool
 personal_api_key = None  # type: str
+project_api_key = None # type: str
 
 default_client = None
 
 
 def capture(
-    distinct_id,  # type: str,
-    event,  # type: str,
+    distinct_id,  # type: str
+    event,  # type: str
     properties=None,  # type: Optional[Dict]
     context=None,  # type: Optional[Dict]
     timestamp=None,  # type: Optional[datetime.datetime]
@@ -252,6 +253,7 @@ def _proxy(method, *args, **kwargs):
             send=send,
             sync_mode=sync_mode,
             personal_api_key=personal_api_key,
+            project_api_key=project_api_key,
         )
 
     fn = getattr(default_client, method)

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -52,7 +52,7 @@ class Client(object):
         self.queue = queue.Queue(max_queue_size)
 
         # api_key: This should be the Team API Key (token), public
-        self.api_key = api_key or project_api_key
+        self.api_key = project_api_key or api_key
 
         require("api_key", self.api_key, string_types)
 
@@ -88,7 +88,7 @@ class Client(object):
                 self.consumers = []
                 consumer = Consumer(
                     self.queue,
-                    api_key,
+                    self.api_key,
                     host=host,
                     on_error=on_error,
                     flush_at=flush_at,

--- a/posthog/consumer.py
+++ b/posthog/consumer.py
@@ -124,6 +124,8 @@ class Consumer(Thread):
                 # retry on server errors and client errors
                 # with 429 status code (rate limited),
                 # don't retry on other client errors
+                if exc.status == "N/A":
+                    return False
                 return (400 <= exc.status < 500) and exc.status != 429
             else:
                 # retry on all other errors (eg. network)

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -43,6 +43,22 @@ class TestClient(unittest.TestCase):
         self.assertEqual(msg["properties"]["$lib"], "posthog-python")
         self.assertEqual(msg["properties"]["$lib_version"], VERSION)
 
+    def test_basic_capture_with_project_api_key(self):
+
+        client = Client(project_api_key=TEST_API_KEY, on_error=self.set_fail)
+
+        success, msg = client.capture("distinct_id", "python test event")
+        client.flush()
+        self.assertTrue(success)
+        self.assertFalse(self.failed)
+
+        self.assertEqual(msg["event"], "python test event")
+        self.assertTrue(isinstance(msg["timestamp"], str))
+        self.assertTrue(isinstance(msg["messageId"], str))
+        self.assertEqual(msg["distinct_id"], "distinct_id")
+        self.assertEqual(msg["properties"]["$lib"], "posthog-python")
+        self.assertEqual(msg["properties"]["$lib_version"], VERSION)
+
     def test_stringifies_distinct_id(self):
         # A large number that loses precision in node:
         # node -e "console.log(157963456373623802 + 1)" > 157963456373623800
@@ -319,6 +335,14 @@ class TestClient(unittest.TestCase):
     @mock.patch("posthog.client.get")
     def test_feature_enabled_simple(self, patch_get):
         client = Client(TEST_API_KEY)
+        client.feature_flags = [
+            {"id": 1, "name": "Beta Feature", "key": "beta-feature", "is_simple_flag": True, "rollout_percentage": 100}
+        ]
+        self.assertTrue(client.feature_enabled("beta-feature", "distinct_id"))
+
+    @mock.patch("posthog.client.get")
+    def test_feature_enabled_simple_with_project_api_key(self, patch_get):
+        client = Client(project_api_key=TEST_API_KEY, on_error=self.set_fail)
         client.feature_flags = [
             {"id": 1, "name": "Beta Feature", "key": "beta-feature", "is_simple_flag": True, "rollout_percentage": 100}
         ]


### PR DESCRIPTION
Fixes #31

This doesn't remove `api_key` yet, but supports both `project_api_key` and `api_key`.