### PR TITLE
Feature: Enable multi variate feature flags for Python library

### DIFF
--- a/posthog/client.py
+++ b/posthog/client.py
@@ -380,10 +380,7 @@ class Client(object):
                 )
                 self.log.warning(e)
             else:
-                if key in resp_data["featureFlags"]:
-                    return True
-                else:
-                    return default
+                response = True if key in resp_data["featureFlags"] else default
 
         self.capture(distinct_id, "$feature_flag_called", {"$feature_flag": key, "$feature_flag_response": response})
         return response

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -380,7 +380,7 @@ class Client(object):
                 )
                 self.log.warning(e)
             else:
-                response = True if key in resp_data["featureFlags"] else default
+                response = resp_data["featureFlags"].get(key, default)
 
         self.capture(distinct_id, "$feature_flag_called", {"$feature_flag": key, "$feature_flag_response": response})
         return response

--- a/posthog/request.py
+++ b/posthog/request.py
@@ -68,7 +68,7 @@ def _process_response(
 
 def decide(api_key: str, host: Optional[str] = None, gzip: bool = False, timeout: int = 15, **kwargs) -> Any:
     """Post the `kwargs to the decide API endpoint"""
-    res = post(api_key, host, "/decide/", gzip, timeout, **kwargs)
+    res = post(api_key, host, "/decide/?v=2", gzip, timeout, **kwargs)
     return _process_response(res, success_message="Feature flags decided successfully")
 
 


### PR DESCRIPTION
Using the v2 decide endpoint. Should be merged after https://github.com/PostHog/posthog-python/pull/57 as that pull request fixes how feature flags are captured on Posthog.