### PR TITLE
fix: datetime comparison issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
+## 2.1.2 - 2022-09-15
+
+Changes:
+
+1. Fixes issues with date comparison.
 ## 2.1.1 - 2022-09-14
 
 Changes:
 
-1. Feature flags local evaluation now supports date property filters as well. Note that this only supports passing in timezone-unaware datetime objects, or strings.
+1. Feature flags local evaluation now supports date property filters as well. Accepts both strings and datetime objects.
 
 ## 2.1.0 - 2022-08-11
 

--- a/posthog/feature_flags.py
+++ b/posthog/feature_flags.py
@@ -4,7 +4,7 @@ import re
 
 from dateutil import parser
 
-from posthog.utils import is_valid_regex
+from posthog.utils import convert_to_datetime_aware, is_valid_regex
 
 __LONG_SCALE__ = float(0xFFFFFFFFFFFFFFF)
 
@@ -131,12 +131,13 @@ def match_property(property, property_values) -> bool:
 
     if operator in ["is_date_before", "is_date_after"]:
         try:
-            parsed_date = parser.parse(value, ignoretz=True)
+            parsed_date = parser.parse(value)
+            parsed_date = convert_to_datetime_aware(parsed_date)
         except Exception:
             raise InconclusiveMatchError("The date set on the flag is not a valid format")
 
         if isinstance(override_value, datetime.datetime):
-            override_date = override_value.replace(tzinfo=None)
+            override_date = convert_to_datetime_aware(override_value)
             if operator == "is_date_before":
                 return override_date < parsed_date
             else:
@@ -148,7 +149,8 @@ def match_property(property, property_values) -> bool:
                 return override_value > parsed_date.date()
         elif isinstance(override_value, str):
             try:
-                override_date = parser.parse(override_value).replace(tzinfo=None)
+                override_date = parser.parse(override_value)
+                override_date = convert_to_datetime_aware(override_date)
                 if operator == "is_date_before":
                     return override_date < parsed_date
                 else:

--- a/posthog/feature_flags.py
+++ b/posthog/feature_flags.py
@@ -131,18 +131,24 @@ def match_property(property, property_values) -> bool:
 
     if operator in ["is_date_before", "is_date_after"]:
         try:
-            parsed_date = parser.parse(value)
+            parsed_date = parser.parse(value, ignoretz=True)
         except Exception:
             raise InconclusiveMatchError("The date set on the flag is not a valid format")
 
-        if isinstance(override_value, datetime.date):
+        if isinstance(override_value, datetime.datetime):
+            override_date = override_value.replace(tzinfo=None)
             if operator == "is_date_before":
-                return override_value < parsed_date
+                return override_date < parsed_date
             else:
-                return override_value > parsed_date
+                return override_date > parsed_date
+        elif isinstance(override_value, datetime.date):
+            if operator == "is_date_before":
+                return override_value < parsed_date.date()
+            else:
+                return override_value > parsed_date.date()
         elif isinstance(override_value, str):
             try:
-                override_date = parser.parse(override_value)
+                override_date = parser.parse(override_value).replace(tzinfo=None)
                 if operator == "is_date_before":
                     return override_date < parsed_date
                 else:

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -1,8 +1,8 @@
-import unittest
 import datetime
-import pytz
+import unittest
 
 import mock
+import pytz
 from dateutil import parser
 from freezegun import freeze_time
 
@@ -1155,18 +1155,16 @@ class TestMatchProperties(unittest.TestCase):
 
         with self.assertRaises(InconclusiveMatchError):
             match_property(property_c, {"key": 1})
-        
 
         # Timezone aware property
         property_d = self.property(key="key", value="2022-04-05 12:34:12 BST", operator="is_date_before")
         self.assertFalse(match_property(property_d, {"key": "2022-05-30"}))
