### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,35 @@
+name: 'Release'
+
+on:
+  - workflow_dispatch
+
+jobs:
+    release:
+        name: Publish release
+        runs-on: ubuntu-20.04
+        env:
+            TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+            TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        steps:
+            - name: Checkout the repository
+              uses: actions/checkout@v2
+              with:
+                  fetch-depth: 0
+                  token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
+
+            - name: Set up Python
+              uses: actions/setup-python@v2
+
+            - name: Detect version
+              run: echo "REPO_VERSION=$(python3 posthog/version.py)" >> $GITHUB_ENV
+
+            - name: Push release to PyPI
+              run: make analytics && make release_analytics
+
+            - name: Create GitHub release
+              uses: actions/create-release@v1
+              env:
+                  GITHUB_TOKEN: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
+              with:
+                  tag_name: v${{ env.REPO_VERSION }}
+                  release_name: ${{ env.REPO_VERSION }}

--- a/README.md
+++ b/README.md
@@ -6,24 +6,20 @@ Please see the main [PostHog docs](https://posthog.com/docs).
 
 Specifically, the [Python integration](https://posthog.com/docs/integrations/python-integration) details.
 
-## Questions?
+## Development
 
-### [Join our Slack community.](https://join.slack.com/t/posthogusers/shared_invite/enQtOTY0MzU5NjAwMDY3LTc2MWQ0OTZlNjhkODk3ZDI3NDVjMDE1YjgxY2I4ZjI4MzJhZmVmNjJkN2NmMGJmMzc2N2U3Yjc3ZjI5NGFlZDQ)
-
-# Local Development
-
-## Testing Locally
+### Testing Locally
 
 1. Run `python3 -m venv env` (creates virtual environment called "env")
 2. Run `source env/bin/activate` (activates the virtual environment)
 3. Run `python3 -m pip install -e ".[test]"` (installs the package in develop mode, along with test dependencies)
 4. Run `make test`
 
-## Running Locally
+### Running Locally
 
 Assuming you have a [local version of PostHog](https://posthog.com/docs/developing-locally) running, you can run `python3 example.py` to see the library in action.
 
-## Running the Django Sentry Integration Locally
+### Running the Django Sentry Integration Locally
 
 There's a sample Django project included, called `sentry_django_example`, which explains how to use PostHog with Sentry.
 
@@ -40,3 +36,11 @@ There's 2 places of importance (Changes required are all marked with TODO in the
 To run things: `make django_example`. This installs the posthog-python library with the sentry-sdk add-on, and then runs the django app.
 Also start the PostHog app locally.
 Then navigate to `http://127.0.0.1:8080/sentry-debug/` and you should get an event in both Sentry and PostHog, with links to each other.
+
+### Releasing Versions
+
+Updated are released using GitHub Actions: after bumping `version.py` in `master`, go to [our release workflow's page](https://github.com/PostHog/http-mmdb/actions/workflows/release.yml) and dispatch it manually, using workflow from `master`.
+
+## Questions?
+
+### [Join our Slack community.](https://join.slack.com/t/posthogusers/shared_invite/enQtOTY0MzU5NjAwMDY3LTc2MWQ0OTZlNjhkODk3ZDI3NDVjMDE1YjgxY2I4ZjI4MzJhZmVmNjJkN2NmMGJmMzc2N2U3Yjc3ZjI5NGFlZDQ)

--- a/posthog/version.py
+++ b/posthog/version.py
@@ -1,1 +1,4 @@
 VERSION = "1.4.1"
+
+if __name__ == "__main__":
+    print(VERSION, end="")


### PR DESCRIPTION
This way any PostHog member will be able to release a new version of `posthog-python`, instead of having to become a PyPI collaborator (much more cumbersome).
CC @yakkomajuri 