### PR TITLE
Support custom UUID values

### DIFF
--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -25,7 +25,7 @@ def capture(
     properties=None,  # type: Optional[Dict]
     context=None,  # type: Optional[Dict]
     timestamp=None,  # type: Optional[datetime.datetime]
-    message_id=None,  # type: Optional[str]
+    uuid=None,  # type: Optional[str]
     groups=None,  # type: Optional[Dict]
 ):
     # type: (...) -> None
@@ -56,7 +56,7 @@ def capture(
         properties=properties,
         context=context,
         timestamp=timestamp,
-        message_id=message_id,
+        uuid=uuid,
         groups=groups,
     )
 
@@ -66,7 +66,7 @@ def identify(
     properties=None,  # type: Optional[Dict]
     context=None,  # type: Optional[Dict]
     timestamp=None,  # type: Optional[datetime.datetime]
-    message_id=None,  # type: Optional[str]
+    uuid=None,  # type: Optional[str]
 ):
     # type: (...) -> None
     """
@@ -90,7 +90,7 @@ def identify(
         properties=properties,
         context=context,
         timestamp=timestamp,
-        message_id=message_id,
+        uuid=uuid,
     )
 
 
@@ -99,7 +99,7 @@ def set(
     properties=None,  # type: Optional[Dict]
     context=None,  # type: Optional[Dict]
     timestamp=None,  # type: Optional[datetime.datetime]
-    message_id=None,  # type: Optional[str]
+    uuid=None,  # type: Optional[str]
 ):
     # type: (...) -> None
     """
@@ -123,7 +123,7 @@ def set(
         properties=properties,
         context=context,
         timestamp=timestamp,
-        message_id=message_id,
+        uuid=uuid,
     )
 
 
@@ -132,7 +132,7 @@ def set_once(
     properties=None,  # type: Optional[Dict]
     context=None,  # type: Optional[Dict]
     timestamp=None,  # type: Optional[datetime.datetime]
-    message_id=None,  # type: Optional[str]
+    uuid=None,  # type: Optional[str]
 ):
     # type: (...) -> None
     """
@@ -156,7 +156,7 @@ def set_once(
         properties=properties,
         context=context,
         timestamp=timestamp,
-        message_id=message_id,
+        uuid=uuid,
     )
 
 
@@ -166,7 +166,7 @@ def group_identify(
     properties=None,  # type: Optional[Dict]
     context=None,  # type: Optional[Dict]
     timestamp=None,  # type: Optional[datetime.datetime]
-    message_id=None,  # type: Optional[str]
+    uuid=None,  # type: Optional[str]
 ):
     # type: (...) -> None
     """
@@ -191,7 +191,7 @@ def group_identify(
         properties=properties,
         context=context,
         timestamp=timestamp,
-        message_id=message_id,
+        uuid=uuid,
     )
 
 