-        
+
         self.assertTrue(match_property(property_d, {"key": "2022-03-30"}))
         self.assertTrue(match_property(property_d, {"key": "2022-04-05 12:34:11 BST"}))
         self.assertTrue(match_property(property_d, {"key": "2022-04-05 12:34:11 CET"}))
 
         self.assertFalse(match_property(property_d, {"key": "2022-04-05 12:34:13 CET"}))
-
 
 
 class TestCaptureCalls(unittest.TestCase):

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -1,5 +1,6 @@
 import unittest
-from datetime import datetime
+import datetime
+import pytz
 
 import mock
 from dateutil import parser
@@ -1124,7 +1125,9 @@ class TestMatchProperties(unittest.TestCase):
         property_a = self.property(key="key", value="2022-05-01", operator="is_date_before")
         self.assertTrue(match_property(property_a, {"key": "2022-03-01"}))
         self.assertTrue(match_property(property_a, {"key": "2022-04-30"}))
-        self.assertTrue(match_property(property_a, {"key": datetime(2022, 4, 30)}))
+        self.assertTrue(match_property(property_a, {"key": datetime.date(2022, 4, 30)}))
+        self.assertTrue(match_property(property_a, {"key": datetime.datetime(2022, 4, 30, 1, 2, 3)}))
+        self.assertTrue(match_property(property_a, {"key": datetime.datetime(2022, 4, 30, 1, 2, 3, tzinfo=pytz.UTC)}))
         self.assertTrue(match_property(property_a, {"key": parser.parse("2022-04-30")}))
         self.assertFalse(match_property(property_a, {"key": "2022-05-30"}))
 
@@ -1139,7 +1142,7 @@ class TestMatchProperties(unittest.TestCase):
         property_b = self.property(key="key", value="2022-05-01", operator="is_date_after")
         self.assertTrue(match_property(property_b, {"key": "2022-05-02"}))
         self.assertTrue(match_property(property_b, {"key": "2022-05-30"}))
-        self.assertTrue(match_property(property_b, {"key": datetime(2022, 5, 30)}))
+        self.assertTrue(match_property(property_b, {"key": datetime.datetime(2022, 5, 30)}))
         self.assertTrue(match_property(property_b, {"key": parser.parse("2022-05-30")}))
         self.assertFalse(match_property(property_b, {"key": "2022-04-30"}))
 
@@ -1152,6 +1155,18 @@ class TestMatchProperties(unittest.TestCase):
 
         with self.assertRaises(InconclusiveMatchError):
             match_property(property_c, {"key": 1})
+        
+
+        # Timezone aware property
+        property_d = self.property(key="key", value="2022-04-05 12:34:12 BST", operator="is_date_before")
+        self.assertFalse(match_property(property_d, {"key": "2022-05-30"}))
+        
+        self.assertTrue(match_property(property_d, {"key": "2022-03-30"}))
+        self.assertTrue(match_property(property_d, {"key": "2022-04-05 12:34:11 BST"}))
+        self.assertTrue(match_property(property_d, {"key": "2022-04-05 12:34:11 CET"}))
+
+        self.assertFalse(match_property(property_d, {"key": "2022-04-05 12:34:13 CET"}))
+
 
 
 class TestCaptureCalls(unittest.TestCase):

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -1126,7 +1126,11 @@ class TestMatchProperties(unittest.TestCase):
         self.assertTrue(match_property(property_a, {"key": "2022-04-30"}))
         self.assertTrue(match_property(property_a, {"key": datetime.date(2022, 4, 30)}))
         self.assertTrue(match_property(property_a, {"key": datetime.datetime(2022, 4, 30, 1, 2, 3)}))
-        self.assertTrue(match_property(property_a, {"key": datetime.datetime(2022, 4, 30, 1, 2, 3, tzinfo=tz.gettz('Europe/Madrid'))}))
+        self.assertTrue(
+            match_property(
+                property_a, {"key": datetime.datetime(2022, 4, 30, 1, 2, 3, tzinfo=tz.gettz("Europe/Madrid"))}
+            )
+        )
         self.assertTrue(match_property(property_a, {"key": parser.parse("2022-04-30")}))
         self.assertFalse(match_property(property_a, {"key": "2022-05-30"}))
 

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -2,8 +2,7 @@ import datetime
 import unittest
 
 import mock
