### PR TITLE
fix: Personal api key not required

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 
 [![PyPI](https://img.shields.io/pypi/v/posthog)](https://pypi.org/project/posthog/)
 
-Please see the main [PostHog docs](https://posthog.com/docs).
 
-Specifically, the [Python integration](https://posthog.com/docs/integrations/python-integration) details.
+Please see the [Python integration docs](https://posthog.com/docs/integrations/python-integration) for details.
 
 ## Development
 
@@ -14,6 +13,7 @@ Specifically, the [Python integration](https://posthog.com/docs/integrations/pyt
 2. Run `source env/bin/activate` (activates the virtual environment)
 3. Run `python3 -m pip install -e ".[test]"` (installs the package in develop mode, along with test dependencies)
 4. Run `make test`
+  1. To run a specific test do `pytest -k test_no_api_key`
 
 ### Running Locally
 

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -364,10 +364,8 @@ class Client(object):
                 if flag["key"] == key:
                     feature_flag = flag
                     if feature_flag.get("is_simple_flag"):
-                        response = _hash(key, distinct_id) <= (
-                            (feature_flag.get("rollout_percentage", 100) or 100) / 100
-                        )
-        if not response:
+                        response = _hash(key, distinct_id) <= (feature_flag.get("rollout_percentage", 100) / 100)
+        if response == None:
             try:
                 request_data = {
                     "distinct_id": distinct_id,

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -364,7 +364,9 @@ class Client(object):
                 if flag["key"] == key:
                     feature_flag = flag
                     if feature_flag.get("is_simple_flag"):
-                        response = _hash(key, distinct_id) <= ((feature_flag.get("rollout_percentage", 100) or 100) / 100)
+                        response = _hash(key, distinct_id) <= (
+                            (feature_flag.get("rollout_percentage", 100) or 100) / 100
+                        )
         if not response:
             try:
                 request_data = {

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -444,8 +444,9 @@ class TestClient(unittest.TestCase):
         self.assertTrue(client.feature_enabled("beta-feature", "distinct_id"))
 
     @mock.patch("posthog.client.Poller")
-    @mock.patch("posthog.client.get")
-    def test_feature_enabled_doesnt_exist(self, patch_get, patch_poll):
+    @mock.patch("posthog.client.decide")
+    def test_feature_enabled_doesnt_exist(self, patch_decide, patch_poll):
+        patch_decide.return_value = {'featureFlags': []}
         client = Client(TEST_API_KEY, personal_api_key="test")
         client.feature_flags = []
 
@@ -453,13 +454,14 @@ class TestClient(unittest.TestCase):
         self.assertTrue(client.feature_enabled("doesnt-exist", "distinct_id", True))
 
     @mock.patch("posthog.client.Poller")
-    @mock.patch("posthog.client.get")
-    def test_personal_api_key_doesnt_exist(self, patch_get, patch_poll):
+    @mock.patch("posthog.client.decide")
+    def test_personal_api_key_doesnt_exist(self, patch_decide, patch_poll):
         client = Client(TEST_API_KEY)
         client.feature_flags = []
 
-        self.assertFalse(client.feature_enabled("doesnt-exist", "distinct_id"))
-        self.assertTrue(client.feature_enabled("doesnt-exist", "distinct_id", True))
+        patch_decide.return_value = {"featureFlags": ["feature-flag"] }
+
+        self.assertTrue(client.feature_enabled("feature-flag", "distinct_id"))
 
     @mock.patch("posthog.client.Poller")
     @mock.patch("posthog.client.get")

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -446,7 +446,7 @@ class TestClient(unittest.TestCase):
     @mock.patch("posthog.client.Poller")
     @mock.patch("posthog.client.decide")
     def test_feature_enabled_doesnt_exist(self, patch_decide, patch_poll):
-        patch_decide.return_value = {'featureFlags': []}
+        patch_decide.return_value = {"featureFlags": []}
         client = Client(TEST_API_KEY, personal_api_key="test")
         client.feature_flags = []
 
@@ -459,7 +459,7 @@ class TestClient(unittest.TestCase):
         client = Client(TEST_API_KEY)
         client.feature_flags = []
 
-        patch_decide.return_value = {"featureFlags": ["feature-flag"] }
+        patch_decide.return_value = {"featureFlags": ["feature-flag"]}
 
         self.assertTrue(client.feature_enabled("feature-flag", "distinct_id"))
 


### PR DESCRIPTION
Most feature flags require a call to decide anyway, so we might as well allow feature flags without first grabbing all active feature flags.