### PR TITLE
chore: change package to be an instantiable client

### DIFF
--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -9,6 +9,7 @@ __version__ = VERSION
 
 default_client = None
 
+
 class Posthog(object):
     log = logging.getLogger("posthog")
 
@@ -16,20 +17,31 @@ class Posthog(object):
     disabled = False  # type: bool
     _client: Client = None  # type: Client
 
-    def __init__(self, api_key, host="https://app.posthog.com", on_error=None, debug=False, send=True, sync_mode=False, personal_api_key=None, project_api_key=None, poll_interval=30, disabled=False):
+    def __init__(
+        self,
+        api_key,
+        host="https://app.posthog.com",
+        on_error=None,
+        debug=False,
+        send=True,
+        sync_mode=False,
+        personal_api_key=None,
+        project_api_key=None,
+        poll_interval=30,
+        disabled=False,
+    ):
         self.disabled = disabled
         self._client = Client(
-            api_key=api_key, 
-            host=host, 
-            on_error=on_error, 
-            debug=debug, 
-            send=send, 
-            sync_mode=sync_mode, 
-            personal_api_key=personal_api_key, 
-            project_api_key=project_api_key, 
-            poll_interval=poll_interval
+            api_key=api_key,
+            host=host,
+            on_error=on_error,
+            debug=debug,
+            send=send,
+            sync_mode=sync_mode,
+            personal_api_key=personal_api_key,
+            project_api_key=project_api_key,
+            poll_interval=poll_interval,
         )
-
 
     def capture(
         self,
@@ -75,7 +87,6 @@ class Posthog(object):
             send_feature_flags=send_feature_flags,
         )
 
-
     def identify(
         self,
         distinct_id,  # type: str
@@ -108,7 +119,6 @@ class Posthog(object):
             timestamp=timestamp,
             uuid=uuid,
         )
-
 
     def set(
         self,
@@ -143,7 +153,6 @@ class Posthog(object):
             uuid=uuid,
         )
 
-
     def set_once(
         self,
         distinct_id,  # type: str
@@ -176,7 +185,6 @@ class Posthog(object):
             timestamp=timestamp,
             uuid=uuid,
         )
-
 
     def group_identify(
         self,
@@ -213,7 +221,6 @@ class Posthog(object):
             uuid=uuid,
         )
 
-
     def alias(
         self,
         previous_id,  # type: str
@@ -247,7 +254,6 @@ class Posthog(object):
             timestamp=timestamp,
             uuid=uuid,
         )
-
 
     def feature_enabled(
         self,
@@ -283,7 +289,6 @@ class Posthog(object):
             only_evaluate_locally=only_evaluate_locally,
             send_feature_flag_events=send_feature_flag_events,
         )
-
 
     def get_feature_flag(
         self,
@@ -328,9 +333,8 @@ class Posthog(object):
             send_feature_flag_events=send_feature_flag_events,
         )
 
-
     def get_all_flags(
-        self, 
+        self,
         distinct_id,  # type: str
         groups={},  # type: dict
         person_properties={},  # type: dict
@@ -355,7 +359,6 @@ class Posthog(object):
             only_evaluate_locally=only_evaluate_locally,
         )
 
-
     def get_feature_flag_payload(
         self,
         key,
@@ -379,7 +382,6 @@ class Posthog(object):
             send_feature_flag_events=send_feature_flag_events,
         )
 
-
     def get_all_flags_and_payloads(
         self,
         distinct_id,
@@ -397,37 +399,31 @@ class Posthog(object):
             only_evaluate_locally=only_evaluate_locally,
         )
 
-
     def page(self, *args, **kwargs):
         """Send a page call."""
         self._proxy("page", *args, **kwargs)
-
 
     def screen(self, *args, **kwargs):
         """Send a screen call."""
         self._proxy("screen", *args, **kwargs)
 
-
     def flush(self):
         """Tell the client to flush."""
         self._proxy("flush")
 
-
     def join(self):
         """Block program until the client clears the queue"""
         self._proxy("join")
-
 
     def shutdown(self):
         """Flush all messages and cleanly shutdown the client"""
         self._proxy("flush")
         self._proxy("join")
 
-
     def _proxy(self, method, *args, **kwargs):
         """Create an analytics client if one doesn't exist and send to it."""
         if self.disabled:
             return None
-        
+
         fn = getattr(self._client, method)
         return fn(*args, **kwargs)

