### PR TITLE
Bump backoff dependency to 1.10.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ long_description = """
 PostHog is developer-friendly, self-hosted product analytics. posthog-python is the python package.
 """
 
-install_requires = ["requests>=2.7,<3.0", "six>=1.5", "monotonic>=1.5", "backoff==1.6.0", "python-dateutil>2.1"]
+install_requires = ["requests>=2.7,<3.0", "six>=1.5", "monotonic>=1.5", "backoff==1.10.0", "python-dateutil>2.1"]
 
 extras_require = {
     "dev": [


### PR DESCRIPTION
Bump backoff dependency as per analytics-python PR https://github.com/segmentio/analytics-python/pull/173.

Have fixed to 1.10.0 as per other PR - however may be better to keep as `>=1.6.0` or so for backwards compatibility.