### PR TITLE
fix: add function for active variants

### DIFF
--- a/posthog/client.py
+++ b/posthog/client.py
@@ -130,6 +130,10 @@ class Client(object):
         resp_data = self.get_decide(distinct_id, groups, person_properties, group_properties)
         return resp_data["featureFlags"]
 
+    def _get_active_feature_variants(self, distinct_id, groups=None, person_properties=None, group_properties=None):
+        feature_variants = self.get_feature_variants(distinct_id, groups, person_properties, group_properties)
+        return {k:v for (k,v) in feature_variants.items() if v is not False} #explicitly test for false to account for values that may seem falsy (ex: 0)
+
     def get_feature_payloads(self, distinct_id, groups=None, person_properties=None, group_properties=None):
         resp_data = self.get_decide(distinct_id, groups, person_properties, group_properties)
         return resp_data["featureFlagPayloads"]
@@ -183,7 +187,7 @@ class Client(object):
 
         if send_feature_flags:
             try:
-                feature_variants = self.get_feature_variants(distinct_id, groups)
+                feature_variants = self._get_active_feature_variants(distinct_id, groups)
             except Exception as e:
                 self.log.exception(f"[FEATURE FLAGS] Unable to get feature variants: {e}")
             else:

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -132,7 +132,9 @@ class Client(object):
 
     def _get_active_feature_variants(self, distinct_id, groups=None, person_properties=None, group_properties=None):
         feature_variants = self.get_feature_variants(distinct_id, groups, person_properties, group_properties)
-        return {k:v for (k,v) in feature_variants.items() if v is not False} #explicitly test for false to account for values that may seem falsy (ex: 0)
+        return {
+            k: v for (k, v) in feature_variants.items() if v is not False
+        }  # explicitly test for false to account for values that may seem falsy (ex: 0)
 
     def get_feature_payloads(self, distinct_id, groups=None, person_properties=None, group_properties=None):
         resp_data = self.get_decide(distinct_id, groups, person_properties, group_properties)

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -108,16 +108,19 @@ class TestClient(unittest.TestCase):
 
     @mock.patch("posthog.client.decide")
     def test_get_active_feature_flags(self, patch_decide):
-        patch_decide.return_value = {"featureFlags": {"beta-feature": "random-variant", "alpha-feature": True, "off-feature": False}}
+        patch_decide.return_value = {
+            "featureFlags": {"beta-feature": "random-variant", "alpha-feature": True, "off-feature": False}
+        }
 
         client = Client(FAKE_TEST_API_KEY, on_error=self.set_fail, personal_api_key=FAKE_TEST_API_KEY)
         variants = client._get_active_feature_variants("some_id", None, None, None)
         print(variants)
 
-
     @mock.patch("posthog.client.decide")
     def test_basic_capture_with_feature_flags_returns_active_only(self, patch_decide):
-        patch_decide.return_value = {"featureFlags": {"beta-feature": "random-variant", "alpha-feature": True, "off-feature": False}}
+        patch_decide.return_value = {
+            "featureFlags": {"beta-feature": "random-variant", "alpha-feature": True, "off-feature": False}
+        }
 
         client = Client(FAKE_TEST_API_KEY, on_error=self.set_fail, personal_api_key=FAKE_TEST_API_KEY)
         success, msg = client.capture("distinct_id", "python test event", send_feature_flags=True)

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -107,6 +107,37 @@ class TestClient(unittest.TestCase):
         self.assertEqual(patch_decide.call_count, 1)
 
     @mock.patch("posthog.client.decide")
+    def test_get_active_feature_flags(self, patch_decide):
+        patch_decide.return_value = {"featureFlags": {"beta-feature": "random-variant", "alpha-feature": True, "off-feature": False}}
+
+        client = Client(FAKE_TEST_API_KEY, on_error=self.set_fail, personal_api_key=FAKE_TEST_API_KEY)
+        variants = client._get_active_feature_variants("some_id", None, None, None)
+        print(variants)
+
+
+    @mock.patch("posthog.client.decide")
+    def test_basic_capture_with_feature_flags_returns_active_only(self, patch_decide):
+        patch_decide.return_value = {"featureFlags": {"beta-feature": "random-variant", "alpha-feature": True, "off-feature": False}}
+
+        client = Client(FAKE_TEST_API_KEY, on_error=self.set_fail, personal_api_key=FAKE_TEST_API_KEY)
+        success, msg = client.capture("distinct_id", "python test event", send_feature_flags=True)
+        client.flush()
+        self.assertTrue(success)
+        self.assertFalse(self.failed)
+
+        self.assertEqual(msg["event"], "python test event")
+        self.assertTrue(isinstance(msg["timestamp"], str))
+        self.assertIsNone(msg.get("uuid"))
+        self.assertEqual(msg["distinct_id"], "distinct_id")
+        self.assertEqual(msg["properties"]["$lib"], "posthog-python")
+        self.assertEqual(msg["properties"]["$lib_version"], VERSION)
+        self.assertEqual(msg["properties"]["$feature/beta-feature"], "random-variant")
+        self.assertEqual(msg["properties"]["$feature/alpha-feature"], True)
+        self.assertEqual(msg["properties"]["$active_feature_flags"], ["beta-feature", "alpha-feature"])
+
+        self.assertEqual(patch_decide.call_count, 1)
+
+    @mock.patch("posthog.client.decide")
     def test_basic_capture_with_feature_flags_switched_off_doesnt_send_them(self, patch_decide):
         patch_decide.return_value = {"featureFlags": {"beta-feature": "random-variant"}}
 


### PR DESCRIPTION
Send feature flags is sending all flags now after decide v3 change. Restore original functionality