--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -112,7 +112,7 @@ class Posthog(object):
 
     def set(
         self,
-        distinct_id,  # type: str,
+        distinct_id,  # type: str
         properties=None,  # type: Optional[Dict]
         context=None,  # type: Optional[Dict]
         timestamp=None,  # type: Optional[datetime.datetime]
@@ -146,7 +146,7 @@ class Posthog(object):
 
     def set_once(
         self,
-        distinct_id,  # type: str,
+        distinct_id,  # type: str
         properties=None,  # type: Optional[Dict]
         context=None,  # type: Optional[Dict]
         timestamp=None,  # type: Optional[datetime.datetime]
@@ -216,8 +216,8 @@ class Posthog(object):
 
     def alias(
         self,
-        previous_id,  # type: str,
-        distinct_id,  # type: str,
+        previous_id,  # type: str
+        distinct_id,  # type: str
         context=None,  # type: Optional[Dict]
         timestamp=None,  # type: Optional[datetime.datetime]
         uuid=None,  # type: Optional[str]
@@ -251,8 +251,8 @@ class Posthog(object):
 
     def feature_enabled(
         self,
-        key,  # type: str,
-        distinct_id,  # type: str,
+        key,  # type: str
+        distinct_id,  # type: str
         groups={},  # type: dict
         person_properties={},  # type: dict
         group_properties={},  # type: dict
@@ -287,8 +287,8 @@ class Posthog(object):
 
     def get_feature_flag(
         self,
-        key,  # type: str,
-        distinct_id,  # type: str,
+        key,  # type: str
+        distinct_id,  # type: str
         groups={},  # type: dict
         person_properties={},  # type: dict
         group_properties={},  # type: dict
@@ -331,7 +331,7 @@ class Posthog(object):
 
     def get_all_flags(
         self, 
-        distinct_id,  # type: str,
+        distinct_id,  # type: str
         groups={},  # type: dict
         person_properties={},  # type: dict
         group_properties={},  # type: dict

--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -420,6 +420,10 @@ def _proxy(method, *args, **kwargs):
             disabled=disabled,
         )
 
+    # always set incase user changes it
+    default_client.disabled = disabled
+    default_client.debug = debug
+
     fn = getattr(default_client, method)
     return fn(*args, **kwargs)
 

--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -1,9 +1,9 @@
 import datetime  # noqa: F401
+import logging
 from typing import Callable, Dict, Optional  # noqa: F401
 
 from posthog.client import Client
 from posthog.version import VERSION
-import logging
 
 __version__ = VERSION
 

--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -424,5 +424,6 @@ def _proxy(method, *args, **kwargs):
     fn = getattr(default_client, method)
     return fn(*args, **kwargs)
 
+
 class Posthog(Client):
     pass

--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -3,23 +3,24 @@ from typing import Callable, Dict, Optional  # noqa: F401
 
 from posthog.client import Client
 from posthog.version import VERSION
+import logging
 
 __version__ = VERSION
 
 """Settings."""
-api_key = None  # type: str
-host = None  # type: str
-on_error = None  # type: Callable
-debug = False  # type: bool
-send = True  # type: bool
-sync_mode = False  # type: bool
+_host = "https://app.posthog.com"  # type: str
+_on_error = None  # type: Callable
+_debug = False  # type: bool
+_send = True  # type: bool
+_sync_mode = False  # type: bool
 disabled = False  # type: bool
-personal_api_key = None  # type: str
-project_api_key = None  # type: str
-poll_interval = 30  # type: int
+_personal_api_key = None  # type: str
+_project_api_key = None  # type: str
+_poll_interval = 30  # type: int
 
 default_client = None
 
+log = logging.getLogger("posthog")
 
 def capture(
     distinct_id,  # type: str
@@ -409,17 +410,22 @@ def _proxy(method, *args, **kwargs):
     if disabled:
         return None
     if not default_client:
-        default_client = Client(
-            api_key,
-            host=host,
-            debug=debug,
-            on_error=on_error,
-            send=send,
-            sync_mode=sync_mode,
-            personal_api_key=personal_api_key,
-            project_api_key=project_api_key,
-            poll_interval=poll_interval,
-        )
-
+        log.error(f"posthog must be initiated with a valid api key and host using posthog.init before calling {method}")
+    
     fn = getattr(default_client, method)
     return fn(*args, **kwargs)
+
+def init(api_key, host=_host, debug=_debug, on_error=_on_error, send=_send, sync_mode=_sync_mode, personal_api_key=_personal_api_key, project_api_key=_project_api_key, poll_interval=_poll_interval):
+    """Initialize the client."""
+    global default_client
+    default_client = Client(
+        api_key,
+        host=host,
+        debug=debug,
+        on_error=on_error,
+        send=send,
+        sync_mode=sync_mode,
+        personal_api_key=personal_api_key,
+        project_api_key=project_api_key,
+        poll_interval=poll_interval,
+    )

--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -7,425 +7,427 @@ import logging
 
 __version__ = VERSION
 
-"""Settings."""
-_host = "https://app.posthog.com"  # type: str
-_on_error = None  # type: Callable
-_debug = False  # type: bool
-_send = True  # type: bool
-_sync_mode = False  # type: bool
-disabled = False  # type: bool
-_personal_api_key = None  # type: str
-_project_api_key = None  # type: str
-_poll_interval = 30  # type: int
-
 default_client = None
 
-log = logging.getLogger("posthog")
+class Posthog(object):
+    log = logging.getLogger("posthog")
 
-def capture(
-    distinct_id,  # type: str
-    event,  # type: str
-    properties=None,  # type: Optional[Dict]
-    context=None,  # type: Optional[Dict]
-    timestamp=None,  # type: Optional[datetime.datetime]
-    uuid=None,  # type: Optional[str]
-    groups=None,  # type: Optional[Dict]
-    send_feature_flags=False,
-):
-    # type: (...) -> None
-    """
-    Capture allows you to capture anything a user does within your system, which you can later use in PostHog to find patterns in usage, work out which features to improve or where people are giving up.
+    """Settings."""
+    disabled = False  # type: bool
+    _client: Client = None  # type: Client
 
-    A `capture` call requires
-    - `distinct id` which uniquely identifies your user
-    - `event name` to specify the event
-    - We recommend using [verb] [noun], like `movie played` or `movie updated` to easily identify what your events mean later on.
-
-    Optionally you can submit
-    - `properties`, which can be a dict with any information you'd like to add
-    - `groups`, which is a dict of group type -> group key mappings
-
-    For example:
-    ```python
-    posthog.capture('distinct id', 'opened app')
-    posthog.capture('distinct id', 'movie played', {'movie_id': '123', 'category': 'romcom'})
-
-    posthog.capture('distinct id', 'purchase', groups={'company': 'id:5'})
-    ```
-    """
-    _proxy(
-        "capture",
-        distinct_id=distinct_id,
-        event=event,
-        properties=properties,
-        context=context,
-        timestamp=timestamp,
-        uuid=uuid,
-        groups=groups,
-        send_feature_flags=send_feature_flags,
-    )
+    def __init__(self, api_key, host="https://app.posthog.com", on_error=None, debug=False, send=True, sync_mode=False, personal_api_key=None, project_api_key=None, poll_interval=30, disabled=False):
+        self.disabled = disabled
+        self._client = Client(
+            api_key=api_key, 
+            host=host, 
+            on_error=on_error, 
+            debug=debug, 
+            send=send, 
+            sync_mode=sync_mode, 
+            personal_api_key=personal_api_key, 
+            project_api_key=project_api_key, 
+            poll_interval=poll_interval
+        )
 
 
-def identify(
-    distinct_id,  # type: str
-    properties=None,  # type: Optional[Dict]
-    context=None,  # type: Optional[Dict]
-    timestamp=None,  # type: Optional[datetime.datetime]
-    uuid=None,  # type: Optional[str]
-):
-    # type: (...) -> None
-    """
-    Identify lets you add metadata on your users so you can more easily identify who they are in PostHog, and even do things like segment users by these properties.
+    def capture(
+        self,
+        distinct_id,  # type: str
+        event,  # type: str
+        properties=None,  # type: Optional[Dict]
+        context=None,  # type: Optional[Dict]
+        timestamp=None,  # type: Optional[datetime.datetime]
+        uuid=None,  # type: Optional[str]
+        groups=None,  # type: Optional[Dict]
+        send_feature_flags=False,
+    ):
+        # type: (...) -> None
+        """
+        Capture allows you to capture anything a user does within your system, which you can later use in PostHog to find patterns in usage, work out which features to improve or where people are giving up.
 
-    An `identify` call requires
-    - `distinct id` which uniquely identifies your user
-    - `properties` with a dict with any key: value pairs
+        A `capture` call requires
+        - `distinct id` which uniquely identifies your user
+        - `event name` to specify the event
+        - We recommend using [verb] [noun], like `movie played` or `movie updated` to easily identify what your events mean later on.
 
-    For example:
-    ```python
-    posthog.identify('distinct id', {
-        'email': 'dwayne@gmail.com',
-        'name': 'Dwayne Johnson'
-    })
-    ```
-    """
-    _proxy(
-        "identify",
-        distinct_id=distinct_id,
-        properties=properties,
-        context=context,
-        timestamp=timestamp,
-        uuid=uuid,
-    )
+        Optionally you can submit
+        - `properties`, which can be a dict with any information you'd like to add
+        - `groups`, which is a dict of group type -> group key mappings
 
+        For example:
+        ```python
+        posthog.capture('distinct id', 'opened app')
+        posthog.capture('distinct id', 'movie played', {'movie_id': '123', 'category': 'romcom'})
 
-def set(
-    distinct_id,  # type: str,
-    properties=None,  # type: Optional[Dict]
-    context=None,  # type: Optional[Dict]
-    timestamp=None,  # type: Optional[datetime.datetime]
-    uuid=None,  # type: Optional[str]
-):
-    # type: (...) -> None
-    """
-    Set properties on a user record.
-    This will overwrite previous people property values, just like `identify`.
-
-     A `set` call requires
-     - `distinct id` which uniquely identifies your user
-     - `properties` with a dict with any key: value pairs
-
-     For example:
-     ```python
-     posthog.set('distinct id', {
-         'current_browser': 'Chrome',
-     })
-     ```
-    """
-    _proxy(
-        "set",
-        distinct_id=distinct_id,
-        properties=properties,
-        context=context,
-        timestamp=timestamp,
-        uuid=uuid,
-    )
+        posthog.capture('distinct id', 'purchase', groups={'company': 'id:5'})
+        ```
+        """
+        self._proxy(
+            "capture",
+            distinct_id=distinct_id,
+            event=event,
+            properties=properties,
+            context=context,
+            timestamp=timestamp,
+            uuid=uuid,
+            groups=groups,
+            send_feature_flags=send_feature_flags,
+        )
 
 
-def set_once(
-    distinct_id,  # type: str,
-    properties=None,  # type: Optional[Dict]
-    context=None,  # type: Optional[Dict]
-    timestamp=None,  # type: Optional[datetime.datetime]
-    uuid=None,  # type: Optional[str]
-):
-    # type: (...) -> None
-    """
-    Set properties on a user record, only if they do not yet exist.
-    This will not overwrite previous people property values, unlike `identify`.
+    def identify(
+        self,
+        distinct_id,  # type: str
+        properties=None,  # type: Optional[Dict]
+        context=None,  # type: Optional[Dict]
+        timestamp=None,  # type: Optional[datetime.datetime]
+        uuid=None,  # type: Optional[str]
+    ):
+        # type: (...) -> None
+        """
+        Identify lets you add metadata on your users so you can more easily identify who they are in PostHog, and even do things like segment users by these properties.
 
-     A `set_once` call requires
-     - `distinct id` which uniquely identifies your user
-     - `properties` with a dict with any key: value pairs
+        An `identify` call requires
+        - `distinct id` which uniquely identifies your user
+        - `properties` with a dict with any key: value pairs
 
-     For example:
-     ```python
-     posthog.set_once('distinct id', {
-         'referred_by': 'friend',
-     })
-     ```
-    """
-    _proxy(
-        "set_once",
-        distinct_id=distinct_id,
-        properties=properties,
-        context=context,
-        timestamp=timestamp,
-        uuid=uuid,
-    )
-
-
-def group_identify(
-    group_type,  # type: str
-    group_key,  # type: str
-    properties=None,  # type: Optional[Dict]
-    context=None,  # type: Optional[Dict]
-    timestamp=None,  # type: Optional[datetime.datetime]
-    uuid=None,  # type: Optional[str]
-):
-    # type: (...) -> None
-    """
-    Set properties on a group
-
-     A `group_identify` call requires
-     - `group_type` type of your group
-     - `group_key` unique identifier of the group
-     - `properties` with a dict with any key: value pairs
-
-     For example:
-     ```python
-     posthog.group_identify('company', 5, {
-         'employees': 11,
-     })
-     ```
-    """
-    _proxy(
-        "group_identify",
-        group_type=group_type,
-        group_key=group_key,
-        properties=properties,
-        context=context,
-        timestamp=timestamp,
-        uuid=uuid,
-    )
+        For example:
+        ```python
+        posthog.identify('distinct id', {
+            'email': 'dwayne@gmail.com',
+            'name': 'Dwayne Johnson'
+        })
+        ```
+        """
+        self._proxy(
+            "identify",
+            distinct_id=distinct_id,
+            properties=properties,
+            context=context,
+            timestamp=timestamp,
+            uuid=uuid,
+        )
 
 
-def alias(
-    previous_id,  # type: str,
-    distinct_id,  # type: str,
-    context=None,  # type: Optional[Dict]
-    timestamp=None,  # type: Optional[datetime.datetime]
-    uuid=None,  # type: Optional[str]
-):
-    # type: (...) -> None
-    """
-    To marry up whatever a user does before they sign up or log in with what they do after you need to make an alias call. This will allow you to answer questions like "Which marketing channels leads to users churning after a month?" or "What do users do on our website before signing up?"
+    def set(
+        self,
+        distinct_id,  # type: str,
+        properties=None,  # type: Optional[Dict]
+        context=None,  # type: Optional[Dict]
+        timestamp=None,  # type: Optional[datetime.datetime]
+        uuid=None,  # type: Optional[str]
+    ):
+        # type: (...) -> None
+        """
+        Set properties on a user record.
+        This will overwrite previous people property values, just like `identify`.
 
-    In a purely back-end implementation, this means whenever an anonymous user does something, you'll want to send a session ID ([Django](https://stackoverflow.com/questions/526179/in-django-how-can-i-find-out-the-request-session-sessionid-and-use-it-as-a-vari), [Flask](https://stackoverflow.com/questions/15156132/flask-login-how-to-get-session-id)) with the capture call. Then, when that users signs up, you want to do an alias call with the session ID and the newly created user ID.
+        A `set` call requires
+        - `distinct id` which uniquely identifies your user
+        - `properties` with a dict with any key: value pairs
 
-    The same concept applies for when a user logs in.
-
-    An `alias` call requires
-    - `previous distinct id` the unique ID of the user before
-    - `distinct id` the current unique id
-
-    For example:
-    ```python
-    posthog.alias('anonymous session id', 'distinct id')
-    ```
-    """
-    _proxy(
-        "alias",
-        previous_id=previous_id,
-        distinct_id=distinct_id,
-        context=context,
-        timestamp=timestamp,
-        uuid=uuid,
-    )
-
-
-def feature_enabled(
-    key,  # type: str,
-    distinct_id,  # type: str,
-    groups={},  # type: dict
-    person_properties={},  # type: dict
-    group_properties={},  # type: dict
-    only_evaluate_locally=False,  # type: bool
-    send_feature_flag_events=True,  # type: bool
-):
-    # type: (...) -> bool
-    """
-    Use feature flags to enable or disable features for users.
-
-    For example:
-    ```python
-    if posthog.feature_enabled('beta feature', 'distinct id'):
-        # do something
-    if posthog.feature_enabled('groups feature', 'distinct id', groups={"organization": "5"}):
-        # do something
-    ```
-
-    You can call `posthog.load_feature_flags()` before to make sure you're not doing unexpected requests.
-    """
-    return _proxy(
-        "feature_enabled",
-        key=key,
-        distinct_id=distinct_id,
-        groups=groups,
-        person_properties=person_properties,
-        group_properties=group_properties,
-        only_evaluate_locally=only_evaluate_locally,
-        send_feature_flag_events=send_feature_flag_events,
-    )
+        For example:
+        ```python
+        posthog.set('distinct id', {
+            'current_browser': 'Chrome',
+        })
+        ```
+        """
+        self._proxy(
+            "set",
+            distinct_id=distinct_id,
+            properties=properties,
+            context=context,
+            timestamp=timestamp,
+            uuid=uuid,
+        )
 
 
-def get_feature_flag(
-    key,  # type: str,
-    distinct_id,  # type: str,
-    groups={},  # type: dict
-    person_properties={},  # type: dict
-    group_properties={},  # type: dict
-    only_evaluate_locally=False,  # type: bool
-    send_feature_flag_events=True,  # type: bool
-):
-    """
-    Get feature flag variant for users. Used with experiments.
-    Example:
-    ```python
-    if posthog.get_feature_flag('beta-feature', 'distinct_id') == 'test-variant':
-        # do test variant code
-    if posthog.get_feature_flag('beta-feature', 'distinct_id') == 'control':
-        # do control code
-    ```
+    def set_once(
+        self,
+        distinct_id,  # type: str,
+        properties=None,  # type: Optional[Dict]
+        context=None,  # type: Optional[Dict]
+        timestamp=None,  # type: Optional[datetime.datetime]
+        uuid=None,  # type: Optional[str]
+    ):
+        # type: (...) -> None
+        """
+        Set properties on a user record, only if they do not yet exist.
+        This will not overwrite previous people property values, unlike `identify`.
 
-    `groups` are a mapping from group type to group key. So, if you have a group type of "organization" and a group key of "5",
-    you would pass groups={"organization": "5"}.
+        A `set_once` call requires
+        - `distinct id` which uniquely identifies your user
+        - `properties` with a dict with any key: value pairs
 
-    `group_properties` take the format: { group_type_name: { group_properties } }
-
-    So, for example, if you have the group type "organization" and the group key "5", with the properties name, and employee count,
-    you'll send these as:
-
-    ```python
-        group_properties={"organization": {"name": "PostHog", "employees": 11}}
-    ```
-    """
-    return _proxy(
-        "get_feature_flag",
-        key=key,
-        distinct_id=distinct_id,
-        groups=groups,
-        person_properties=person_properties,
-        group_properties=group_properties,
-        only_evaluate_locally=only_evaluate_locally,
-        send_feature_flag_events=send_feature_flag_events,
-    )
+        For example:
+        ```python
+        posthog.set_once('distinct id', {
+            'referred_by': 'friend',
+        })
+        ```
+        """
+        self._proxy(
+            "set_once",
+            distinct_id=distinct_id,
+            properties=properties,
+            context=context,
+            timestamp=timestamp,
+            uuid=uuid,
+        )
 
 
-def get_all_flags(
-    distinct_id,  # type: str,
-    groups={},  # type: dict
-    person_properties={},  # type: dict
-    group_properties={},  # type: dict
-    only_evaluate_locally=False,  # type: bool
-):
-    """
-    Get all flags for a given user.
-    Example:
-    ```python
-    flags = posthog.get_all_flags('distinct_id')
-    ```
+    def group_identify(
+        self,
+        group_type,  # type: str
+        group_key,  # type: str
+        properties=None,  # type: Optional[Dict]
+        context=None,  # type: Optional[Dict]
+        timestamp=None,  # type: Optional[datetime.datetime]
+        uuid=None,  # type: Optional[str]
+    ):
+        # type: (...) -> None
+        """
+        Set properties on a group
 
-    flags are key-value pairs where the key is the flag key and the value is the flag variant, or True, or False.
-    """
-    return _proxy(
-        "get_all_flags",
-        distinct_id=distinct_id,
-        groups=groups,
-        person_properties=person_properties,
-        group_properties=group_properties,
-        only_evaluate_locally=only_evaluate_locally,
-    )
+        A `group_identify` call requires
+        - `group_type` type of your group
+        - `group_key` unique identifier of the group
+        - `properties` with a dict with any key: value pairs
 
-
-def get_feature_flag_payload(
-    key,
-    distinct_id,
-    match_value=None,
-    groups={},
-    person_properties={},
-    group_properties={},
-    only_evaluate_locally=False,
-    send_feature_flag_events=True,
-):
-    return _proxy(
-        "get_feature_flag_payload",
-        key=key,
-        distinct_id=distinct_id,
-        match_value=match_value,
-        groups=groups,
-        person_properties=person_properties,
-        group_properties=group_properties,
-        only_evaluate_locally=only_evaluate_locally,
-        send_feature_flag_events=send_feature_flag_events,
-    )
+        For example:
+        ```python
+        posthog.group_identify('company', 5, {
+            'employees': 11,
+        })
+        ```
+        """
+        self._proxy(
+            "group_identify",
+            group_type=group_type,
+            group_key=group_key,
+            properties=properties,
+            context=context,
+            timestamp=timestamp,
+            uuid=uuid,
+        )
 
 
-def get_all_flags_and_payloads(
-    distinct_id,
-    groups={},
-    person_properties={},
-    group_properties={},
-    only_evaluate_locally=False,
-):
-    return _proxy(
-        "get_all_flags_and_payloads",
-        distinct_id=distinct_id,
-        groups=groups,
-        person_properties=person_properties,
-        group_properties=group_properties,
-        only_evaluate_locally=only_evaluate_locally,
-    )
+    def alias(
+        self,
+        previous_id,  # type: str,
+        distinct_id,  # type: str,
+        context=None,  # type: Optional[Dict]
+        timestamp=None,  # type: Optional[datetime.datetime]
+        uuid=None,  # type: Optional[str]
+    ):
+        # type: (...) -> None
+        """
+        To marry up whatever a user does before they sign up or log in with what they do after you need to make an alias call. This will allow you to answer questions like "Which marketing channels leads to users churning after a month?" or "What do users do on our website before signing up?"
+
+        In a purely back-end implementation, this means whenever an anonymous user does something, you'll want to send a session ID ([Django](https://stackoverflow.com/questions/526179/in-django-how-can-i-find-out-the-request-session-sessionid-and-use-it-as-a-vari), [Flask](https://stackoverflow.com/questions/15156132/flask-login-how-to-get-session-id)) with the capture call. Then, when that users signs up, you want to do an alias call with the session ID and the newly created user ID.
+
+        The same concept applies for when a user logs in.
+
+        An `alias` call requires
+        - `previous distinct id` the unique ID of the user before
+        - `distinct id` the current unique id
+
+        For example:
+        ```python
+        posthog.alias('anonymous session id', 'distinct id')
+        ```
+        """
+        self._proxy(
+            "alias",
+            previous_id=previous_id,
+            distinct_id=distinct_id,
+            context=context,
+            timestamp=timestamp,
+            uuid=uuid,
+        )
 
 
-def page(*args, **kwargs):
-    """Send a page call."""
-    _proxy("page", *args, **kwargs)
+    def feature_enabled(
+        self,
+        key,  # type: str,
+        distinct_id,  # type: str,
+        groups={},  # type: dict
+        person_properties={},  # type: dict
+        group_properties={},  # type: dict
+        only_evaluate_locally=False,  # type: bool
+        send_feature_flag_events=True,  # type: bool
+    ):
+        # type: (...) -> bool
+        """
+        Use feature flags to enable or disable features for users.
+
+        For example:
+        ```python
+        if posthog.feature_enabled('beta feature', 'distinct id'):
+            # do something
+        if posthog.feature_enabled('groups feature', 'distinct id', groups={"organization": "5"}):
+            # do something
+        ```
+
+        You can call `posthog.load_feature_flags()` before to make sure you're not doing unexpected requests.
+        """
+        return self._proxy(
+            "feature_enabled",
+            key=key,
+            distinct_id=distinct_id,
+            groups=groups,
+            person_properties=person_properties,
+            group_properties=group_properties,
+            only_evaluate_locally=only_evaluate_locally,
+            send_feature_flag_events=send_feature_flag_events,
+        )
 
 
-def screen(*args, **kwargs):
-    """Send a screen call."""
-    _proxy("screen", *args, **kwargs)
+    def get_feature_flag(
+        self,
+        key,  # type: str,
+        distinct_id,  # type: str,
+        groups={},  # type: dict
+        person_properties={},  # type: dict
+        group_properties={},  # type: dict
+        only_evaluate_locally=False,  # type: bool
+        send_feature_flag_events=True,  # type: bool
+    ):
+        """
+        Get feature flag variant for users. Used with experiments.
+        Example:
+        ```python
+        if posthog.get_feature_flag('beta-feature', 'distinct_id') == 'test-variant':
+            # do test variant code
+        if posthog.get_feature_flag('beta-feature', 'distinct_id') == 'control':
+            # do control code
+        ```
+
+        `groups` are a mapping from group type to group key. So, if you have a group type of "organization" and a group key of "5",
+        you would pass groups={"organization": "5"}.
+
+        `group_properties` take the format: { group_type_name: { group_properties } }
+
+        So, for example, if you have the group type "organization" and the group key "5", with the properties name, and employee count,
+        you'll send these as:
+
+        ```python
+            group_properties={"organization": {"name": "PostHog", "employees": 11}}
+        ```
+        """
+        return self._proxy(
+            "get_feature_flag",
+            key=key,
+            distinct_id=distinct_id,
+            groups=groups,
+            person_properties=person_properties,
+            group_properties=group_properties,
+            only_evaluate_locally=only_evaluate_locally,
+            send_feature_flag_events=send_feature_flag_events,
+        )
 
 
-def flush():
-    """Tell the client to flush."""
-    _proxy("flush")
+    def get_all_flags(
+        self, 
+        distinct_id,  # type: str,
+        groups={},  # type: dict
+        person_properties={},  # type: dict
+        group_properties={},  # type: dict
+        only_evaluate_locally=False,  # type: bool
+    ):
+        """
+        Get all flags for a given user.
+        Example:
+        ```python
+        flags = posthog.get_all_flags('distinct_id')
+        ```
+
+        flags are key-value pairs where the key is the flag key and the value is the flag variant, or True, or False.
+        """
+        return self._proxy(
+            "get_all_flags",
+            distinct_id=distinct_id,
+            groups=groups,
+            person_properties=person_properties,
+            group_properties=group_properties,
+            only_evaluate_locally=only_evaluate_locally,
+        )
 
 
-def join():
-    """Block program until the client clears the queue"""
-    _proxy("join")
+    def get_feature_flag_payload(
+        self,
+        key,
+        distinct_id,
+        match_value=None,
+        groups={},
+        person_properties={},
+        group_properties={},
+        only_evaluate_locally=False,
+        send_feature_flag_events=True,
+    ):
+        return self._proxy(
+            "get_feature_flag_payload",
+            key=key,
+            distinct_id=distinct_id,
+            match_value=match_value,
+            groups=groups,
+            person_properties=person_properties,
+            group_properties=group_properties,
+            only_evaluate_locally=only_evaluate_locally,
+            send_feature_flag_events=send_feature_flag_events,
+        )
 
 
-def shutdown():
-    """Flush all messages and cleanly shutdown the client"""
-    _proxy("flush")
-    _proxy("join")
+    def get_all_flags_and_payloads(
+        self,
+        distinct_id,
+        groups={},
+        person_properties={},
+        group_properties={},
+        only_evaluate_locally=False,
+    ):
+        return self._proxy(
+            "get_all_flags_and_payloads",
+            distinct_id=distinct_id,
+            groups=groups,
+            person_properties=person_properties,
+            group_properties=group_properties,
+            only_evaluate_locally=only_evaluate_locally,
+        )
 
 
-def _proxy(method, *args, **kwargs):
-    """Create an analytics client if one doesn't exist and send to it."""
-    global default_client
-    if disabled:
-        return None
-    if not default_client:
-        log.error(f"posthog must be initiated with a valid api key and host using posthog.init before calling {method}")
-    
-    fn = getattr(default_client, method)
-    return fn(*args, **kwargs)
+    def page(self, *args, **kwargs):
+        """Send a page call."""
+        self._proxy("page", *args, **kwargs)
 
-def init(api_key, host=_host, debug=_debug, on_error=_on_error, send=_send, sync_mode=_sync_mode, personal_api_key=_personal_api_key, project_api_key=_project_api_key, poll_interval=_poll_interval):
-    """Initialize the client."""
-    global default_client
-    default_client = Client(
-        api_key,
-        host=host,
-        debug=debug,
-        on_error=on_error,
-        send=send,
-        sync_mode=sync_mode,
-        personal_api_key=personal_api_key,
-        project_api_key=project_api_key,
-        poll_interval=poll_interval,
-    )
+
+    def screen(self, *args, **kwargs):
+        """Send a screen call."""
+        self._proxy("screen", *args, **kwargs)
+
+
+    def flush(self):
+        """Tell the client to flush."""
+        self._proxy("flush")
+
+
+    def join(self):
+        """Block program until the client clears the queue"""
+        self._proxy("join")
+
+
+    def shutdown(self):
+        """Flush all messages and cleanly shutdown the client"""
+        self._proxy("flush")
+        self._proxy("join")
+
+
+    def _proxy(self, method, *args, **kwargs):
+        """Create an analytics client if one doesn't exist and send to it."""
+        if self.disabled:
+            return None
+        
+        fn = getattr(self._client, method)
+        return fn(*args, **kwargs)

--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -1,5 +1,4 @@
 import datetime  # noqa: F401
-import logging
 from typing import Callable, Dict, Optional  # noqa: F401
 
 from posthog.client import Client
@@ -7,35 +6,414 @@ from posthog.version import VERSION
 
 __version__ = VERSION
 
+"""Settings."""
+api_key = None  # type: str
+host = None  # type: str
+on_error = None  # type: Callable
+debug = False  # type: bool
+send = True  # type: bool
+sync_mode = False  # type: bool
+disabled = False  # type: bool
+personal_api_key = None  # type: str
+project_api_key = None  # type: str
+poll_interval = 30  # type: int
+
 default_client = None
 
 
-class Posthog(object):
-    log = logging.getLogger("posthog")
+def capture(
+    distinct_id,  # type: str
+    event,  # type: str
+    properties=None,  # type: Optional[Dict]
+    context=None,  # type: Optional[Dict]
+    timestamp=None,  # type: Optional[datetime.datetime]
+    uuid=None,  # type: Optional[str]
+    groups=None,  # type: Optional[Dict]
+    send_feature_flags=False,
+):
+    # type: (...) -> None
+    """
+    Capture allows you to capture anything a user does within your system, which you can later use in PostHog to find patterns in usage, work out which features to improve or where people are giving up.
 
-    """Settings."""
-    disabled = False  # type: bool
-    _client: Client = None  # type: Client
+    A `capture` call requires
+    - `distinct id` which uniquely identifies your user
+    - `event name` to specify the event
+    - We recommend using [verb] [noun], like `movie played` or `movie updated` to easily identify what your events mean later on.
 
-    def __init__(
-        self,
-        api_key,
-        host="https://app.posthog.com",
-        on_error=None,
-        debug=False,
-        send=True,
-        sync_mode=False,
-        personal_api_key=None,
-        project_api_key=None,
-        poll_interval=30,
-        disabled=False,
-    ):
-        self.disabled = disabled
-        self._client = Client(
-            api_key=api_key,
+    Optionally you can submit
+    - `properties`, which can be a dict with any information you'd like to add
+    - `groups`, which is a dict of group type -> group key mappings
+
+    For example:
+    ```python
+    posthog.capture('distinct id', 'opened app')
+    posthog.capture('distinct id', 'movie played', {'movie_id': '123', 'category': 'romcom'})
+
+    posthog.capture('distinct id', 'purchase', groups={'company': 'id:5'})
+    ```
+    """
+    _proxy(
+        "capture",
+        distinct_id=distinct_id,
+        event=event,
+        properties=properties,
+        context=context,
+        timestamp=timestamp,
+        uuid=uuid,
+        groups=groups,
+        send_feature_flags=send_feature_flags,
+    )
+
+
+def identify(
+    distinct_id,  # type: str
+    properties=None,  # type: Optional[Dict]
+    context=None,  # type: Optional[Dict]
+    timestamp=None,  # type: Optional[datetime.datetime]
+    uuid=None,  # type: Optional[str]
+):
+    # type: (...) -> None
+    """
+    Identify lets you add metadata on your users so you can more easily identify who they are in PostHog, and even do things like segment users by these properties.
+
+    An `identify` call requires
+    - `distinct id` which uniquely identifies your user
+    - `properties` with a dict with any key: value pairs
+
+    For example:
+    ```python
+    posthog.identify('distinct id', {
+        'email': 'dwayne@gmail.com',
+        'name': 'Dwayne Johnson'
+    })
+    ```
+    """
+    _proxy(
+        "identify",
+        distinct_id=distinct_id,
+        properties=properties,
+        context=context,
+        timestamp=timestamp,
+        uuid=uuid,
+    )
+
+
+def set(
+    distinct_id,  # type: str,
+    properties=None,  # type: Optional[Dict]
+    context=None,  # type: Optional[Dict]
+    timestamp=None,  # type: Optional[datetime.datetime]
+    uuid=None,  # type: Optional[str]
+):
+    # type: (...) -> None
+    """
+    Set properties on a user record.
+    This will overwrite previous people property values, just like `identify`.
+
+     A `set` call requires
+     - `distinct id` which uniquely identifies your user
+     - `properties` with a dict with any key: value pairs
+
+     For example:
+     ```python
+     posthog.set('distinct id', {
+         'current_browser': 'Chrome',
+     })
+     ```
+    """
+    _proxy(
+        "set",
+        distinct_id=distinct_id,
+        properties=properties,
+        context=context,
+        timestamp=timestamp,
+        uuid=uuid,
+    )
+
+
+def set_once(
+    distinct_id,  # type: str,
+    properties=None,  # type: Optional[Dict]
+    context=None,  # type: Optional[Dict]
+    timestamp=None,  # type: Optional[datetime.datetime]
+    uuid=None,  # type: Optional[str]
+):
+    # type: (...) -> None
+    """
+    Set properties on a user record, only if they do not yet exist.
+    This will not overwrite previous people property values, unlike `identify`.
+
+     A `set_once` call requires
+     - `distinct id` which uniquely identifies your user
+     - `properties` with a dict with any key: value pairs
+
+     For example:
+     ```python
+     posthog.set_once('distinct id', {
+         'referred_by': 'friend',
+     })
+     ```
+    """
+    _proxy(
+        "set_once",
+        distinct_id=distinct_id,
+        properties=properties,
+        context=context,
+        timestamp=timestamp,
+        uuid=uuid,
+    )
+
+
+def group_identify(
+    group_type,  # type: str
+    group_key,  # type: str
+    properties=None,  # type: Optional[Dict]
+    context=None,  # type: Optional[Dict]
+    timestamp=None,  # type: Optional[datetime.datetime]
+    uuid=None,  # type: Optional[str]
+):
+    # type: (...) -> None
+    """
+    Set properties on a group
+
+     A `group_identify` call requires
+     - `group_type` type of your group
+     - `group_key` unique identifier of the group
+     - `properties` with a dict with any key: value pairs
+
+     For example:
+     ```python
+     posthog.group_identify('company', 5, {
+         'employees': 11,
+     })
+     ```
+    """
+    _proxy(
+        "group_identify",
+        group_type=group_type,
+        group_key=group_key,
+        properties=properties,
+        context=context,
+        timestamp=timestamp,
+        uuid=uuid,
+    )
+
+
+def alias(
+    previous_id,  # type: str,
+    distinct_id,  # type: str,
+    context=None,  # type: Optional[Dict]
+    timestamp=None,  # type: Optional[datetime.datetime]
+    uuid=None,  # type: Optional[str]
+):
+    # type: (...) -> None
+    """
+    To marry up whatever a user does before they sign up or log in with what they do after you need to make an alias call. This will allow you to answer questions like "Which marketing channels leads to users churning after a month?" or "What do users do on our website before signing up?"
+
+    In a purely back-end implementation, this means whenever an anonymous user does something, you'll want to send a session ID ([Django](https://stackoverflow.com/questions/526179/in-django-how-can-i-find-out-the-request-session-sessionid-and-use-it-as-a-vari), [Flask](https://stackoverflow.com/questions/15156132/flask-login-how-to-get-session-id)) with the capture call. Then, when that users signs up, you want to do an alias call with the session ID and the newly created user ID.
+
+    The same concept applies for when a user logs in.
+
+    An `alias` call requires
+    - `previous distinct id` the unique ID of the user before
+    - `distinct id` the current unique id
+
+    For example:
+    ```python
+    posthog.alias('anonymous session id', 'distinct id')
+    ```
+    """
+    _proxy(
+        "alias",
+        previous_id=previous_id,
+        distinct_id=distinct_id,
+        context=context,
+        timestamp=timestamp,
+        uuid=uuid,
+    )
+
+
+def feature_enabled(
+    key,  # type: str,
+    distinct_id,  # type: str,
+    groups={},  # type: dict
+    person_properties={},  # type: dict
+    group_properties={},  # type: dict
+    only_evaluate_locally=False,  # type: bool
+    send_feature_flag_events=True,  # type: bool
+):
+    # type: (...) -> bool
+    """
+    Use feature flags to enable or disable features for users.
+
+    For example:
+    ```python
+    if posthog.feature_enabled('beta feature', 'distinct id'):
+        # do something
+    if posthog.feature_enabled('groups feature', 'distinct id', groups={"organization": "5"}):
+        # do something
+    ```
+
+    You can call `posthog.load_feature_flags()` before to make sure you're not doing unexpected requests.
+    """
+    return _proxy(
+        "feature_enabled",
+        key=key,
+        distinct_id=distinct_id,
+        groups=groups,
+        person_properties=person_properties,
+        group_properties=group_properties,
+        only_evaluate_locally=only_evaluate_locally,
+        send_feature_flag_events=send_feature_flag_events,
+    )
+
+
+def get_feature_flag(
+    key,  # type: str,
+    distinct_id,  # type: str,
+    groups={},  # type: dict
+    person_properties={},  # type: dict
+    group_properties={},  # type: dict
+    only_evaluate_locally=False,  # type: bool
+    send_feature_flag_events=True,  # type: bool
+):
+    """
+    Get feature flag variant for users. Used with experiments.
+    Example:
+    ```python
+    if posthog.get_feature_flag('beta-feature', 'distinct_id') == 'test-variant':
+        # do test variant code
+    if posthog.get_feature_flag('beta-feature', 'distinct_id') == 'control':
+        # do control code
+    ```
+
+    `groups` are a mapping from group type to group key. So, if you have a group type of "organization" and a group key of "5",
+    you would pass groups={"organization": "5"}.
+
+    `group_properties` take the format: { group_type_name: { group_properties } }
+
+    So, for example, if you have the group type "organization" and the group key "5", with the properties name, and employee count,
+    you'll send these as:
+
+    ```python
+        group_properties={"organization": {"name": "PostHog", "employees": 11}}
+    ```
+    """
+    return _proxy(
+        "get_feature_flag",
+        key=key,
+        distinct_id=distinct_id,
+        groups=groups,
+        person_properties=person_properties,
+        group_properties=group_properties,
+        only_evaluate_locally=only_evaluate_locally,
+        send_feature_flag_events=send_feature_flag_events,
+    )
+
+
+def get_all_flags(
+    distinct_id,  # type: str,
+    groups={},  # type: dict
+    person_properties={},  # type: dict
+    group_properties={},  # type: dict
+    only_evaluate_locally=False,  # type: bool
+):
+    """
+    Get all flags for a given user.
+    Example:
+    ```python
+    flags = posthog.get_all_flags('distinct_id')
+    ```
+
+    flags are key-value pairs where the key is the flag key and the value is the flag variant, or True, or False.
+    """
+    return _proxy(
+        "get_all_flags",
+        distinct_id=distinct_id,
+        groups=groups,
+        person_properties=person_properties,
+        group_properties=group_properties,
+        only_evaluate_locally=only_evaluate_locally,
+    )
+
+
+def get_feature_flag_payload(
+    key,
+    distinct_id,
+    match_value=None,
+    groups={},
+    person_properties={},
+    group_properties={},
+    only_evaluate_locally=False,
+    send_feature_flag_events=True,
+):
+    return _proxy(
+        "get_feature_flag_payload",
+        key=key,
+        distinct_id=distinct_id,
+        match_value=match_value,
+        groups=groups,
+        person_properties=person_properties,
+        group_properties=group_properties,
+        only_evaluate_locally=only_evaluate_locally,
+        send_feature_flag_events=send_feature_flag_events,
+    )
+
+
+def get_all_flags_and_payloads(
+    distinct_id,
+    groups={},
+    person_properties={},
+    group_properties={},
+    only_evaluate_locally=False,
+):
+    return _proxy(
+        "get_all_flags_and_payloads",
+        distinct_id=distinct_id,
+        groups=groups,
+        person_properties=person_properties,
+        group_properties=group_properties,
+        only_evaluate_locally=only_evaluate_locally,
+    )
+
+
+def page(*args, **kwargs):
+    """Send a page call."""
+    _proxy("page", *args, **kwargs)
+
+
+def screen(*args, **kwargs):
+    """Send a screen call."""
+    _proxy("screen", *args, **kwargs)
+
+
+def flush():
+    """Tell the client to flush."""
+    _proxy("flush")
+
+
+def join():
+    """Block program until the client clears the queue"""
+    _proxy("join")
+
+
+def shutdown():
+    """Flush all messages and cleanly shutdown the client"""
+    _proxy("flush")
+    _proxy("join")
+
+
+def _proxy(method, *args, **kwargs):
+    """Create an analytics client if one doesn't exist and send to it."""
+    global default_client
+    if disabled:
+        return None
+    if not default_client:
+        default_client = Client(
+            api_key,
             host=host,
-            on_error=on_error,
             debug=debug,
+            on_error=on_error,
             send=send,
             sync_mode=sync_mode,
             personal_api_key=personal_api_key,
@@ -43,387 +421,8 @@ class Posthog(object):
             poll_interval=poll_interval,
         )
 
-    def capture(
-        self,
-        distinct_id,  # type: str
-        event,  # type: str
-        properties=None,  # type: Optional[Dict]
-        context=None,  # type: Optional[Dict]
-        timestamp=None,  # type: Optional[datetime.datetime]
-        uuid=None,  # type: Optional[str]
-        groups=None,  # type: Optional[Dict]
-        send_feature_flags=False,
-    ):
-        # type: (...) -> None
-        """
-        Capture allows you to capture anything a user does within your system, which you can later use in PostHog to find patterns in usage, work out which features to improve or where people are giving up.
+    fn = getattr(default_client, method)
+    return fn(*args, **kwargs)
 
-        A `capture` call requires
-        - `distinct id` which uniquely identifies your user
-        - `event name` to specify the event
-        - We recommend using [verb] [noun], like `movie played` or `movie updated` to easily identify what your events mean later on.
-
-        Optionally you can submit
-        - `properties`, which can be a dict with any information you'd like to add
-        - `groups`, which is a dict of group type -> group key mappings
-
-        For example:
-        ```python
-        posthog.capture('distinct id', 'opened app')
-        posthog.capture('distinct id', 'movie played', {'movie_id': '123', 'category': 'romcom'})
-
-        posthog.capture('distinct id', 'purchase', groups={'company': 'id:5'})
-        ```
-        """
-        self._proxy(
-            "capture",
-            distinct_id=distinct_id,
-            event=event,
-            properties=properties,
-            context=context,
-            timestamp=timestamp,
-            uuid=uuid,
-            groups=groups,
-            send_feature_flags=send_feature_flags,
-        )
-
-    def identify(
-        self,
-        distinct_id,  # type: str
-        properties=None,  # type: Optional[Dict]
-        context=None,  # type: Optional[Dict]
-        timestamp=None,  # type: Optional[datetime.datetime]
-        uuid=None,  # type: Optional[str]
-    ):
-        # type: (...) -> None
-        """
-        Identify lets you add metadata on your users so you can more easily identify who they are in PostHog, and even do things like segment users by these properties.
-
-        An `identify` call requires
-        - `distinct id` which uniquely identifies your user
-        - `properties` with a dict with any key: value pairs
-
-        For example:
-        ```python
-        posthog.identify('distinct id', {
-            'email': 'dwayne@gmail.com',
-            'name': 'Dwayne Johnson'
-        })
-        ```
-        """
-        self._proxy(
-            "identify",
-            distinct_id=distinct_id,
-            properties=properties,
-            context=context,
-            timestamp=timestamp,
-            uuid=uuid,
-        )
-
-    def set(
-        self,
-        distinct_id,  # type: str
-        properties=None,  # type: Optional[Dict]
-        context=None,  # type: Optional[Dict]
-        timestamp=None,  # type: Optional[datetime.datetime]
-        uuid=None,  # type: Optional[str]
-    ):
-        # type: (...) -> None
-        """
-        Set properties on a user record.
-        This will overwrite previous people property values, just like `identify`.
-
-        A `set` call requires
-        - `distinct id` which uniquely identifies your user
-        - `properties` with a dict with any key: value pairs
-
-        For example:
-        ```python
-        posthog.set('distinct id', {
-            'current_browser': 'Chrome',
-        })
-        ```
-        """
-        self._proxy(
-            "set",
-            distinct_id=distinct_id,
-            properties=properties,
-            context=context,
-            timestamp=timestamp,
-            uuid=uuid,
-        )
-
-    def set_once(
-        self,
-        distinct_id,  # type: str
-        properties=None,  # type: Optional[Dict]
-        context=None,  # type: Optional[Dict]
-        timestamp=None,  # type: Optional[datetime.datetime]
-        uuid=None,  # type: Optional[str]
-    ):
-        # type: (...) -> None
-        """
-        Set properties on a user record, only if they do not yet exist.
-        This will not overwrite previous people property values, unlike `identify`.
-
-        A `set_once` call requires
-        - `distinct id` which uniquely identifies your user
-        - `properties` with a dict with any key: value pairs
-
-        For example:
-        ```python
-        posthog.set_once('distinct id', {
-            'referred_by': 'friend',
-        })
-        ```
-        """
-        self._proxy(
-            "set_once",
-            distinct_id=distinct_id,
-            properties=properties,
-            context=context,
-            timestamp=timestamp,
-            uuid=uuid,
-        )
-
-    def group_identify(
-        self,
-        group_type,  # type: str
-        group_key,  # type: str
-        properties=None,  # type: Optional[Dict]
-        context=None,  # type: Optional[Dict]
-        timestamp=None,  # type: Optional[datetime.datetime]
-        uuid=None,  # type: Optional[str]
-    ):
-        # type: (...) -> None
-        """
-        Set properties on a group
-
-        A `group_identify` call requires
-        - `group_type` type of your group
-        - `group_key` unique identifier of the group
-        - `properties` with a dict with any key: value pairs
-
-        For example:
-        ```python
-        posthog.group_identify('company', 5, {
-            'employees': 11,
-        })
-        ```
-        """
-        self._proxy(
-            "group_identify",
-            group_type=group_type,
-            group_key=group_key,
-            properties=properties,
-            context=context,
-            timestamp=timestamp,
-            uuid=uuid,
-        )
-
-    def alias(
-        self,
-        previous_id,  # type: str
-        distinct_id,  # type: str
-        context=None,  # type: Optional[Dict]
-        timestamp=None,  # type: Optional[datetime.datetime]
-        uuid=None,  # type: Optional[str]
-    ):
-        # type: (...) -> None
-        """
-        To marry up whatever a user does before they sign up or log in with what they do after you need to make an alias call. This will allow you to answer questions like "Which marketing channels leads to users churning after a month?" or "What do users do on our website before signing up?"
-
-        In a purely back-end implementation, this means whenever an anonymous user does something, you'll want to send a session ID ([Django](https://stackoverflow.com/questions/526179/in-django-how-can-i-find-out-the-request-session-sessionid-and-use-it-as-a-vari), [Flask](https://stackoverflow.com/questions/15156132/flask-login-how-to-get-session-id)) with the capture call. Then, when that users signs up, you want to do an alias call with the session ID and the newly created user ID.
-
-        The same concept applies for when a user logs in.
-
-        An `alias` call requires
-        - `previous distinct id` the unique ID of the user before
-        - `distinct id` the current unique id
-
-        For example:
-        ```python
-        posthog.alias('anonymous session id', 'distinct id')
-        ```
-        """
-        self._proxy(
-            "alias",
-            previous_id=previous_id,
-            distinct_id=distinct_id,
-            context=context,
-            timestamp=timestamp,
-            uuid=uuid,
-        )
-
-    def feature_enabled(
-        self,
-        key,  # type: str
-        distinct_id,  # type: str
-        groups={},  # type: dict
-        person_properties={},  # type: dict
-        group_properties={},  # type: dict
-        only_evaluate_locally=False,  # type: bool
-        send_feature_flag_events=True,  # type: bool
-    ):
-        # type: (...) -> bool
-        """
-        Use feature flags to enable or disable features for users.
-
-        For example:
-        ```python
-        if posthog.feature_enabled('beta feature', 'distinct id'):
-            # do something
-        if posthog.feature_enabled('groups feature', 'distinct id', groups={"organization": "5"}):
-            # do something
-        ```
-
-        You can call `posthog.load_feature_flags()` before to make sure you're not doing unexpected requests.
-        """
-        return self._proxy(
-            "feature_enabled",
-            key=key,
-            distinct_id=distinct_id,
-            groups=groups,
-            person_properties=person_properties,
-            group_properties=group_properties,
-            only_evaluate_locally=only_evaluate_locally,
-            send_feature_flag_events=send_feature_flag_events,
-        )
-
-    def get_feature_flag(
-        self,
-        key,  # type: str
-        distinct_id,  # type: str
-        groups={},  # type: dict
-        person_properties={},  # type: dict
-        group_properties={},  # type: dict
-        only_evaluate_locally=False,  # type: bool
-        send_feature_flag_events=True,  # type: bool
-    ):
-        """
-        Get feature flag variant for users. Used with experiments.
-        Example:
-        ```python
-        if posthog.get_feature_flag('beta-feature', 'distinct_id') == 'test-variant':
-            # do test variant code
-        if posthog.get_feature_flag('beta-feature', 'distinct_id') == 'control':
-            # do control code
-        ```
-
-        `groups` are a mapping from group type to group key. So, if you have a group type of "organization" and a group key of "5",
-        you would pass groups={"organization": "5"}.
-
-        `group_properties` take the format: { group_type_name: { group_properties } }
-
-        So, for example, if you have the group type "organization" and the group key "5", with the properties name, and employee count,
-        you'll send these as:
-
-        ```python
-            group_properties={"organization": {"name": "PostHog", "employees": 11}}
-        ```
-        """
-        return self._proxy(
-            "get_feature_flag",
-            key=key,
-            distinct_id=distinct_id,
-            groups=groups,
-            person_properties=person_properties,
-            group_properties=group_properties,
-            only_evaluate_locally=only_evaluate_locally,
-            send_feature_flag_events=send_feature_flag_events,
-        )
-
-    def get_all_flags(
-        self,
-        distinct_id,  # type: str
-        groups={},  # type: dict
-        person_properties={},  # type: dict
-        group_properties={},  # type: dict
-        only_evaluate_locally=False,  # type: bool
-    ):
-        """
-        Get all flags for a given user.
-        Example:
-        ```python
-        flags = posthog.get_all_flags('distinct_id')
-        ```
-
-        flags are key-value pairs where the key is the flag key and the value is the flag variant, or True, or False.
-        """
-        return self._proxy(
-            "get_all_flags",
-            distinct_id=distinct_id,
-            groups=groups,
-            person_properties=person_properties,
-            group_properties=group_properties,
-            only_evaluate_locally=only_evaluate_locally,
-        )
-
-    def get_feature_flag_payload(
-        self,
-        key,
-        distinct_id,
-        match_value=None,
-        groups={},
-        person_properties={},
-        group_properties={},
-        only_evaluate_locally=False,
-        send_feature_flag_events=True,
-    ):
-        return self._proxy(
-            "get_feature_flag_payload",
-            key=key,
-            distinct_id=distinct_id,
-            match_value=match_value,
-            groups=groups,
-            person_properties=person_properties,
-            group_properties=group_properties,
-            only_evaluate_locally=only_evaluate_locally,
-            send_feature_flag_events=send_feature_flag_events,
-        )
-
-    def get_all_flags_and_payloads(
-        self,
-        distinct_id,
-        groups={},
-        person_properties={},
-        group_properties={},
-        only_evaluate_locally=False,
-    ):
-        return self._proxy(
-            "get_all_flags_and_payloads",
-            distinct_id=distinct_id,
-            groups=groups,
-            person_properties=person_properties,
-            group_properties=group_properties,
-            only_evaluate_locally=only_evaluate_locally,
-        )
-
-    def page(self, *args, **kwargs):
-        """Send a page call."""
-        self._proxy("page", *args, **kwargs)
-
-    def screen(self, *args, **kwargs):
-        """Send a screen call."""
-        self._proxy("screen", *args, **kwargs)
-
-    def flush(self):
-        """Tell the client to flush."""
-        self._proxy("flush")
-
-    def join(self):
-        """Block program until the client clears the queue"""
-        self._proxy("join")
-
-    def shutdown(self):
-        """Flush all messages and cleanly shutdown the client"""
-        self._proxy("flush")
-        self._proxy("join")
-
-    def _proxy(self, method, *args, **kwargs):
-        """Create an analytics client if one doesn't exist and send to it."""
-        if self.disabled:
-            return None
-
-        fn = getattr(self._client, method)
-        return fn(*args, **kwargs)
+class Posthog(Client):
+    pass

--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -99,7 +99,7 @@ def identify(
 
 
 def set(
-    distinct_id,  # type: str,
+    distinct_id,  # type: str
     properties=None,  # type: Optional[Dict]
     context=None,  # type: Optional[Dict]
     timestamp=None,  # type: Optional[datetime.datetime]
@@ -132,7 +132,7 @@ def set(
 
 
 def set_once(
-    distinct_id,  # type: str,
+    distinct_id,  # type: str
     properties=None,  # type: Optional[Dict]
     context=None,  # type: Optional[Dict]
     timestamp=None,  # type: Optional[datetime.datetime]
@@ -200,8 +200,8 @@ def group_identify(
 
 
 def alias(
-    previous_id,  # type: str,
-    distinct_id,  # type: str,
+    previous_id,  # type: str
+    distinct_id,  # type: str
     context=None,  # type: Optional[Dict]
     timestamp=None,  # type: Optional[datetime.datetime]
     uuid=None,  # type: Optional[str]
@@ -234,8 +234,8 @@ def alias(
 
 
 def feature_enabled(
-    key,  # type: str,
-    distinct_id,  # type: str,
+    key,  # type: str
+    distinct_id,  # type: str
     groups={},  # type: dict
     person_properties={},  # type: dict
     group_properties={},  # type: dict
@@ -269,8 +269,8 @@ def feature_enabled(
 
 
 def get_feature_flag(
-    key,  # type: str,
-    distinct_id,  # type: str,
+    key,  # type: str
+    distinct_id,  # type: str
     groups={},  # type: dict
     person_properties={},  # type: dict
     group_properties={},  # type: dict
@@ -312,7 +312,7 @@ def get_feature_flag(
 
 
 def get_all_flags(
-    distinct_id,  # type: str,
+    distinct_id,  # type: str
     groups={},  # type: dict
     person_properties={},  # type: dict
     group_properties={},  # type: dict
@@ -406,8 +406,6 @@ def shutdown():
 def _proxy(method, *args, **kwargs):
     """Create an analytics client if one doesn't exist and send to it."""
     global default_client
-    if disabled:
-        return None
     if not default_client:
         default_client = Client(
             api_key,
@@ -419,6 +417,7 @@ def _proxy(method, *args, **kwargs):
             personal_api_key=personal_api_key,
             project_api_key=project_api_key,
             poll_interval=poll_interval,
+            disabled=disabled,
         )
 
     fn = getattr(default_client, method)

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -47,6 +47,7 @@ class Client(object):
         poll_interval=30,
         personal_api_key=None,
         project_api_key=None,
+        disabled=False
     ):
         self.queue = queue.Queue(max_queue_size)
 
@@ -69,6 +70,7 @@ class Client(object):
         self.poll_interval = poll_interval
         self.poller = None
         self.distinct_ids_feature_flags_reported = SizeLimitedDict(MAX_DICT_SIZE, set)
+        self.disabled = disabled
 
         # personal_api_key: This should be a generated Personal API Key, private
         self.personal_api_key = personal_api_key
@@ -299,6 +301,10 @@ class Client(object):
 
     def _enqueue(self, msg):
         """Push a new `msg` onto the queue, return `(success, msg)`"""
+
+        if self.disabled:
+            return False, "disabled"
+        
         timestamp = msg["timestamp"]
         if timestamp is None:
             timestamp = datetime.utcnow().replace(tzinfo=tzutc())

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -47,7 +47,7 @@ class Client(object):
         poll_interval=30,
         personal_api_key=None,
         project_api_key=None,
-        disabled=False
+        disabled=False,
     ):
         self.queue = queue.Queue(max_queue_size)
 
@@ -304,7 +304,7 @@ class Client(object):
 
         if self.disabled:
             return False, "disabled"
-        
+
         timestamp = msg["timestamp"]
         if timestamp is None:
             timestamp = datetime.utcnow().replace(tzinfo=tzutc())

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -468,6 +468,15 @@ class TestClient(unittest.TestCase):
         for consumer in client.consumers:
             self.assertEqual(consumer.timeout, 15)
 
+    def test_disabled(self):
+        client = Client(FAKE_TEST_API_KEY, on_error=self.set_fail, disabled=True)
+        success, msg = client.capture("distinct_id", "python test event")
+        client.flush()
+        self.assertFalse(success)
+        self.assertFalse(self.failed)
+
+        self.assertEqual(msg, "disabled")
+
     @mock.patch("posthog.client.Poller")
     @mock.patch("posthog.client.get")
     def test_call_identify_fails(self, patch_get, patch_poll):

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -477,6 +477,23 @@ class TestClient(unittest.TestCase):
 
         self.assertEqual(msg, "disabled")
 
+    def test_enabled_to_disabled(self):
+        client = Client(FAKE_TEST_API_KEY, on_error=self.set_fail, disabled=False)
+        success, msg = client.capture("distinct_id", "python test event")
+        client.flush()
+
+        self.assertTrue(success)
+        self.assertFalse(self.failed)
+        self.assertEqual(msg["event"], "python test event")
+
+        client.disabled = True
+        success, msg = client.capture("distinct_id", "python test event")
+        client.flush()
+        self.assertFalse(success)
+        self.assertFalse(self.failed)
+
+        self.assertEqual(msg, "disabled")
+
     @mock.patch("posthog.client.Poller")
     @mock.patch("posthog.client.get")
     def test_call_identify_fails(self, patch_get, patch_poll):

--- a/posthog/test/test_module.py
+++ b/posthog/test/test_module.py
@@ -1,40 +1,42 @@
 import unittest
 
-import posthog
+from posthog import Posthog
 
 
 class TestModule(unittest.TestCase):
+
+    posthog = None
+
     def failed(self):
         self.failed = True
 
     def setUp(self):
         self.failed = False
-        posthog.api_key = "testsecret"
-        posthog.on_error = self.failed
+        self.posthog = Posthog("testsecret", host="http://localhost:8000", on_error=self.failed)
 
     def test_no_api_key(self):
-        posthog.api_key = None
-        self.assertRaises(Exception, posthog.capture)
+        self.posthog.api_key = None
+        self.assertRaises(Exception, self.posthog.capture)
 
     def test_no_host(self):
-        posthog.host = None
-        self.assertRaises(Exception, posthog.capture)
+        self.posthog.host = None
+        self.assertRaises(Exception, self.posthog.capture)
 
     def test_track(self):
-        posthog.capture("distinct_id", "python module event")
-        posthog.flush()
+        self.posthog.capture("distinct_id", "python module event")
+        self.posthog.flush()
 
     def test_identify(self):
-        posthog.identify("distinct_id", {"email": "user@email.com"})
-        posthog.flush()
+        self.posthog.identify("distinct_id", {"email": "user@email.com"})
+        self.posthog.flush()
 
     def test_alias(self):
-        posthog.alias("previousId", "distinct_id")
-        posthog.flush()
+        self.posthog.alias("previousId", "distinct_id")
+        self.posthog.flush()
 
     def test_page(self):
-        posthog.page("distinct_id", "https://posthog.com/contact")
-        posthog.flush()
+        self.posthog.page("distinct_id", "https://posthog.com/contact")
+        self.posthog.flush()
 
     def test_flush(self):
-        posthog.flush()
+        self.posthog.flush()

--- a/posthog/test/test_module.py
+++ b/posthog/test/test_module.py
@@ -4,7 +4,6 @@ from posthog import Posthog
 
 
 class TestModule(unittest.TestCase):
-
     posthog = None
 
     def failed(self):


### PR DESCRIPTION
Using global client is setting up for failure if there are overlapping posthogs in a dependency and the project using the depency

Changes:
- wrap the function headers in __init__.py to be an object that can be instantiated

Note: This is a major version change as it breaks the current pattern