@@ -200,7 +200,7 @@ def alias(
     distinct_id,  # type: str,
     context=None,  # type: Optional[Dict]
     timestamp=None,  # type: Optional[datetime.datetime]
-    message_id=None,  # type: Optional[str]
+    uuid=None,  # type: Optional[str]
 ):
     # type: (...) -> None
     """
@@ -225,7 +225,7 @@ def alias(
         distinct_id=distinct_id,
         context=context,
         timestamp=timestamp,
-        message_id=message_id,
+        uuid=uuid,
     )
 
 

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -178,9 +178,7 @@ class Client(object):
 
         return self._enqueue(msg)
 
-    def group_identify(
-        self, group_type=None, group_key=None, properties=None, context=None, timestamp=None, uuid=None
-    ):
+    def group_identify(self, group_type=None, group_key=None, properties=None, context=None, timestamp=None, uuid=None):
         properties = properties or {}
         context = context or {}
         require("group_type", group_type, ID_TYPES)

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -103,7 +103,7 @@ class Client(object):
                 if send:
                     consumer.start()
 
-    def identify(self, distinct_id=None, properties=None, context=None, timestamp=None, message_id=None):
+    def identify(self, distinct_id=None, properties=None, context=None, timestamp=None, uuid=None):
         properties = properties or {}
         context = context or {}
         require("distinct_id", distinct_id, ID_TYPES)
@@ -115,13 +115,13 @@ class Client(object):
             "distinct_id": distinct_id,
             "$set": properties,
             "event": "$identify",
-            "messageId": message_id,
+            "uuid": uuid,
         }
 
         return self._enqueue(msg)
 
     def capture(
-        self, distinct_id=None, event=None, properties=None, context=None, timestamp=None, message_id=None, groups=None
+        self, distinct_id=None, event=None, properties=None, context=None, timestamp=None, uuid=None, groups=None
     ):
         properties = properties or {}
         context = context or {}
@@ -135,7 +135,7 @@ class Client(object):
             "context": context,
             "distinct_id": distinct_id,
             "event": event,
-            "messageId": message_id,
+            "uuid": uuid,
         }
 
         if groups:
@@ -144,7 +144,7 @@ class Client(object):
 
         return self._enqueue(msg)
 
-    def set(self, distinct_id=None, properties=None, context=None, timestamp=None, message_id=None):
+    def set(self, distinct_id=None, properties=None, context=None, timestamp=None, uuid=None):
         properties = properties or {}
         context = context or {}
         require("distinct_id", distinct_id, ID_TYPES)
@@ -156,12 +156,12 @@ class Client(object):
             "distinct_id": distinct_id,
             "$set": properties,
             "event": "$set",
-            "messageId": message_id,
+            "uuid": uuid,
         }
 
         return self._enqueue(msg)
 
-    def set_once(self, distinct_id=None, properties=None, context=None, timestamp=None, message_id=None):
+    def set_once(self, distinct_id=None, properties=None, context=None, timestamp=None, uuid=None):
         properties = properties or {}
         context = context or {}
         require("distinct_id", distinct_id, ID_TYPES)
@@ -173,13 +173,13 @@ class Client(object):
             "distinct_id": distinct_id,
             "$set_once": properties,
             "event": "$set_once",
-            "messageId": message_id,
+            "uuid": uuid,
         }
 
         return self._enqueue(msg)
 
     def group_identify(
-        self, group_type=None, group_key=None, properties=None, context=None, timestamp=None, message_id=None
+        self, group_type=None, group_key=None, properties=None, context=None, timestamp=None, uuid=None
     ):
         properties = properties or {}
         context = context or {}
@@ -197,12 +197,12 @@ class Client(object):
             "distinct_id": "${}_{}".format(group_type, group_key),
             "timestamp": timestamp,
             "context": context,
-            "messageId": message_id,
+            "uuid": uuid,
         }
 
         return self._enqueue(msg)
 
-    def alias(self, previous_id=None, distinct_id=None, context=None, timestamp=None, message_id=None):
+    def alias(self, previous_id=None, distinct_id=None, context=None, timestamp=None, uuid=None):
         context = context or {}
 
         require("previous_id", previous_id, ID_TYPES)
@@ -221,7 +221,7 @@ class Client(object):
 
         return self._enqueue(msg)
 
-    def page(self, distinct_id=None, url=None, properties=None, context=None, timestamp=None, message_id=None):
+    def page(self, distinct_id=None, url=None, properties=None, context=None, timestamp=None, uuid=None):
         properties = properties or {}
         context = context or {}
 
@@ -237,7 +237,7 @@ class Client(object):
             "timestamp": timestamp,
             "context": context,
             "distinct_id": distinct_id,
-            "messageId": message_id,
+            "uuid": uuid,
         }
 
         return self._enqueue(msg)
@@ -247,9 +247,6 @@ class Client(object):
         timestamp = msg["timestamp"]
         if timestamp is None:
             timestamp = datetime.utcnow().replace(tzinfo=tzutc())
-        message_id = msg.get("messageId")
-        if message_id is None:
-            message_id = uuid4()
 
         require("timestamp", timestamp, datetime)
         require("context", msg["context"], dict)
@@ -257,7 +254,7 @@ class Client(object):
         # add common
         timestamp = guess_timezone(timestamp)
         msg["timestamp"] = timestamp.isoformat()
-        msg["messageId"] = stringify_id(message_id)
+        msg["uuid"] = stringify_id(msg.get("uuid"))
         if not msg.get("properties"):
             msg["properties"] = {}
         msg["properties"]["$lib"] = "posthog-python"

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -254,7 +254,13 @@ class Client(object):
         # add common
         timestamp = guess_timezone(timestamp)
         msg["timestamp"] = timestamp.isoformat()
-        msg["uuid"] = stringify_id(msg.get("uuid"))
+
+        # only send if "uuid" is truthy
+        if "uuid" in msg:
+            uuid = msg.pop("uuid")
+            if uuid:
+                msg["uuid"] = stringify_id(uuid)
+
         if not msg.get("properties"):
             msg["properties"] = {}
         msg["properties"]["$lib"] = "posthog-python"

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -38,7 +38,7 @@ class TestClient(unittest.TestCase):
 
         self.assertEqual(msg["event"], "python test event")
         self.assertTrue(isinstance(msg["timestamp"], str))
-        self.assertFalse(isinstance(msg["uuid"], str))
+        self.assertIsNone(msg.get("uuid"))
         self.assertEqual(msg["distinct_id"], "distinct_id")
         self.assertEqual(msg["properties"]["$lib"], "posthog-python")
         self.assertEqual(msg["properties"]["$lib_version"], VERSION)
@@ -69,7 +69,7 @@ class TestClient(unittest.TestCase):
 
         self.assertEqual(msg["event"], "python test event")
         self.assertTrue(isinstance(msg["timestamp"], str))
-        self.assertFalse(isinstance(msg["uuid"], str))
+        self.assertIsNone(msg.get("uuid"))
         self.assertEqual(msg["distinct_id"], "distinct_id")
         self.assertEqual(msg["properties"]["$lib"], "posthog-python")
         self.assertEqual(msg["properties"]["$lib_version"], VERSION)
@@ -127,7 +127,7 @@ class TestClient(unittest.TestCase):
 
         self.assertEqual(msg["$set"]["trait"], "value")
         self.assertTrue(isinstance(msg["timestamp"], str))
-        self.assertFalse(isinstance(msg["uuid"], str))
+        self.assertIsNone(msg.get("uuid"))
         self.assertEqual(msg["distinct_id"], "distinct_id")
 
     def test_advanced_identify(self):
@@ -156,7 +156,7 @@ class TestClient(unittest.TestCase):
 
         self.assertEqual(msg["$set"]["trait"], "value")
         self.assertTrue(isinstance(msg["timestamp"], str))
-        self.assertFalse(isinstance(msg["uuid"], str))
+        self.assertIsNone(msg.get("uuid"))
         self.assertEqual(msg["distinct_id"], "distinct_id")
 
     def test_advanced_set(self):
@@ -185,7 +185,7 @@ class TestClient(unittest.TestCase):
 
         self.assertEqual(msg["$set_once"]["trait"], "value")
         self.assertTrue(isinstance(msg["timestamp"], str))
-        self.assertFalse(isinstance(msg["uuid"], str))
+        self.assertIsNone(msg.get("uuid"))
         self.assertEqual(msg["distinct_id"], "distinct_id")
 
     def test_advanced_set_once(self):
@@ -222,7 +222,7 @@ class TestClient(unittest.TestCase):
             },
         )
         self.assertTrue(isinstance(msg["timestamp"], str))
-        self.assertFalse(isinstance(msg["uuid"], str))
+        self.assertIsNone(msg.get("uuid"))
 
     def test_advanced_group_identify(self):
         success, msg = self.client.group_identify(

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -38,7 +38,22 @@ class TestClient(unittest.TestCase):
 
         self.assertEqual(msg["event"], "python test event")
         self.assertTrue(isinstance(msg["timestamp"], str))
-        self.assertTrue(isinstance(msg["messageId"], str))
+        self.assertFalse(isinstance(msg["uuid"], str))
+        self.assertEqual(msg["distinct_id"], "distinct_id")
+        self.assertEqual(msg["properties"]["$lib"], "posthog-python")
+        self.assertEqual(msg["properties"]["$lib_version"], VERSION)
+
+    def test_basic_capture_with_uuid(self):
+        client = self.client
+        uuid = str(uuid4())
+        success, msg = client.capture("distinct_id", "python test event", uuid=uuid)
+        client.flush()
+        self.assertTrue(success)
+        self.assertFalse(self.failed)
+
+        self.assertEqual(msg["event"], "python test event")
+        self.assertTrue(isinstance(msg["timestamp"], str))
+        self.assertEqual(msg["uuid"], uuid)
         self.assertEqual(msg["distinct_id"], "distinct_id")
         self.assertEqual(msg["properties"]["$lib"], "posthog-python")
         self.assertEqual(msg["properties"]["$lib_version"], VERSION)
@@ -54,7 +69,7 @@ class TestClient(unittest.TestCase):
 
         self.assertEqual(msg["event"], "python test event")
         self.assertTrue(isinstance(msg["timestamp"], str))
-        self.assertTrue(isinstance(msg["messageId"], str))
+        self.assertFalse(isinstance(msg["uuid"], str))
         self.assertEqual(msg["distinct_id"], "distinct_id")
         self.assertEqual(msg["properties"]["$lib"], "posthog-python")
         self.assertEqual(msg["properties"]["$lib_version"], VERSION)
@@ -78,7 +93,7 @@ class TestClient(unittest.TestCase):
             {"property": "value"},
             {"ip": "192.168.0.1"},
             datetime(2014, 9, 3),
-            "messageId",
+            "new-uuid",
         )
 
         self.assertTrue(success)
@@ -89,7 +104,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(msg["event"], "python test event")
         self.assertEqual(msg["properties"]["$lib"], "posthog-python")
         self.assertEqual(msg["properties"]["$lib_version"], VERSION)
-        self.assertEqual(msg["messageId"], "messageId")
+        self.assertEqual(msg["uuid"], "new-uuid")
         self.assertEqual(msg["distinct_id"], "distinct_id")
         self.assertTrue("$groups" not in msg["properties"])
 
@@ -112,13 +127,13 @@ class TestClient(unittest.TestCase):
 
         self.assertEqual(msg["$set"]["trait"], "value")
         self.assertTrue(isinstance(msg["timestamp"], str))
-        self.assertTrue(isinstance(msg["messageId"], str))
+        self.assertFalse(isinstance(msg["uuid"], str))
         self.assertEqual(msg["distinct_id"], "distinct_id")
 
     def test_advanced_identify(self):
         client = self.client
         success, msg = client.identify(
-            "distinct_id", {"trait": "value"}, {"ip": "192.168.0.1"}, datetime(2014, 9, 3), "messageId"
+            "distinct_id", {"trait": "value"}, {"ip": "192.168.0.1"}, datetime(2014, 9, 3), "new-uuid"
         )
 
         self.assertTrue(success)
@@ -129,7 +144,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(msg["properties"]["$lib"], "posthog-python")
         self.assertEqual(msg["properties"]["$lib_version"], VERSION)
         self.assertTrue(isinstance(msg["timestamp"], str))
-        self.assertEqual(msg["messageId"], "messageId")
+        self.assertEqual(msg["uuid"], "new-uuid")
         self.assertEqual(msg["distinct_id"], "distinct_id")
 
     def test_basic_set(self):
@@ -141,13 +156,13 @@ class TestClient(unittest.TestCase):
 
         self.assertEqual(msg["$set"]["trait"], "value")
         self.assertTrue(isinstance(msg["timestamp"], str))
-        self.assertTrue(isinstance(msg["messageId"], str))
+        self.assertFalse(isinstance(msg["uuid"], str))
         self.assertEqual(msg["distinct_id"], "distinct_id")
 
     def test_advanced_set(self):
         client = self.client
         success, msg = client.set(
-            "distinct_id", {"trait": "value"}, {"ip": "192.168.0.1"}, datetime(2014, 9, 3), "messageId"
+            "distinct_id", {"trait": "value"}, {"ip": "192.168.0.1"}, datetime(2014, 9, 3), "new-uuid"
         )
 
         self.assertTrue(success)
@@ -158,7 +173,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(msg["properties"]["$lib"], "posthog-python")
         self.assertEqual(msg["properties"]["$lib_version"], VERSION)
         self.assertTrue(isinstance(msg["timestamp"], str))
-        self.assertEqual(msg["messageId"], "messageId")
+        self.assertEqual(msg["uuid"], "new-uuid")
         self.assertEqual(msg["distinct_id"], "distinct_id")
 
     def test_basic_set_once(self):
@@ -170,13 +185,13 @@ class TestClient(unittest.TestCase):
 
         self.assertEqual(msg["$set_once"]["trait"], "value")
         self.assertTrue(isinstance(msg["timestamp"], str))
-        self.assertTrue(isinstance(msg["messageId"], str))
+        self.assertFalse(isinstance(msg["uuid"], str))
         self.assertEqual(msg["distinct_id"], "distinct_id")
 
     def test_advanced_set_once(self):
         client = self.client
         success, msg = client.set_once(
-            "distinct_id", {"trait": "value"}, {"ip": "192.168.0.1"}, datetime(2014, 9, 3), "messageId"
+            "distinct_id", {"trait": "value"}, {"ip": "192.168.0.1"}, datetime(2014, 9, 3), "new-uuid"
         )
 
         self.assertTrue(success)
@@ -187,7 +202,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(msg["properties"]["$lib"], "posthog-python")
         self.assertEqual(msg["properties"]["$lib_version"], VERSION)
         self.assertTrue(isinstance(msg["timestamp"], str))
-        self.assertEqual(msg["messageId"], "messageId")
+        self.assertEqual(msg["uuid"], "new-uuid")
         self.assertEqual(msg["distinct_id"], "distinct_id")
 
     def test_basic_group_identify(self):
@@ -207,11 +222,11 @@ class TestClient(unittest.TestCase):
             },
         )
         self.assertTrue(isinstance(msg["timestamp"], str))
-        self.assertTrue(isinstance(msg["messageId"], str))
+        self.assertFalse(isinstance(msg["uuid"], str))
 
     def test_advanced_group_identify(self):
         success, msg = self.client.group_identify(
-            "organization", "id:5", {"trait": "value"}, {"ip": "192.168.0.1"}, datetime(2014, 9, 3), "messageId"
+            "organization", "id:5", {"trait": "value"}, {"ip": "192.168.0.1"}, datetime(2014, 9, 3), "new-uuid"
         )
 
         self.assertTrue(success)
@@ -266,7 +281,7 @@ class TestClient(unittest.TestCase):
             {"property": "value"},
             {"ip": "192.168.0.1"},
             datetime(2014, 9, 3),
-            "messageId",
+            "new-uuid",
         )
 
         self.assertTrue(success)
@@ -278,7 +293,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(msg["properties"]["$lib"], "posthog-python")
         self.assertEqual(msg["properties"]["$lib_version"], VERSION)
         self.assertTrue(isinstance(msg["timestamp"], str))
-        self.assertEqual(msg["messageId"], "messageId")
+        self.assertEqual(msg["uuid"], "new-uuid")
         self.assertEqual(msg["distinct_id"], "distinct_id")
 
     def test_flush(self):
@@ -347,7 +362,7 @@ class TestClient(unittest.TestCase):
         client = Client(TEST_API_KEY, on_error=self.fail, flush_at=10, flush_interval=3)
 
         def mock_post_fn(*args, **kwargs):
-            self.assertEquals(len(kwargs["batch"]), 10)
+            self.assertEqual(len(kwargs["batch"]), 10)
 
         # the post function should be called 2 times, with a batch size of 10
         # each time.
@@ -355,17 +370,17 @@ class TestClient(unittest.TestCase):
             for _ in range(20):
                 client.identify("distinct_id", {"trait": "value"})
             time.sleep(1)
-            self.assertEquals(mock_post.call_count, 2)
+            self.assertEqual(mock_post.call_count, 2)
 
     def test_user_defined_timeout(self):
         client = Client(TEST_API_KEY, timeout=10)
         for consumer in client.consumers:
-            self.assertEquals(consumer.timeout, 10)
+            self.assertEqual(consumer.timeout, 10)
 
     def test_default_timeout_15(self):
         client = Client(TEST_API_KEY)
         for consumer in client.consumers:
-            self.assertEquals(consumer.timeout, 15)
+            self.assertEqual(consumer.timeout, 15)
 
     @mock.patch("posthog.client.Poller")
     @mock.patch("posthog.client.get")

--- a/posthog/test/test_consumer.py
+++ b/posthog/test/test_consumer.py
@@ -161,4 +161,4 @@ class TestConsumer(unittest.TestCase):
             for _ in range(0, n_msgs + 2):
                 q.put(track)
             q.join()
-            self.assertEquals(mock_post.call_count, 2)
+            self.assertEqual(mock_post.call_count, 2)


### PR DESCRIPTION
The library used to have a `message_id` value you can attach to your events, but this value was effectively ignored.

This PR replaces that with a `uuid` value that is actually respected by the plugin server, but only if it's a real `uuid`. 

This came from a customer request in Slack.