### PR TITLE
fix: change api error to log

### DIFF
--- a/posthog/client.py
+++ b/posthog/client.py
@@ -366,7 +366,9 @@ class Client(object):
 
         except APIError as e:
             if e.status == 401:
-                self.log.error(f"[FEATURE FLAGS] Error loading feature flags: To use feature flags, please set a valid personal_api_key. More information: https://posthog.com/docs/api/overview")
+                self.log.error(
+                    f"[FEATURE FLAGS] Error loading feature flags: To use feature flags, please set a valid personal_api_key. More information: https://posthog.com/docs/api/overview"
+                )
             else:
                 self.log.error(f"[FEATURE FLAGS] Error loading feature flags: {e}")
         except Exception as e:

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -368,6 +368,13 @@ class Client(object):
                 self.log.error(
                     f"[FEATURE FLAGS] Error loading feature flags: To use feature flags, please set a valid personal_api_key. More information: https://posthog.com/docs/api/overview"
                 )
+                if self.debug:
+                    raise APIError(
+                        status=401,
+                        message="You are using a write-only key with feature flags. "
+                        "To use feature flags, please set a personal_api_key "
+                        "More information: https://posthog.com/docs/api/overview",
+                    )
             else:
                 self.log.error(f"[FEATURE FLAGS] Error loading feature flags: {e}")
         except Exception as e:

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -366,12 +366,7 @@ class Client(object):
 
         except APIError as e:
             if e.status == 401:
-                raise APIError(
-                    status=401,
-                    message="You are using a write-only key with feature flags. "
-                    "To use feature flags, please set a personal_api_key "
-                    "More information: https://posthog.com/docs/api/overview",
-                )
+                self.log.error(f"[FEATURE FLAGS] Error loading feature flags: To use feature flags, please set a valid personal_api_key. More information: https://posthog.com/docs/api/overview")
             else:
                 self.log.error(f"[FEATURE FLAGS] Error loading feature flags: {e}")
         except Exception as e:

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -48,7 +48,6 @@ class Client(object):
         personal_api_key=None,
         project_api_key=None,
     ):
-
         self.queue = queue.Queue(max_queue_size)
 
         # api_key: This should be the Team API Key (token), public
@@ -392,7 +391,6 @@ class Client(object):
             self.poller.start()
 
     def _compute_flag_locally(self, feature_flag, distinct_id, *, groups={}, person_properties={}, group_properties={}):
-
         if feature_flag.get("ensure_experience_continuity", False):
             raise InconclusiveMatchError("Flag has experience continuity enabled")
 

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -71,7 +71,6 @@ class TestClient(unittest.TestCase):
         self.assertEqual(msg["properties"]["$lib_version"], VERSION)
 
     def test_basic_capture_with_project_api_key(self):
-
         client = Client(project_api_key=FAKE_TEST_API_KEY, on_error=self.set_fail)
 
         success, msg = client.capture("distinct_id", "python test event")

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -762,8 +762,8 @@ class TestLocalEvaluation(unittest.TestCase):
                 logs.output[0],
                 "ERROR:posthog:[FEATURE FLAGS] Error loading feature flags: To use feature flags, please set a valid personal_api_key. More information: https://posthog.com/docs/api/overview",
             )
-      client.debug = True
-      self.assertRaises(APIError, client.load_feature_flags)
+        client.debug = True
+        self.assertRaises(APIError, client.load_feature_flags)
 
     @mock.patch("posthog.client.decide")
     @mock.patch("posthog.client.get")

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -762,6 +762,8 @@ class TestLocalEvaluation(unittest.TestCase):
                 logs.output[0],
                 "ERROR:posthog:[FEATURE FLAGS] Error loading feature flags: To use feature flags, please set a valid personal_api_key. More information: https://posthog.com/docs/api/overview",
             )
+      client.debug = True
+      self.assertRaises(APIError, client.load_feature_flags)
 
     @mock.patch("posthog.client.decide")
     @mock.patch("posthog.client.get")

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -754,7 +754,6 @@ class TestLocalEvaluation(unittest.TestCase):
         self.assertEqual(patch_poll.call_count, 1)
 
     def test_load_feature_flags_wrong_key(self):
-
         client = Client(FAKE_TEST_API_KEY, personal_api_key=FAKE_TEST_API_KEY)
 
         with self.assertLogs("posthog", level="ERROR") as logs:

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -1,5 +1,6 @@
 import datetime
 import unittest
+
 import mock
 from dateutil import parser, tz
 from freezegun import freeze_time


### PR DESCRIPTION
Context: https://posthog.slack.com/archives/C04LVFQ481Y/p1674834256925379

Incorrect api key was causing error to be thrown. Change error handling to be a log