-import pytz
-from dateutil import parser
+from dateutil import parser, tz
 from freezegun import freeze_time
 
 from posthog.client import Client
@@ -1127,7 +1126,7 @@ class TestMatchProperties(unittest.TestCase):
         self.assertTrue(match_property(property_a, {"key": "2022-04-30"}))
         self.assertTrue(match_property(property_a, {"key": datetime.date(2022, 4, 30)}))
         self.assertTrue(match_property(property_a, {"key": datetime.datetime(2022, 4, 30, 1, 2, 3)}))
-        self.assertTrue(match_property(property_a, {"key": datetime.datetime(2022, 4, 30, 1, 2, 3, tzinfo=pytz.UTC)}))
+        self.assertTrue(match_property(property_a, {"key": datetime.datetime(2022, 4, 30, 1, 2, 3, tzinfo=tz.gettz('Europe/Madrid'))}))
         self.assertTrue(match_property(property_a, {"key": parser.parse("2022-04-30")}))
         self.assertFalse(match_property(property_a, {"key": "2022-05-30"}))
 

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -1156,14 +1156,17 @@ class TestMatchProperties(unittest.TestCase):
             match_property(property_c, {"key": 1})
 
         # Timezone aware property
-        property_d = self.property(key="key", value="2022-04-05 12:34:12 BST", operator="is_date_before")
+        property_d = self.property(key="key", value="2022-04-05 12:34:12 +01:00", operator="is_date_before")
         self.assertFalse(match_property(property_d, {"key": "2022-05-30"}))
 
         self.assertTrue(match_property(property_d, {"key": "2022-03-30"}))
-        self.assertTrue(match_property(property_d, {"key": "2022-04-05 12:34:11 BST"}))
-        self.assertTrue(match_property(property_d, {"key": "2022-04-05 12:34:11 CET"}))
+        self.assertTrue(match_property(property_d, {"key": "2022-04-05 12:34:11 +01:00"}))
+        self.assertTrue(match_property(property_d, {"key": "2022-04-05 12:34:11 +01:00"}))
 
-        self.assertFalse(match_property(property_d, {"key": "2022-04-05 12:34:13 CET"}))
+        self.assertFalse(match_property(property_d, {"key": "2022-04-05 12:34:13 +01:00"}))
+
+        self.assertTrue(match_property(property_d, {"key": "2022-04-05 11:34:11 +00:00"}))
+        self.assertFalse(match_property(property_d, {"key": "2022-04-05 11:34:13 +00:00"}))
 
 
 class TestCaptureCalls(unittest.TestCase):

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -110,7 +110,8 @@ class SizeLimitedDict(defaultdict):
 
         super().__setitem__(key, value)
 
+
 def convert_to_datetime_aware(date_obj):
     if date_obj.tzinfo is None:
-       date_obj = date_obj.replace(tzinfo=timezone.utc)
+        date_obj = date_obj.replace(tzinfo=timezone.utc)
     return date_obj

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -2,7 +2,7 @@ import logging
 import numbers
 import re
 from collections import defaultdict
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from decimal import Decimal
 from uuid import UUID
 
@@ -109,3 +109,8 @@ class SizeLimitedDict(defaultdict):
             self.clear()
 
         super().__setitem__(key, value)
+
+def convert_to_datetime_aware(date_obj):
+    if date_obj.tzinfo is None:
+       date_obj = date_obj.replace(tzinfo=timezone.utc)
+    return date_obj

--- a/posthog/version.py
+++ b/posthog/version.py
@@ -1,4 +1,4 @@
-VERSION = "2.1.1"
+VERSION = "2.1.2"
 
 if __name__ == "__main__":
     print(VERSION, end="")


### PR DESCRIPTION

Have gone for a naive datetime approach here, so we disregard timezone information. Not sure if we want to handle this / if there's valid usecases for this yet.