### PR TITLE
Remove "context"

### DIFF
--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -23,7 +23,6 @@ def capture(
     distinct_id,  # type: str
     event,  # type: str
     properties=None,  # type: Optional[Dict]
-    context=None,  # type: Optional[Dict]
     timestamp=None,  # type: Optional[datetime.datetime]
     uuid=None,  # type: Optional[str]
     groups=None,  # type: Optional[Dict]
@@ -54,7 +53,6 @@ def capture(
         distinct_id=distinct_id,
         event=event,
         properties=properties,
-        context=context,
         timestamp=timestamp,
         uuid=uuid,
         groups=groups,
@@ -64,7 +62,6 @@ def capture(
 def identify(
     distinct_id,  # type: str
     properties=None,  # type: Optional[Dict]
-    context=None,  # type: Optional[Dict]
     timestamp=None,  # type: Optional[datetime.datetime]
     uuid=None,  # type: Optional[str]
 ):
@@ -88,7 +85,6 @@ def identify(
         "identify",
         distinct_id=distinct_id,
         properties=properties,
-        context=context,
         timestamp=timestamp,
         uuid=uuid,
     )
@@ -97,7 +93,6 @@ def identify(
 def set(
     distinct_id,  # type: str,
     properties=None,  # type: Optional[Dict]
-    context=None,  # type: Optional[Dict]
     timestamp=None,  # type: Optional[datetime.datetime]
     uuid=None,  # type: Optional[str]
 ):
@@ -121,7 +116,6 @@ def set(
         "set",
         distinct_id=distinct_id,
         properties=properties,
-        context=context,
         timestamp=timestamp,
         uuid=uuid,
     )
@@ -130,7 +124,6 @@ def set(
 def set_once(
     distinct_id,  # type: str,
     properties=None,  # type: Optional[Dict]
-    context=None,  # type: Optional[Dict]
     timestamp=None,  # type: Optional[datetime.datetime]
     uuid=None,  # type: Optional[str]
 ):
@@ -154,7 +147,6 @@ def set_once(
         "set_once",
         distinct_id=distinct_id,
         properties=properties,
-        context=context,
         timestamp=timestamp,
         uuid=uuid,
     )
@@ -164,7 +156,6 @@ def group_identify(
     group_type,  # type: str
     group_key,  # type: str
     properties=None,  # type: Optional[Dict]
-    context=None,  # type: Optional[Dict]
     timestamp=None,  # type: Optional[datetime.datetime]
     uuid=None,  # type: Optional[str]
 ):
@@ -189,7 +180,6 @@ def group_identify(
         group_type=group_type,
         group_key=group_key,
         properties=properties,
-        context=context,
         timestamp=timestamp,
         uuid=uuid,
     )
@@ -198,7 +188,6 @@ def group_identify(
 def alias(
     previous_id,  # type: str,
     distinct_id,  # type: str,
-    context=None,  # type: Optional[Dict]
     timestamp=None,  # type: Optional[datetime.datetime]
     uuid=None,  # type: Optional[str]
 ):
@@ -223,7 +212,6 @@ def alias(
         "alias",
         previous_id=previous_id,
         distinct_id=distinct_id,
-        context=context,
         timestamp=timestamp,
         uuid=uuid,
     )

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -340,9 +340,7 @@ class Client(object):
 
         return self._enqueue(msg, disable_geoip)
 
-    def page(
-        self, distinct_id=None, url=None, properties=None, timestamp=None, uuid=None, disable_geoip=None
-    ):
+    def page(self, distinct_id=None, url=None, properties=None, timestamp=None, uuid=None, disable_geoip=None):
         properties = properties or {}
 
         require("distinct_id", distinct_id, ID_TYPES)

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -103,15 +103,13 @@ class Client(object):
                 if send:
                     consumer.start()
 
-    def identify(self, distinct_id=None, properties=None, context=None, timestamp=None, uuid=None):
+    def identify(self, distinct_id=None, properties=None, timestamp=None, uuid=None):
         properties = properties or {}
-        context = context or {}
         require("distinct_id", distinct_id, ID_TYPES)
         require("properties", properties, dict)
 
         msg = {
             "timestamp": timestamp,
-            "context": context,
             "distinct_id": distinct_id,
             "$set": properties,
             "event": "$identify",
@@ -121,10 +119,9 @@ class Client(object):
         return self._enqueue(msg)
 
     def capture(
-        self, distinct_id=None, event=None, properties=None, context=None, timestamp=None, uuid=None, groups=None
+        self, distinct_id=None, event=None, properties=None, timestamp=None, uuid=None, groups=None
     ):
         properties = properties or {}
-        context = context or {}
         require("distinct_id", distinct_id, ID_TYPES)
         require("properties", properties, dict)
         require("event", event, string_types)
@@ -132,7 +129,6 @@ class Client(object):
         msg = {
             "properties": properties,
             "timestamp": timestamp,
-            "context": context,
             "distinct_id": distinct_id,
             "event": event,
             "uuid": uuid,
@@ -144,15 +140,13 @@ class Client(object):
 
         return self._enqueue(msg)
 
-    def set(self, distinct_id=None, properties=None, context=None, timestamp=None, uuid=None):
+    def set(self, distinct_id=None, properties=None, timestamp=None, uuid=None):
         properties = properties or {}
-        context = context or {}
         require("distinct_id", distinct_id, ID_TYPES)
         require("properties", properties, dict)
 
         msg = {
             "timestamp": timestamp,
-            "context": context,
             "distinct_id": distinct_id,
             "$set": properties,
             "event": "$set",
@@ -161,15 +155,13 @@ class Client(object):
 
         return self._enqueue(msg)
 
-    def set_once(self, distinct_id=None, properties=None, context=None, timestamp=None, uuid=None):
+    def set_once(self, distinct_id=None, properties=None, timestamp=None, uuid=None):
         properties = properties or {}
-        context = context or {}
         require("distinct_id", distinct_id, ID_TYPES)
         require("properties", properties, dict)
 
         msg = {
             "timestamp": timestamp,
-            "context": context,
             "distinct_id": distinct_id,
             "$set_once": properties,
             "event": "$set_once",
@@ -178,9 +170,8 @@ class Client(object):
 
         return self._enqueue(msg)
 
-    def group_identify(self, group_type=None, group_key=None, properties=None, context=None, timestamp=None, uuid=None):
+    def group_identify(self, group_type=None, group_key=None, properties=None, timestamp=None, uuid=None):
         properties = properties or {}
-        context = context or {}
         require("group_type", group_type, ID_TYPES)
         require("group_key", group_key, ID_TYPES)
         require("properties", properties, dict)
@@ -194,15 +185,12 @@ class Client(object):
             },
             "distinct_id": "${}_{}".format(group_type, group_key),
             "timestamp": timestamp,
-            "context": context,
             "uuid": uuid,
         }
 
         return self._enqueue(msg)
 
-    def alias(self, previous_id=None, distinct_id=None, context=None, timestamp=None, uuid=None):
-        context = context or {}
-
+    def alias(self, previous_id=None, distinct_id=None, timestamp=None, uuid=None):
         require("previous_id", previous_id, ID_TYPES)
         require("distinct_id", distinct_id, ID_TYPES)
 
@@ -212,16 +200,14 @@ class Client(object):
                 "alias": distinct_id,
             },
             "timestamp": timestamp,
-            "context": context,
             "event": "$create_alias",
             "distinct_id": previous_id,
         }
 
         return self._enqueue(msg)
 
-    def page(self, distinct_id=None, url=None, properties=None, context=None, timestamp=None, uuid=None):
+    def page(self, distinct_id=None, url=None, properties=None, timestamp=None, uuid=None):
         properties = properties or {}
-        context = context or {}
 
         require("distinct_id", distinct_id, ID_TYPES)
         require("properties", properties, dict)
@@ -233,7 +219,6 @@ class Client(object):
             "event": "$pageview",
             "properties": properties,
             "timestamp": timestamp,
-            "context": context,
             "distinct_id": distinct_id,
             "uuid": uuid,
         }
@@ -247,7 +232,6 @@ class Client(object):
             timestamp = datetime.utcnow().replace(tzinfo=tzutc())
 
         require("timestamp", timestamp, datetime)
-        require("context", msg["context"], dict)
 
         # add common
         timestamp = guess_timezone(timestamp)

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -118,9 +118,7 @@ class Client(object):
 
         return self._enqueue(msg)
 
-    def capture(
-        self, distinct_id=None, event=None, properties=None, timestamp=None, uuid=None, groups=None
-    ):
+    def capture(self, distinct_id=None, event=None, properties=None, timestamp=None, uuid=None, groups=None):
         properties = properties or {}
         require("distinct_id", distinct_id, ID_TYPES)
         require("properties", properties, dict)

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -323,8 +323,6 @@ class Client(object):
         return self._enqueue(msg, disable_geoip)
 
     def alias(self, previous_id=None, distinct_id=None, timestamp=None, uuid=None, disable_geoip=None):
-        context = context or {}
-
         require("previous_id", previous_id, ID_TYPES)
         require("distinct_id", distinct_id, ID_TYPES)
 

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -91,7 +91,6 @@ class TestClient(unittest.TestCase):
             "distinct_id",
             "python test event",
             {"property": "value"},
-            {"ip": "192.168.0.1"},
             datetime(2014, 9, 3),
             "new-uuid",
         )
@@ -100,7 +99,6 @@ class TestClient(unittest.TestCase):
 
         self.assertEqual(msg["timestamp"], "2014-09-03T00:00:00+00:00")
         self.assertEqual(msg["properties"]["property"], "value")
-        self.assertEqual(msg["context"]["ip"], "192.168.0.1")
         self.assertEqual(msg["event"], "python test event")
         self.assertEqual(msg["properties"]["$lib"], "posthog-python")
         self.assertEqual(msg["properties"]["$lib_version"], VERSION)
@@ -133,13 +131,12 @@ class TestClient(unittest.TestCase):
     def test_advanced_identify(self):
         client = self.client
         success, msg = client.identify(
-            "distinct_id", {"trait": "value"}, {"ip": "192.168.0.1"}, datetime(2014, 9, 3), "new-uuid"
+            "distinct_id", {"trait": "value"}, datetime(2014, 9, 3), "new-uuid"
         )
 
         self.assertTrue(success)
 
         self.assertEqual(msg["timestamp"], "2014-09-03T00:00:00+00:00")
-        self.assertEqual(msg["context"]["ip"], "192.168.0.1")
         self.assertEqual(msg["$set"]["trait"], "value")
         self.assertEqual(msg["properties"]["$lib"], "posthog-python")
         self.assertEqual(msg["properties"]["$lib_version"], VERSION)
@@ -162,13 +159,12 @@ class TestClient(unittest.TestCase):
     def test_advanced_set(self):
         client = self.client
         success, msg = client.set(
-            "distinct_id", {"trait": "value"}, {"ip": "192.168.0.1"}, datetime(2014, 9, 3), "new-uuid"
+            "distinct_id", {"trait": "value"}, datetime(2014, 9, 3), "new-uuid"
         )
 
         self.assertTrue(success)
 
         self.assertEqual(msg["timestamp"], "2014-09-03T00:00:00+00:00")
-        self.assertEqual(msg["context"]["ip"], "192.168.0.1")
         self.assertEqual(msg["$set"]["trait"], "value")
         self.assertEqual(msg["properties"]["$lib"], "posthog-python")
         self.assertEqual(msg["properties"]["$lib_version"], VERSION)
@@ -191,13 +187,12 @@ class TestClient(unittest.TestCase):
     def test_advanced_set_once(self):
         client = self.client
         success, msg = client.set_once(
-            "distinct_id", {"trait": "value"}, {"ip": "192.168.0.1"}, datetime(2014, 9, 3), "new-uuid"
+            "distinct_id", {"trait": "value"}, datetime(2014, 9, 3), "new-uuid"
         )
 
         self.assertTrue(success)
 
         self.assertEqual(msg["timestamp"], "2014-09-03T00:00:00+00:00")
-        self.assertEqual(msg["context"]["ip"], "192.168.0.1")
         self.assertEqual(msg["$set_once"]["trait"], "value")
         self.assertEqual(msg["properties"]["$lib"], "posthog-python")
         self.assertEqual(msg["properties"]["$lib_version"], VERSION)
@@ -226,7 +221,7 @@ class TestClient(unittest.TestCase):
 
     def test_advanced_group_identify(self):
         success, msg = self.client.group_identify(
-            "organization", "id:5", {"trait": "value"}, {"ip": "192.168.0.1"}, datetime(2014, 9, 3), "new-uuid"
+            "organization", "id:5", {"trait": "value"}, datetime(2014, 9, 3), "new-uuid"
         )
 
         self.assertTrue(success)
@@ -243,7 +238,6 @@ class TestClient(unittest.TestCase):
             },
         )
         self.assertEqual(msg["timestamp"], "2014-09-03T00:00:00+00:00")
-        self.assertEqual(msg["context"]["ip"], "192.168.0.1")
 
     def test_basic_alias(self):
         client = self.client
@@ -279,7 +273,6 @@ class TestClient(unittest.TestCase):
             "distinct_id",
             "https://posthog.com/contact",
             {"property": "value"},
-            {"ip": "192.168.0.1"},
             datetime(2014, 9, 3),
             "new-uuid",
         )
@@ -287,7 +280,6 @@ class TestClient(unittest.TestCase):
         self.assertTrue(success)
 
         self.assertEqual(msg["timestamp"], "2014-09-03T00:00:00+00:00")
-        self.assertEqual(msg["context"]["ip"], "192.168.0.1")
         self.assertEqual(msg["properties"]["$current_url"], "https://posthog.com/contact")
         self.assertEqual(msg["properties"]["property"], "value")
         self.assertEqual(msg["properties"]["$lib"], "posthog-python")

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -743,14 +743,12 @@ class TestClient(unittest.TestCase):
             },
         )
         self.assertEqual(msg["timestamp"], "2014-09-03T00:00:00+00:00")
