### PR TITLE
Relax backoff version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ long_description = """
 PostHog is developer-friendly, self-hosted product analytics. posthog-python is the python package.
 """
 
-install_requires = ["requests>=2.7,<3.0", "six>=1.5", "monotonic>=1.5", "backoff>=1.10.0,<2.0.0", "python-dateutil>2.1"]
+install_requires = ["requests>=2.7,<3.0", "six>=1.5", "monotonic>=1.5", "backoff>=1.10.0,<3.0.0", "python-dateutil>2.1"]
 
 extras_require = {
     "dev": [


### PR DESCRIPTION
Seems like the only breaking change was to remove Python version support.

https://github.com/litl/backoff/blob/master/CHANGELOG.md