### PR TITLE
Use Sentry DSN to obtain project ID

### DIFF
--- a/posthog/sentry/posthog_integration.py
+++ b/posthog/sentry/posthog_integration.py
@@ -40,7 +40,7 @@ class PostHogIntegration(Integration):
                     }
 
                     if PostHogIntegration.organization:
-                        project_id = PostHogIntegration.project_id or Dsn(Hub.current.client.dsn).project_id
+                        project_id = PostHogIntegration.project_id or (not not Hub.current.client.dsn and Dsn(Hub.current.client.dsn).project_id)
                         if project_id:
                             properties[
                                 "$sentry_url"

--- a/posthog/sentry/posthog_integration.py
+++ b/posthog/sentry/posthog_integration.py
@@ -1,8 +1,8 @@
 from sentry_sdk._types import MYPY
+from sentry_sdk.client import Client
 from sentry_sdk.hub import Hub
 from sentry_sdk.integrations import Integration
 from sentry_sdk.scope import add_global_event_processor
-from sentry_sdk.client import Client
 from sentry_sdk.utils import Dsn
 
 import posthog

--- a/posthog/sentry/posthog_integration.py
+++ b/posthog/sentry/posthog_integration.py
@@ -40,7 +40,7 @@ class PostHogIntegration(Integration):
                     }
 
                     if PostHogIntegration.organization:
-                        project_id = PostHogIntegration.project_id or Dsn(Client.dsn).project_id
+                        project_id = PostHogIntegration.project_id or Dsn(Hub.current.client.dsn).project_id
                         if project_id:
                             properties[
                                 "$sentry_url"

--- a/posthog/sentry/posthog_integration.py
+++ b/posthog/sentry/posthog_integration.py
@@ -40,7 +40,9 @@ class PostHogIntegration(Integration):
                     }
 
                     if PostHogIntegration.organization:
-                        project_id = PostHogIntegration.project_id or (not not Hub.current.client.dsn and Dsn(Hub.current.client.dsn).project_id)
+                        project_id = PostHogIntegration.project_id or (
+                            not not Hub.current.client.dsn and Dsn(Hub.current.client.dsn).project_id
+                        )
                         if project_id:
                             properties[
                                 "$sentry_url"

--- a/sentry_django_example/sentry_django_example/settings.py
+++ b/sentry_django_example/sentry_django_example/settings.py
@@ -44,7 +44,6 @@ posthog.host = "http://127.0.0.1:8000"
 from posthog.sentry.posthog_integration import PostHogIntegration
 
 PostHogIntegration.organization = "posthog"  # TODO: your sentry organization
-PostHogIntegration.project_id = "5624115"  # TODO: your sentry projectID
 # PostHogIntegration.prefix = # TODO: your self hosted Sentry url. (default: https://sentry.io/organizations/)
 
 # Since Sentry doesn't allow Integrations configuration (see https://github.com/getsentry/sentry-python/blob/master/sentry_sdk/integrations/__init__.py#L171-L183)


### PR DESCRIPTION
From user feedback, we now use the Sentry DSN to obtain the project ID when building the `$sentry_url` property. Unfortunately the DSN doesn't contain the organization_id so the user will still need to type that.