-        self.assertEqual(msg["context"]["ip"], "192.168.0.1")
 
     def test_advanced_group_identify_with_distinct_id(self):
         success, msg = self.client.group_identify(
             "organization",
             "id:5",
             {"trait": "value"},
-            {"ip": "192.168.0.1"},
             datetime(2014, 9, 3),
             "new-uuid",
             distinct_id="distinct_id",

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -130,9 +130,7 @@ class TestClient(unittest.TestCase):
 
     def test_advanced_identify(self):
         client = self.client
-        success, msg = client.identify(
-            "distinct_id", {"trait": "value"}, datetime(2014, 9, 3), "new-uuid"
-        )
+        success, msg = client.identify("distinct_id", {"trait": "value"}, datetime(2014, 9, 3), "new-uuid")
 
         self.assertTrue(success)
 
@@ -158,9 +156,7 @@ class TestClient(unittest.TestCase):
 
     def test_advanced_set(self):
         client = self.client
-        success, msg = client.set(
-            "distinct_id", {"trait": "value"}, datetime(2014, 9, 3), "new-uuid"
-        )
+        success, msg = client.set("distinct_id", {"trait": "value"}, datetime(2014, 9, 3), "new-uuid")
 
         self.assertTrue(success)
 
@@ -186,9 +182,7 @@ class TestClient(unittest.TestCase):
 
     def test_advanced_set_once(self):
         client = self.client
-        success, msg = client.set_once(
-            "distinct_id", {"trait": "value"}, datetime(2014, 9, 3), "new-uuid"
-        )
+        success, msg = client.set_once("distinct_id", {"trait": "value"}, datetime(2014, 9, 3), "new-uuid")
 
         self.assertTrue(success)
 

--- a/posthog/version.py
+++ b/posthog/version.py
@@ -1,4 +1,4 @@
-VERSION = "1.4.6"
+VERSION = "1.5.0"
 
 if __name__ == "__main__":
     print(VERSION, end="")


### PR DESCRIPTION
We ignore it and never use it, so let's remove. This is a remnant from the early life of this library.