### PR TITLE
Avoid unclosed SSLSocket warnings

### DIFF
--- a/posthog/client.py
+++ b/posthog/client.py
@@ -10,7 +10,7 @@ from six import string_types
 
 from posthog.consumer import Consumer
 from posthog.poller import Poller
-from posthog.request import APIError, batch_post, decide, get
+from posthog.request import APIError, batch_post, decide, get, shutdown as request_close
 from posthog.utils import clean, guess_timezone
 from posthog.version import VERSION
 
@@ -308,6 +308,9 @@ class Client(object):
 
         if self.poller:
             self.poller.stop()
+
+        # Close request sessions before leaving
+        request_close()
 
     def shutdown(self):
         """Flush all messages and cleanly shutdown the client"""

--- a/posthog/request.py
+++ b/posthog/request.py
@@ -85,6 +85,13 @@ def get(api_key: str, url: str, host: Optional[str] = None, timeout: Optional[in
     res = requests.get(url, headers={"Authorization": "Bearer %s" % api_key, "User-Agent": USER_AGENT}, timeout=timeout)
     return _process_response(res, success_message=f"GET {url} completed successfully")
 
+def shutdown():
+    # Avoid logs with
+    #     sys:1: ResourceWarning: unclosed
+    #      <ssl.SSLSocket fd=10, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0,
+    #       laddr=('x.x.x.x', y), raddr=('x.x.x.x', 443)>
+    # Should only be called when once, renders `_session` unusable
+    _session.close()
 
 class APIError(Exception):
     def __init__(self, status: Union[int, str], message: str):


### PR DESCRIPTION
When using posthog, even when manually calling `posthog.shutdown()`, we always get a warning at the end:

```py
sys:1: ResourceWarning: unclosed <ssl.SSLSocket fd=10, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('192.168.1.110', 59478), raddr=('34.227.250.33', 443)>
```

The warning only happens if we did send some messages (try calling `flush`, which is called by `shutdown` anyways, to make it show up).