### PR TITLE
Disable geoip for capture and decide calls by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Breaking change:
 
-All events by default now send the `$geoip_disable` property to disable geoip lookup in app. This is because usually we don't
+All events by default now send the `$disable_geoip` property to disable geoip lookup in app. This is because usually we don't
 want to update person properties to take the server's location.
 
 The same now happens for feature flag requests, where we discard the IP address of the server for matching on geoip properties like city, country, continent.
@@ -10,10 +10,10 @@ The same now happens for feature flag requests, where we discard the IP address 
 To restore previous behaviour, you can set the default to False like so:
 
 ```python
-posthog.geoip_disable = False
+posthog.disable_geoip = False
 
 # // and if using client instantiation:
-posthog = Posthog('api_key', geoip_disable=False)
+posthog = Posthog('api_key', disable_geoip=False)
 
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Breaking change:
 
-All events by default now send the `$disable_geoip` property to disable geoip lookup in app. This is because usually we don't
+All events by default now send the `$geoip_disable` property to disable geoip lookup in app. This is because usually we don't
 want to update person properties to take the server's location.
 
 The same now happens for feature flag requests, where we discard the IP address of the server for matching on geoip properties like city, country, continent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## 3.0.0 - 2023-04-14
+
+Breaking change:
+
+All events by default now send the `$geoip_disable` property to disable geoip lookup in app. This is because usually we don't
+want to update person properties to take the server's location.
+
+The same now happens for feature flag requests, where we discard the IP address of the server for matching on geoip properties like city, country, continent.
+
+To restore previous behaviour, you can set the default to False like so:
+
+```python
+posthog.geoip_disable = False
+
+# // and if using client instantiation:
+posthog = Posthog('api_key', geoip_disable=False)
+
+```
+
 ## 2.5.0 - 2023-04-10
 
 1. Add option for instantiating separate client object

--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -17,6 +17,7 @@ disabled = False  # type: bool
 personal_api_key = None  # type: str
 project_api_key = None  # type: str
 poll_interval = 30  # type: int
+geoip_disable = True # type: bool
 
 default_client = None
 
@@ -30,6 +31,7 @@ def capture(
     uuid=None,  # type: Optional[str]
     groups=None,  # type: Optional[Dict]
     send_feature_flags=False,
+    geoip_disable=None, # type: Optional[bool]
 ):
     # type: (...) -> None
     """
@@ -62,6 +64,7 @@ def capture(
         uuid=uuid,
         groups=groups,
         send_feature_flags=send_feature_flags,
+        geoip_disable=geoip_disable,
     )
 
 
@@ -71,6 +74,7 @@ def identify(
     context=None,  # type: Optional[Dict]
     timestamp=None,  # type: Optional[datetime.datetime]
     uuid=None,  # type: Optional[str]
+    geoip_disable=None, # type: Optional[bool]
 ):
     # type: (...) -> None
     """
@@ -95,6 +99,7 @@ def identify(
         context=context,
         timestamp=timestamp,
         uuid=uuid,
+        geoip_disable=geoip_disable,
     )
 
 
@@ -104,6 +109,7 @@ def set(
     context=None,  # type: Optional[Dict]
     timestamp=None,  # type: Optional[datetime.datetime]
     uuid=None,  # type: Optional[str]
+    geoip_disable=None, # type: Optional[bool]
 ):
     # type: (...) -> None
     """
@@ -128,6 +134,7 @@ def set(
         context=context,
         timestamp=timestamp,
         uuid=uuid,
+        geoip_disable=geoip_disable,
     )
 
 
@@ -137,6 +144,7 @@ def set_once(
     context=None,  # type: Optional[Dict]
     timestamp=None,  # type: Optional[datetime.datetime]
     uuid=None,  # type: Optional[str]
+    geoip_disable=None, # type: Optional[bool]
 ):
     # type: (...) -> None
     """
@@ -161,6 +169,7 @@ def set_once(
         context=context,
         timestamp=timestamp,
         uuid=uuid,
+        geoip_disable=geoip_disable,
     )
 
 
@@ -171,6 +180,7 @@ def group_identify(
     context=None,  # type: Optional[Dict]
     timestamp=None,  # type: Optional[datetime.datetime]
     uuid=None,  # type: Optional[str]
+    geoip_disable=None, # type: Optional[bool]
 ):
     # type: (...) -> None
     """
@@ -196,6 +206,7 @@ def group_identify(
         context=context,
         timestamp=timestamp,
         uuid=uuid,
+        geoip_disable=geoip_disable,
     )
 
 
@@ -205,6 +216,7 @@ def alias(
     context=None,  # type: Optional[Dict]
     timestamp=None,  # type: Optional[datetime.datetime]
     uuid=None,  # type: Optional[str]
+    geoip_disable=None, # type: Optional[bool]
 ):
     # type: (...) -> None
     """
@@ -230,6 +242,7 @@ def alias(
         context=context,
         timestamp=timestamp,
         uuid=uuid,
+        geoip_disable=geoip_disable,
     )
 
 
@@ -241,6 +254,7 @@ def feature_enabled(
     group_properties={},  # type: dict
     only_evaluate_locally=False,  # type: bool
     send_feature_flag_events=True,  # type: bool
+    geoip_disable=None, # type: Optional[bool]
 ):
     # type: (...) -> bool
     """
@@ -265,6 +279,7 @@ def feature_enabled(
         group_properties=group_properties,
         only_evaluate_locally=only_evaluate_locally,
         send_feature_flag_events=send_feature_flag_events,
+        geoip_disable=geoip_disable,
     )
 
 
@@ -276,6 +291,7 @@ def get_feature_flag(
     group_properties={},  # type: dict
     only_evaluate_locally=False,  # type: bool
     send_feature_flag_events=True,  # type: bool
+    geoip_disable=None, # type: Optional[bool]
 ):
     """
     Get feature flag variant for users. Used with experiments.
@@ -308,6 +324,7 @@ def get_feature_flag(
         group_properties=group_properties,
         only_evaluate_locally=only_evaluate_locally,
         send_feature_flag_events=send_feature_flag_events,
+        geoip_disable=geoip_disable,
     )
 
 
@@ -317,6 +334,7 @@ def get_all_flags(
     person_properties={},  # type: dict
     group_properties={},  # type: dict
     only_evaluate_locally=False,  # type: bool
+    geoip_disable=None, # type: Optional[bool]
 ):
     """
     Get all flags for a given user.
@@ -334,6 +352,7 @@ def get_all_flags(
         person_properties=person_properties,
         group_properties=group_properties,
         only_evaluate_locally=only_evaluate_locally,
+        geoip_disable=geoip_disable,
     )
 
 
@@ -346,6 +365,7 @@ def get_feature_flag_payload(
     group_properties={},
     only_evaluate_locally=False,
     send_feature_flag_events=True,
+    geoip_disable=None, # type: Optional[bool]
 ):
     return _proxy(
         "get_feature_flag_payload",
@@ -357,6 +377,7 @@ def get_feature_flag_payload(
         group_properties=group_properties,
         only_evaluate_locally=only_evaluate_locally,
         send_feature_flag_events=send_feature_flag_events,
+        geoip_disable=geoip_disable,
     )
 
 
@@ -366,6 +387,7 @@ def get_all_flags_and_payloads(
     person_properties={},
     group_properties={},
     only_evaluate_locally=False,
+    geoip_disable=None, # type: Optional[bool]
 ):
     return _proxy(
         "get_all_flags_and_payloads",
@@ -374,6 +396,7 @@ def get_all_flags_and_payloads(
         person_properties=person_properties,
         group_properties=group_properties,
         only_evaluate_locally=only_evaluate_locally,
+        geoip_disable=geoip_disable,
     )
 
 
@@ -418,6 +441,7 @@ def _proxy(method, *args, **kwargs):
             project_api_key=project_api_key,
             poll_interval=poll_interval,
             disabled=disabled,
+            geoip_disable=geoip_disable,
         )
 
     # always set incase user changes it

--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -17,7 +17,7 @@ disabled = False  # type: bool
 personal_api_key = None  # type: str
 project_api_key = None  # type: str
 poll_interval = 30  # type: int
-geoip_disable = True # type: bool
+geoip_disable = True  # type: bool
 
 default_client = None
 
@@ -31,7 +31,7 @@ def capture(
     uuid=None,  # type: Optional[str]
     groups=None,  # type: Optional[Dict]
     send_feature_flags=False,
-    geoip_disable=None, # type: Optional[bool]
+    geoip_disable=None,  # type: Optional[bool]
 ):
     # type: (...) -> None
     """
@@ -74,7 +74,7 @@ def identify(
     context=None,  # type: Optional[Dict]
     timestamp=None,  # type: Optional[datetime.datetime]
     uuid=None,  # type: Optional[str]
-    geoip_disable=None, # type: Optional[bool]
+    geoip_disable=None,  # type: Optional[bool]
 ):
     # type: (...) -> None
     """
@@ -109,7 +109,7 @@ def set(
     context=None,  # type: Optional[Dict]
     timestamp=None,  # type: Optional[datetime.datetime]
     uuid=None,  # type: Optional[str]
-    geoip_disable=None, # type: Optional[bool]
+    geoip_disable=None,  # type: Optional[bool]
 ):
     # type: (...) -> None
     """
@@ -144,7 +144,7 @@ def set_once(
     context=None,  # type: Optional[Dict]
     timestamp=None,  # type: Optional[datetime.datetime]
     uuid=None,  # type: Optional[str]
-    geoip_disable=None, # type: Optional[bool]
+    geoip_disable=None,  # type: Optional[bool]
 ):
     # type: (...) -> None
     """
@@ -180,7 +180,7 @@ def group_identify(
     context=None,  # type: Optional[Dict]
     timestamp=None,  # type: Optional[datetime.datetime]
     uuid=None,  # type: Optional[str]
-    geoip_disable=None, # type: Optional[bool]
+    geoip_disable=None,  # type: Optional[bool]
 ):
     # type: (...) -> None
     """
@@ -216,7 +216,7 @@ def alias(
     context=None,  # type: Optional[Dict]
     timestamp=None,  # type: Optional[datetime.datetime]
     uuid=None,  # type: Optional[str]
-    geoip_disable=None, # type: Optional[bool]
+    geoip_disable=None,  # type: Optional[bool]
 ):
     # type: (...) -> None
     """
@@ -254,7 +254,7 @@ def feature_enabled(
     group_properties={},  # type: dict
     only_evaluate_locally=False,  # type: bool
     send_feature_flag_events=True,  # type: bool
-    geoip_disable=None, # type: Optional[bool]
+    geoip_disable=None,  # type: Optional[bool]
 ):
     # type: (...) -> bool
     """
@@ -291,7 +291,7 @@ def get_feature_flag(
     group_properties={},  # type: dict
     only_evaluate_locally=False,  # type: bool
     send_feature_flag_events=True,  # type: bool
-    geoip_disable=None, # type: Optional[bool]
+    geoip_disable=None,  # type: Optional[bool]
 ):
     """
     Get feature flag variant for users. Used with experiments.
@@ -334,7 +334,7 @@ def get_all_flags(
     person_properties={},  # type: dict
     group_properties={},  # type: dict
     only_evaluate_locally=False,  # type: bool
-    geoip_disable=None, # type: Optional[bool]
+    geoip_disable=None,  # type: Optional[bool]
 ):
     """
     Get all flags for a given user.
@@ -365,7 +365,7 @@ def get_feature_flag_payload(
     group_properties={},
     only_evaluate_locally=False,
     send_feature_flag_events=True,
-    geoip_disable=None, # type: Optional[bool]
+    geoip_disable=None,  # type: Optional[bool]
 ):
     return _proxy(
         "get_feature_flag_payload",
@@ -387,7 +387,7 @@ def get_all_flags_and_payloads(
     person_properties={},
     group_properties={},
     only_evaluate_locally=False,
-    geoip_disable=None, # type: Optional[bool]
+    geoip_disable=None,  # type: Optional[bool]
 ):
     return _proxy(
         "get_all_flags_and_payloads",

--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -17,7 +17,7 @@ disabled = False  # type: bool
 personal_api_key = None  # type: str
 project_api_key = None  # type: str
 poll_interval = 30  # type: int
-geoip_disable = True  # type: bool
+disable_geoip = True  # type: bool
 
 default_client = None
 
@@ -31,7 +31,7 @@ def capture(
     uuid=None,  # type: Optional[str]
     groups=None,  # type: Optional[Dict]
     send_feature_flags=False,
-    geoip_disable=None,  # type: Optional[bool]
+    disable_geoip=None,  # type: Optional[bool]
 ):
     # type: (...) -> None
     """
@@ -64,7 +64,7 @@ def capture(
         uuid=uuid,
         groups=groups,
         send_feature_flags=send_feature_flags,
-        geoip_disable=geoip_disable,
+        disable_geoip=disable_geoip,
     )
 
 
@@ -74,7 +74,7 @@ def identify(
     context=None,  # type: Optional[Dict]
     timestamp=None,  # type: Optional[datetime.datetime]
     uuid=None,  # type: Optional[str]
-    geoip_disable=None,  # type: Optional[bool]
+    disable_geoip=None,  # type: Optional[bool]
 ):
     # type: (...) -> None
     """
@@ -99,7 +99,7 @@ def identify(
         context=context,
         timestamp=timestamp,
         uuid=uuid,
-        geoip_disable=geoip_disable,
+        disable_geoip=disable_geoip,
     )
 
 
@@ -109,7 +109,7 @@ def set(
     context=None,  # type: Optional[Dict]
     timestamp=None,  # type: Optional[datetime.datetime]
     uuid=None,  # type: Optional[str]
-    geoip_disable=None,  # type: Optional[bool]
+    disable_geoip=None,  # type: Optional[bool]
 ):
     # type: (...) -> None
     """
@@ -134,7 +134,7 @@ def set(
         context=context,
         timestamp=timestamp,
         uuid=uuid,
-        geoip_disable=geoip_disable,
+        disable_geoip=disable_geoip,
     )
 
 
@@ -144,7 +144,7 @@ def set_once(
     context=None,  # type: Optional[Dict]
     timestamp=None,  # type: Optional[datetime.datetime]
     uuid=None,  # type: Optional[str]
-    geoip_disable=None,  # type: Optional[bool]
+    disable_geoip=None,  # type: Optional[bool]
 ):
     # type: (...) -> None
     """
@@ -169,7 +169,7 @@ def set_once(
         context=context,
         timestamp=timestamp,
         uuid=uuid,
-        geoip_disable=geoip_disable,
+        disable_geoip=disable_geoip,
     )
 
 
@@ -180,7 +180,7 @@ def group_identify(
     context=None,  # type: Optional[Dict]
     timestamp=None,  # type: Optional[datetime.datetime]
     uuid=None,  # type: Optional[str]
-    geoip_disable=None,  # type: Optional[bool]
+    disable_geoip=None,  # type: Optional[bool]
 ):
     # type: (...) -> None
     """
@@ -206,7 +206,7 @@ def group_identify(
         context=context,
         timestamp=timestamp,
         uuid=uuid,
-        geoip_disable=geoip_disable,
+        disable_geoip=disable_geoip,
     )
 
 
@@ -216,7 +216,7 @@ def alias(
     context=None,  # type: Optional[Dict]
     timestamp=None,  # type: Optional[datetime.datetime]
     uuid=None,  # type: Optional[str]
-    geoip_disable=None,  # type: Optional[bool]
+    disable_geoip=None,  # type: Optional[bool]
 ):
     # type: (...) -> None
     """
@@ -242,7 +242,7 @@ def alias(
         context=context,
         timestamp=timestamp,
         uuid=uuid,
-        geoip_disable=geoip_disable,
+        disable_geoip=disable_geoip,
     )
 
 
@@ -254,7 +254,7 @@ def feature_enabled(
     group_properties={},  # type: dict
     only_evaluate_locally=False,  # type: bool
     send_feature_flag_events=True,  # type: bool
-    geoip_disable=None,  # type: Optional[bool]
+    disable_geoip=None,  # type: Optional[bool]
 ):
     # type: (...) -> bool
     """
@@ -279,7 +279,7 @@ def feature_enabled(
         group_properties=group_properties,
         only_evaluate_locally=only_evaluate_locally,
         send_feature_flag_events=send_feature_flag_events,
-        geoip_disable=geoip_disable,
+        disable_geoip=disable_geoip,
     )
 
 
@@ -291,7 +291,7 @@ def get_feature_flag(
     group_properties={},  # type: dict
     only_evaluate_locally=False,  # type: bool
     send_feature_flag_events=True,  # type: bool
-    geoip_disable=None,  # type: Optional[bool]
+    disable_geoip=None,  # type: Optional[bool]
 ):
     """
     Get feature flag variant for users. Used with experiments.
@@ -324,7 +324,7 @@ def get_feature_flag(
         group_properties=group_properties,
         only_evaluate_locally=only_evaluate_locally,
         send_feature_flag_events=send_feature_flag_events,
-        geoip_disable=geoip_disable,
+        disable_geoip=disable_geoip,
     )
 
 
@@ -334,7 +334,7 @@ def get_all_flags(
     person_properties={},  # type: dict
     group_properties={},  # type: dict
     only_evaluate_locally=False,  # type: bool
-    geoip_disable=None,  # type: Optional[bool]
+    disable_geoip=None,  # type: Optional[bool]
 ):
     """
     Get all flags for a given user.
@@ -352,7 +352,7 @@ def get_all_flags(
         person_properties=person_properties,
         group_properties=group_properties,
         only_evaluate_locally=only_evaluate_locally,
-        geoip_disable=geoip_disable,
+        disable_geoip=disable_geoip,
     )
 
 
@@ -365,7 +365,7 @@ def get_feature_flag_payload(
     group_properties={},
     only_evaluate_locally=False,
     send_feature_flag_events=True,
-    geoip_disable=None,  # type: Optional[bool]
+    disable_geoip=None,  # type: Optional[bool]
 ):
     return _proxy(
         "get_feature_flag_payload",
@@ -377,7 +377,7 @@ def get_feature_flag_payload(
         group_properties=group_properties,
         only_evaluate_locally=only_evaluate_locally,
         send_feature_flag_events=send_feature_flag_events,
-        geoip_disable=geoip_disable,
+        disable_geoip=disable_geoip,
     )
 
 
@@ -387,7 +387,7 @@ def get_all_flags_and_payloads(
     person_properties={},
     group_properties={},
     only_evaluate_locally=False,
-    geoip_disable=None,  # type: Optional[bool]
+    disable_geoip=None,  # type: Optional[bool]
 ):
     return _proxy(
         "get_all_flags_and_payloads",
@@ -396,7 +396,7 @@ def get_all_flags_and_payloads(
         person_properties=person_properties,
         group_properties=group_properties,
         only_evaluate_locally=only_evaluate_locally,
-        geoip_disable=geoip_disable,
+        disable_geoip=disable_geoip,
     )
 
 
@@ -441,7 +441,7 @@ def _proxy(method, *args, **kwargs):
             project_api_key=project_api_key,
             poll_interval=poll_interval,
             disabled=disabled,
-            geoip_disable=geoip_disable,
+            disable_geoip=disable_geoip,
         )
 
     # always set incase user changes it

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -252,7 +252,16 @@ class Client(object):
 
         return self._enqueue(msg, geoip_disable)
 
-    def group_identify(self, group_type=None, group_key=None, properties=None, context=None, timestamp=None, uuid=None, geoip_disable=None):
+    def group_identify(
+        self,
+        group_type=None,
+        group_key=None,
+        properties=None,
+        context=None,
+        timestamp=None,
+        uuid=None,
+        geoip_disable=None,
+    ):
         properties = properties or {}
         context = context or {}
         require("group_type", group_type, ID_TYPES)
@@ -293,7 +302,9 @@ class Client(object):
 
         return self._enqueue(msg, geoip_disable)
 
-    def page(self, distinct_id=None, url=None, properties=None, context=None, timestamp=None, uuid=None, geoip_disable=None):
+    def page(
+        self, distinct_id=None, url=None, properties=None, context=None, timestamp=None, uuid=None, geoip_disable=None
+    ):
         properties = properties or {}
         context = context or {}
 

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -171,6 +171,7 @@ class Client(object):
         uuid=None,
         groups=None,
         send_feature_flags=False,
+        geoip_disable=True,
     ):
         properties = properties or {}
         context = context or {}
@@ -200,6 +201,9 @@ class Client(object):
                 for feature, variant in feature_variants.items():
                     msg["properties"]["$feature/{}".format(feature)] = variant
                 msg["properties"]["$active_feature_flags"] = list(feature_variants.keys())
+
+        if geoip_disable:
+            msg["properties"]["$geoip_disable"] = True
 
         return self._enqueue(msg)
 

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -589,7 +589,7 @@ class Client(object):
                     "locally_evaluated": flag_was_locally_evaluated,
                 },
                 groups=groups,
-                geoip_disable=geoip_disable
+                geoip_disable=geoip_disable,
             )
             self.distinct_ids_feature_flags_reported[distinct_id].add(feature_flag_reported_key)
         return response
@@ -625,7 +625,9 @@ class Client(object):
             response = self._compute_payload_locally(key, match_value)
 
         if response is None and not only_evaluate_locally:
-            decide_payloads = self.get_feature_payloads(distinct_id, groups, person_properties, group_properties, geoip_disable)
+            decide_payloads = self.get_feature_payloads(
+                distinct_id, groups, person_properties, group_properties, geoip_disable
+            )
             response = decide_payloads.get(str(key).lower(), None)
 
         return response

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -589,6 +589,7 @@ class Client(object):
                     "locally_evaluated": flag_was_locally_evaluated,
                 },
                 groups=groups,
+                geoip_disable=geoip_disable
             )
             self.distinct_ids_feature_flags_reported[distinct_id].add(feature_flag_reported_key)
         return response

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -139,7 +139,7 @@ class Client(object):
 
     def _get_active_feature_variants(
         self, distinct_id, groups=None, person_properties=None, group_properties=None, geoip_disable=None
-    ):        
+    ):
         feature_variants = self.get_feature_variants(
             distinct_id, groups, person_properties, group_properties, geoip_disable
         )

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -208,7 +208,7 @@ class Client(object):
 
         if send_feature_flags:
             try:
-                feature_variants = self._get_active_feature_variants(distinct_id, groups)
+                feature_variants = self._get_active_feature_variants(distinct_id, groups, geoip_disable)
             except Exception as e:
                 self.log.exception(f"[FEATURE FLAGS] Unable to get feature variants: {e}")
             else:

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -48,7 +48,7 @@ class Client(object):
         personal_api_key=None,
         project_api_key=None,
         disabled=False,
-        geoip_disable=True,
+        disable_geoip=True,
     ):
         self.queue = queue.Queue(max_queue_size)
 
@@ -72,7 +72,7 @@ class Client(object):
         self.poller = None
         self.distinct_ids_feature_flags_reported = SizeLimitedDict(MAX_DICT_SIZE, set)
         self.disabled = disabled
-        self.geoip_disable = geoip_disable
+        self.disable_geoip = disable_geoip
 
         # personal_api_key: This should be a generated Personal API Key, private
         self.personal_api_key = personal_api_key
@@ -114,7 +114,7 @@ class Client(object):
                 if send:
                     consumer.start()
 
-    def identify(self, distinct_id=None, properties=None, context=None, timestamp=None, uuid=None, geoip_disable=None):
+    def identify(self, distinct_id=None, properties=None, context=None, timestamp=None, uuid=None, disable_geoip=None):
         properties = properties or {}
         context = context or {}
         require("distinct_id", distinct_id, ID_TYPES)
@@ -129,35 +129,35 @@ class Client(object):
             "uuid": uuid,
         }
 
-        return self._enqueue(msg, geoip_disable)
+        return self._enqueue(msg, disable_geoip)
 
     def get_feature_variants(
-        self, distinct_id, groups=None, person_properties=None, group_properties=None, geoip_disable=None
+        self, distinct_id, groups=None, person_properties=None, group_properties=None, disable_geoip=None
     ):
-        resp_data = self.get_decide(distinct_id, groups, person_properties, group_properties, geoip_disable)
+        resp_data = self.get_decide(distinct_id, groups, person_properties, group_properties, disable_geoip)
         return resp_data["featureFlags"]
 
     def _get_active_feature_variants(
-        self, distinct_id, groups=None, person_properties=None, group_properties=None, geoip_disable=None
+        self, distinct_id, groups=None, person_properties=None, group_properties=None, disable_geoip=None
     ):
         feature_variants = self.get_feature_variants(
-            distinct_id, groups, person_properties, group_properties, geoip_disable
+            distinct_id, groups, person_properties, group_properties, disable_geoip
         )
         return {
             k: v for (k, v) in feature_variants.items() if v is not False
         }  # explicitly test for false to account for values that may seem falsy (ex: 0)
 
     def get_feature_payloads(
-        self, distinct_id, groups=None, person_properties=None, group_properties=None, geoip_disable=None
+        self, distinct_id, groups=None, person_properties=None, group_properties=None, disable_geoip=None
     ):
-        resp_data = self.get_decide(distinct_id, groups, person_properties, group_properties, geoip_disable)
+        resp_data = self.get_decide(distinct_id, groups, person_properties, group_properties, disable_geoip)
         return resp_data["featureFlagPayloads"]
 
-    def get_decide(self, distinct_id, groups=None, person_properties=None, group_properties=None, geoip_disable=None):
+    def get_decide(self, distinct_id, groups=None, person_properties=None, group_properties=None, disable_geoip=None):
         require("distinct_id", distinct_id, ID_TYPES)
 
-        if geoip_disable is None:
-            geoip_disable = self.geoip_disable
+        if disable_geoip is None:
+            disable_geoip = self.disable_geoip
 
         if groups:
             require("groups", groups, dict)
@@ -169,7 +169,7 @@ class Client(object):
             "groups": groups,
             "person_properties": person_properties,
             "group_properties": group_properties,
-            "geoip_disable": geoip_disable,
+            "disable_geoip": disable_geoip,
         }
         resp_data = decide(self.api_key, self.host, timeout=10, **request_data)
 
@@ -185,7 +185,7 @@ class Client(object):
         uuid=None,
         groups=None,
         send_feature_flags=False,
-        geoip_disable=None,
+        disable_geoip=None,
     ):
         properties = properties or {}
         context = context or {}
@@ -208,7 +208,7 @@ class Client(object):
 
         if send_feature_flags:
             try:
-                feature_variants = self._get_active_feature_variants(distinct_id, groups, geoip_disable=geoip_disable)
+                feature_variants = self._get_active_feature_variants(distinct_id, groups, disable_geoip=disable_geoip)
             except Exception as e:
                 self.log.exception(f"[FEATURE FLAGS] Unable to get feature variants: {e}")
             else:
@@ -216,9 +216,9 @@ class Client(object):
                     msg["properties"]["$feature/{}".format(feature)] = variant
                 msg["properties"]["$active_feature_flags"] = list(feature_variants.keys())
 
-        return self._enqueue(msg, geoip_disable)
+        return self._enqueue(msg, disable_geoip)
 
-    def set(self, distinct_id=None, properties=None, context=None, timestamp=None, uuid=None, geoip_disable=None):
+    def set(self, distinct_id=None, properties=None, context=None, timestamp=None, uuid=None, disable_geoip=None):
         properties = properties or {}
         context = context or {}
         require("distinct_id", distinct_id, ID_TYPES)
@@ -233,9 +233,9 @@ class Client(object):
             "uuid": uuid,
         }
 
-        return self._enqueue(msg, geoip_disable)
+        return self._enqueue(msg, disable_geoip)
 
-    def set_once(self, distinct_id=None, properties=None, context=None, timestamp=None, uuid=None, geoip_disable=None):
+    def set_once(self, distinct_id=None, properties=None, context=None, timestamp=None, uuid=None, disable_geoip=None):
         properties = properties or {}
         context = context or {}
         require("distinct_id", distinct_id, ID_TYPES)
@@ -250,7 +250,7 @@ class Client(object):
             "uuid": uuid,
         }
 
-        return self._enqueue(msg, geoip_disable)
+        return self._enqueue(msg, disable_geoip)
 
     def group_identify(
         self,
@@ -260,7 +260,7 @@ class Client(object):
         context=None,
         timestamp=None,
         uuid=None,
-        geoip_disable=None,
+        disable_geoip=None,
     ):
         properties = properties or {}
         context = context or {}
@@ -281,9 +281,9 @@ class Client(object):
             "uuid": uuid,
         }
 
-        return self._enqueue(msg, geoip_disable)
+        return self._enqueue(msg, disable_geoip)
 
-    def alias(self, previous_id=None, distinct_id=None, context=None, timestamp=None, uuid=None, geoip_disable=None):
+    def alias(self, previous_id=None, distinct_id=None, context=None, timestamp=None, uuid=None, disable_geoip=None):
         context = context or {}
 
         require("previous_id", previous_id, ID_TYPES)
@@ -300,10 +300,10 @@ class Client(object):
             "distinct_id": previous_id,
         }
 
-        return self._enqueue(msg, geoip_disable)
+        return self._enqueue(msg, disable_geoip)
 
     def page(
-        self, distinct_id=None, url=None, properties=None, context=None, timestamp=None, uuid=None, geoip_disable=None
+        self, distinct_id=None, url=None, properties=None, context=None, timestamp=None, uuid=None, disable_geoip=None
     ):
         properties = properties or {}
         context = context or {}
@@ -323,9 +323,9 @@ class Client(object):
             "uuid": uuid,
         }
 
-        return self._enqueue(msg, geoip_disable)
+        return self._enqueue(msg, disable_geoip)
 
-    def _enqueue(self, msg, geoip_disable):
+    def _enqueue(self, msg, disable_geoip):
         """Push a new `msg` onto the queue, return `(success, msg)`"""
 
         if self.disabled:
@@ -353,10 +353,10 @@ class Client(object):
         msg["properties"]["$lib"] = "posthog-python"
         msg["properties"]["$lib_version"] = VERSION
 
-        if geoip_disable is None:
-            geoip_disable = self.geoip_disable
+        if disable_geoip is None:
+            disable_geoip = self.disable_geoip
 
-        if geoip_disable:
+        if disable_geoip:
             msg["properties"]["$geoip_disable"] = True
 
         msg["distinct_id"] = stringify_id(msg.get("distinct_id", None))
@@ -502,7 +502,7 @@ class Client(object):
         group_properties={},
         only_evaluate_locally=False,
         send_feature_flag_events=True,
-        geoip_disable=None,
+        disable_geoip=None,
     ):
         response = self.get_feature_flag(
             key,
@@ -512,7 +512,7 @@ class Client(object):
             group_properties=group_properties,
             only_evaluate_locally=only_evaluate_locally,
             send_feature_flag_events=send_feature_flag_events,
-            geoip_disable=geoip_disable,
+            disable_geoip=disable_geoip,
         )
 
         if response is None:
@@ -529,7 +529,7 @@ class Client(object):
         group_properties={},
         only_evaluate_locally=False,
         send_feature_flag_events=True,
-        geoip_disable=None,
+        disable_geoip=None,
     ):
         require("key", key, string_types)
         require("distinct_id", distinct_id, ID_TYPES)
@@ -567,7 +567,7 @@ class Client(object):
                     groups=groups,
                     person_properties=person_properties,
                     group_properties=group_properties,
-                    geoip_disable=geoip_disable,
+                    disable_geoip=disable_geoip,
                 )
                 response = feature_flags.get(key)
                 if response is None:
@@ -590,7 +590,7 @@ class Client(object):
                     "locally_evaluated": flag_was_locally_evaluated,
                 },
                 groups=groups,
-                geoip_disable=geoip_disable,
+                disable_geoip=disable_geoip,
             )
             self.distinct_ids_feature_flags_reported[distinct_id].add(feature_flag_reported_key)
         return response
@@ -606,7 +606,7 @@ class Client(object):
         group_properties={},
         only_evaluate_locally=False,
         send_feature_flag_events=True,
-        geoip_disable=None,
+        disable_geoip=None,
     ):
         if match_value is None:
             match_value = self.get_feature_flag(
@@ -617,7 +617,7 @@ class Client(object):
                 group_properties=group_properties,
                 send_feature_flag_events=send_feature_flag_events,
                 only_evaluate_locally=True,
-                geoip_disable=geoip_disable,
+                disable_geoip=disable_geoip,
             )
 
         response = None
@@ -627,7 +627,7 @@ class Client(object):
 
         if response is None and not only_evaluate_locally:
             decide_payloads = self.get_feature_payloads(
-                distinct_id, groups, person_properties, group_properties, geoip_disable
+                distinct_id, groups, person_properties, group_properties, disable_geoip
             )
             response = decide_payloads.get(str(key).lower(), None)
 
@@ -653,7 +653,7 @@ class Client(object):
         person_properties={},
         group_properties={},
         only_evaluate_locally=False,
-        geoip_disable=None,
+        disable_geoip=None,
     ):
         flags = self.get_all_flags_and_payloads(
             distinct_id,
@@ -661,7 +661,7 @@ class Client(object):
             person_properties=person_properties,
             group_properties=group_properties,
             only_evaluate_locally=only_evaluate_locally,
-            geoip_disable=geoip_disable,
+            disable_geoip=disable_geoip,
         )
         return flags["featureFlags"]
 
@@ -673,7 +673,7 @@ class Client(object):
         person_properties={},
         group_properties={},
         only_evaluate_locally=False,
-        geoip_disable=None,
+        disable_geoip=None,
     ):
         flags, payloads, fallback_to_decide = self._get_all_flags_and_payloads_locally(
             distinct_id, groups=groups, person_properties=person_properties, group_properties=group_properties
@@ -687,7 +687,7 @@ class Client(object):
                     groups=groups,
                     person_properties=person_properties,
                     group_properties=group_properties,
-                    geoip_disable=geoip_disable,
+                    disable_geoip=disable_geoip,
                 )
                 response = flags_and_payloads
             except Exception as e:

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -48,7 +48,7 @@ class Client(object):
         personal_api_key=None,
         project_api_key=None,
         disabled=False,
-        geoip_disable=None,
+        geoip_disable=True,
     ):
         self.queue = queue.Queue(max_queue_size)
 

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -139,7 +139,7 @@ class Client(object):
 
     def _get_active_feature_variants(
         self, distinct_id, groups=None, person_properties=None, group_properties=None, geoip_disable=None
-    ):
+    ):        
         feature_variants = self.get_feature_variants(
             distinct_id, groups, person_properties, group_properties, geoip_disable
         )
@@ -208,7 +208,7 @@ class Client(object):
 
         if send_feature_flags:
             try:
-                feature_variants = self._get_active_feature_variants(distinct_id, groups, geoip_disable)
+                feature_variants = self._get_active_feature_variants(distinct_id, groups, geoip_disable=geoip_disable)
             except Exception as e:
                 self.log.exception(f"[FEATURE FLAGS] Unable to get feature variants: {e}")
             else:
@@ -355,7 +355,7 @@ class Client(object):
 
         if geoip_disable is None:
             geoip_disable = self.geoip_disable
-            if geoip_disable is True:
+            if geoip_disable:
                 msg["properties"]["$geoip_disable"] = True
 
         msg["distinct_id"] = stringify_id(msg.get("distinct_id", None))

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -604,6 +604,7 @@ class Client(object):
         group_properties={},
         only_evaluate_locally=False,
         send_feature_flag_events=True,
+        geoip_disable=None,
     ):
         if match_value is None:
             match_value = self.get_feature_flag(
@@ -614,6 +615,7 @@ class Client(object):
                 group_properties=group_properties,
                 send_feature_flag_events=send_feature_flag_events,
                 only_evaluate_locally=True,
+                geoip_disable=geoip_disable,
             )
 
         response = None
@@ -622,7 +624,7 @@ class Client(object):
             response = self._compute_payload_locally(key, match_value)
 
         if response is None and not only_evaluate_locally:
-            decide_payloads = self.get_feature_payloads(distinct_id, groups, person_properties, group_properties)
+            decide_payloads = self.get_feature_payloads(distinct_id, groups, person_properties, group_properties, geoip_disable)
             response = decide_payloads.get(str(key).lower(), None)
 
         return response

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -355,8 +355,9 @@ class Client(object):
 
         if geoip_disable is None:
             geoip_disable = self.geoip_disable
-            if geoip_disable:
-                msg["properties"]["$geoip_disable"] = True
+
+        if geoip_disable:
+            msg["properties"]["$geoip_disable"] = True
 
         msg["distinct_id"] = stringify_id(msg.get("distinct_id", None))
 

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -48,6 +48,7 @@ class Client(object):
         personal_api_key=None,
         project_api_key=None,
         disabled=False,
+        geoip_disable=True,
     ):
         self.queue = queue.Queue(max_queue_size)
 
@@ -71,6 +72,7 @@ class Client(object):
         self.poller = None
         self.distinct_ids_feature_flags_reported = SizeLimitedDict(MAX_DICT_SIZE, set)
         self.disabled = disabled
+        self.geoip_disable = geoip_disable
 
         # personal_api_key: This should be a generated Personal API Key, private
         self.personal_api_key = personal_api_key
@@ -171,7 +173,6 @@ class Client(object):
         uuid=None,
         groups=None,
         send_feature_flags=False,
-        geoip_disable=True,
     ):
         properties = properties or {}
         context = context or {}
@@ -202,7 +203,7 @@ class Client(object):
                     msg["properties"]["$feature/{}".format(feature)] = variant
                 msg["properties"]["$active_feature_flags"] = list(feature_variants.keys())
 
-        if geoip_disable:
+        if self.geoip_disable:
             msg["properties"]["$geoip_disable"] = True
 
         return self._enqueue(msg)

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -131,17 +131,25 @@ class Client(object):
 
         return self._enqueue(msg)
 
-    def get_feature_variants(self, distinct_id, groups=None, person_properties=None, group_properties=None, geoip_disable=True):
+    def get_feature_variants(
+        self, distinct_id, groups=None, person_properties=None, group_properties=None, geoip_disable=True
+    ):
         resp_data = self.get_decide(distinct_id, groups, person_properties, group_properties, geoip_disable)
         return resp_data["featureFlags"]
 
-    def _get_active_feature_variants(self, distinct_id, groups=None, person_properties=None, group_properties=None, geoip_disable=True):
-        feature_variants = self.get_feature_variants(distinct_id, groups, person_properties, group_properties, geoip_disable)
+    def _get_active_feature_variants(
+        self, distinct_id, groups=None, person_properties=None, group_properties=None, geoip_disable=True
+    ):
+        feature_variants = self.get_feature_variants(
+            distinct_id, groups, person_properties, group_properties, geoip_disable
+        )
         return {
             k: v for (k, v) in feature_variants.items() if v is not False
         }  # explicitly test for false to account for values that may seem falsy (ex: 0)
 
-    def get_feature_payloads(self, distinct_id, groups=None, person_properties=None, group_properties=None, geoip_disable=True):
+    def get_feature_payloads(
+        self, distinct_id, groups=None, person_properties=None, group_properties=None, geoip_disable=True
+    ):
         resp_data = self.get_decide(distinct_id, groups, person_properties, group_properties, geoip_disable)
         return resp_data["featureFlagPayloads"]
 
@@ -158,7 +166,7 @@ class Client(object):
             "groups": groups,
             "person_properties": person_properties,
             "group_properties": group_properties,
-            "geoip_disable": geoip_disable
+            "geoip_disable": geoip_disable,
         }
         resp_data = decide(self.api_key, self.host, timeout=10, **request_data)
 
@@ -537,7 +545,11 @@ class Client(object):
         if not flag_was_locally_evaluated and not only_evaluate_locally:
             try:
                 feature_flags = self.get_feature_variants(
-                    distinct_id, groups=groups, person_properties=person_properties, group_properties=group_properties, geoip_disable=geoip_disable
+                    distinct_id,
+                    groups=groups,
+                    person_properties=person_properties,
+                    group_properties=group_properties,
+                    geoip_disable=geoip_disable,
                 )
                 response = feature_flags.get(key)
                 if response is None:
@@ -611,7 +623,14 @@ class Client(object):
         return payload
 
     def get_all_flags(
-        self, distinct_id, *, groups={}, person_properties={}, group_properties={}, only_evaluate_locally=False, geoip_disable=True,
+        self,
+        distinct_id,
+        *,
+        groups={},
+        person_properties={},
+        group_properties={},
+        only_evaluate_locally=False,
+        geoip_disable=True,
     ):
         flags = self.get_all_flags_and_payloads(
             distinct_id,
@@ -619,12 +638,19 @@ class Client(object):
             person_properties=person_properties,
             group_properties=group_properties,
             only_evaluate_locally=only_evaluate_locally,
-            geoip_disable=geoip_disable
+            geoip_disable=geoip_disable,
         )
         return flags["featureFlags"]
 
     def get_all_flags_and_payloads(
-        self, distinct_id, *, groups={}, person_properties={}, group_properties={}, only_evaluate_locally=False, geoip_disable=True
+        self,
+        distinct_id,
+        *,
+        groups={},
+        person_properties={},
+        group_properties={},
+        only_evaluate_locally=False,
+        geoip_disable=True,
     ):
         flags, payloads, fallback_to_decide = self._get_all_flags_and_payloads_locally(
             distinct_id, groups=groups, person_properties=person_properties, group_properties=group_properties
@@ -634,7 +660,11 @@ class Client(object):
         if fallback_to_decide and not only_evaluate_locally:
             try:
                 flags_and_payloads = self.get_decide(
-                    distinct_id, groups=groups, person_properties=person_properties, group_properties=group_properties, geoip_disable=geoip_disable
+                    distinct_id,
+                    groups=groups,
+                    person_properties=person_properties,
+                    group_properties=group_properties,
+                    geoip_disable=geoip_disable,
                 )
                 response = flags_and_payloads
             except Exception as e:

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -562,6 +562,16 @@ class TestClient(unittest.TestCase):
         client.flush()
         self.assertEqual(identify_msg["properties"]["$geoip_disable"], True)
 
+    def test_geoip_disable_override_on_events(self):
+        client = Client(FAKE_TEST_API_KEY, on_error=self.set_fail, geoip_disable=False)
+        _, capture_msg = client.set("distinct_id", {"a": "b", "c": "d"}, geoip_disable=True)
+        client.flush()
+        self.assertEqual(capture_msg["properties"]["$geoip_disable"], True)
+
+        _, identify_msg = client.page("distinct_id", "http://a.com", {"trait": "value"}, geoip_disable=False)
+        client.flush()
+        self.assertEqual("$geoip_disable" not in identify_msg["properties"], True)
+
     def test_geoip_disable_method_overrides_init_on_events(self):
         client = Client(FAKE_TEST_API_KEY, on_error=self.set_fail, geoip_disable=True)
         _, msg = client.capture("distinct_id", "python test event", geoip_disable=False)

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -112,7 +112,7 @@ class TestClient(unittest.TestCase):
         }
 
         client = Client(FAKE_TEST_API_KEY, on_error=self.set_fail, personal_api_key=FAKE_TEST_API_KEY)
-        variants = client._get_active_feature_variants("some_id", None, None, None)
+        variants = client._get_active_feature_variants("some_id", None, None, None, True)
         self.assertEqual(variants, {"beta-feature": "random-variant", "alpha-feature": True})
 
     @mock.patch("posthog.client.decide")
@@ -493,6 +493,11 @@ class TestClient(unittest.TestCase):
         self.assertFalse(self.failed)
 
         self.assertEqual(msg, "disabled")
+
+    def test_geoip_disable(self):
+        client = Client(FAKE_TEST_API_KEY, on_error=self.set_fail, geoip_disable=True)
+        _, msg = client.capture("distinct_id", "python test event")
+        self.assertEqual(msg["properties"]["$geoip_disable"], True)
 
     @mock.patch("posthog.client.Poller")
     @mock.patch("posthog.client.get")

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -315,6 +315,7 @@ class TestClient(unittest.TestCase):
                 "$group_set": {},
                 "$lib": "posthog-python",
                 "$lib_version": VERSION,
+                "$geoip_disable": True,
             },
         )
         self.assertTrue(isinstance(msg["timestamp"], str))
@@ -336,6 +337,7 @@ class TestClient(unittest.TestCase):
                 "$group_set": {"trait": "value"},
                 "$lib": "posthog-python",
                 "$lib_version": VERSION,
+                "$geoip_disable": True,
             },
         )
         self.assertEqual(msg["timestamp"], "2014-09-03T00:00:00+00:00")

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -114,7 +114,16 @@ class TestClient(unittest.TestCase):
         client = Client(FAKE_TEST_API_KEY, on_error=self.set_fail, personal_api_key=FAKE_TEST_API_KEY)
         variants = client._get_active_feature_variants("some_id", None, None, None, False)
         self.assertEqual(variants, {"beta-feature": "random-variant", "alpha-feature": True})
-        patch_decide.assert_called_with("random_key", None, timeout=10, distinct_id="some_id", groups={}, person_properties=None, group_properties=None, geoip_disable=False)
+        patch_decide.assert_called_with(
+            "random_key",
+            None,
+            timeout=10,
+            distinct_id="some_id",
+            groups={},
+            person_properties=None,
+            group_properties=None,
+            geoip_disable=False,
+        )
 
     @mock.patch("posthog.client.decide")
     def test_basic_capture_with_feature_flags_returns_active_only(self, patch_decide):

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -159,14 +159,16 @@ class TestClient(unittest.TestCase):
             group_properties=None,
             geoip_disable=True,
         )
-    
+
     @mock.patch("posthog.client.decide")
     def test_basic_capture_with_feature_flags_and_geoip_disable_returns_correctly(self, patch_decide):
         patch_decide.return_value = {
             "featureFlags": {"beta-feature": "random-variant", "alpha-feature": True, "off-feature": False}
         }
 
-        client = Client(FAKE_TEST_API_KEY, on_error=self.set_fail, personal_api_key=FAKE_TEST_API_KEY, geoip_disable=True)
+        client = Client(
+            FAKE_TEST_API_KEY, on_error=self.set_fail, personal_api_key=FAKE_TEST_API_KEY, geoip_disable=True
+        )
         success, msg = client.capture("distinct_id", "python test event", send_feature_flags=True, geoip_disable=False)
         client.flush()
         self.assertTrue(success)

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -122,7 +122,7 @@ class TestClient(unittest.TestCase):
             groups={},
             person_properties=None,
             group_properties=None,
-            geoip_disable=False,
+            disable_geoip=False,
         )
 
     @mock.patch("posthog.client.decide")
@@ -157,19 +157,19 @@ class TestClient(unittest.TestCase):
             groups={},
             person_properties=None,
             group_properties=None,
-            geoip_disable=True,
+            disable_geoip=True,
         )
 
     @mock.patch("posthog.client.decide")
-    def test_basic_capture_with_feature_flags_and_geoip_disable_returns_correctly(self, patch_decide):
+    def test_basic_capture_with_feature_flags_and_disable_geoip_returns_correctly(self, patch_decide):
         patch_decide.return_value = {
             "featureFlags": {"beta-feature": "random-variant", "alpha-feature": True, "off-feature": False}
         }
 
         client = Client(
-            FAKE_TEST_API_KEY, on_error=self.set_fail, personal_api_key=FAKE_TEST_API_KEY, geoip_disable=True
+            FAKE_TEST_API_KEY, on_error=self.set_fail, personal_api_key=FAKE_TEST_API_KEY, disable_geoip=True
         )
-        success, msg = client.capture("distinct_id", "python test event", send_feature_flags=True, geoip_disable=False)
+        success, msg = client.capture("distinct_id", "python test event", send_feature_flags=True, disable_geoip=False)
         client.flush()
         self.assertTrue(success)
         self.assertFalse(self.failed)
@@ -194,7 +194,7 @@ class TestClient(unittest.TestCase):
             groups={},
             person_properties=None,
             group_properties=None,
-            geoip_disable=False,
+            disable_geoip=False,
         )
 
     @mock.patch("posthog.client.decide")
@@ -554,8 +554,8 @@ class TestClient(unittest.TestCase):
 
         self.assertEqual(msg, "disabled")
 
-    def test_geoip_disable_default_on_events(self):
-        client = Client(FAKE_TEST_API_KEY, on_error=self.set_fail, geoip_disable=True)
+    def test_disable_geoip_default_on_events(self):
+        client = Client(FAKE_TEST_API_KEY, on_error=self.set_fail, disable_geoip=True)
         _, capture_msg = client.capture("distinct_id", "python test event")
         client.flush()
         self.assertEqual(capture_msg["properties"]["$geoip_disable"], True)
@@ -564,29 +564,29 @@ class TestClient(unittest.TestCase):
         client.flush()
         self.assertEqual(identify_msg["properties"]["$geoip_disable"], True)
 
-    def test_geoip_disable_override_on_events(self):
-        client = Client(FAKE_TEST_API_KEY, on_error=self.set_fail, geoip_disable=False)
-        _, capture_msg = client.set("distinct_id", {"a": "b", "c": "d"}, geoip_disable=True)
+    def test_disable_geoip_override_on_events(self):
+        client = Client(FAKE_TEST_API_KEY, on_error=self.set_fail, disable_geoip=False)
+        _, capture_msg = client.set("distinct_id", {"a": "b", "c": "d"}, disable_geoip=True)
         client.flush()
         self.assertEqual(capture_msg["properties"]["$geoip_disable"], True)
 
-        _, identify_msg = client.page("distinct_id", "http://a.com", {"trait": "value"}, geoip_disable=False)
+        _, identify_msg = client.page("distinct_id", "http://a.com", {"trait": "value"}, disable_geoip=False)
         client.flush()
         self.assertEqual("$geoip_disable" not in identify_msg["properties"], True)
 
-    def test_geoip_disable_method_overrides_init_on_events(self):
-        client = Client(FAKE_TEST_API_KEY, on_error=self.set_fail, geoip_disable=True)
-        _, msg = client.capture("distinct_id", "python test event", geoip_disable=False)
+    def test_disable_geoip_method_overrides_init_on_events(self):
+        client = Client(FAKE_TEST_API_KEY, on_error=self.set_fail, disable_geoip=True)
+        _, msg = client.capture("distinct_id", "python test event", disable_geoip=False)
         client.flush()
         self.assertTrue("$geoip_disable" not in msg["properties"])
 
     @mock.patch("posthog.client.decide")
-    def test_geoip_disable_default_on_decide(self, patch_decide):
+    def test_disable_geoip_default_on_decide(self, patch_decide):
         patch_decide.return_value = {
             "featureFlags": {"beta-feature": "random-variant", "alpha-feature": True, "off-feature": False}
         }
-        client = Client(FAKE_TEST_API_KEY, on_error=self.set_fail, geoip_disable=False)
-        client.get_feature_flag("random_key", "some_id", geoip_disable=True)
+        client = Client(FAKE_TEST_API_KEY, on_error=self.set_fail, disable_geoip=False)
+        client.get_feature_flag("random_key", "some_id", disable_geoip=True)
         patch_decide.assert_called_with(
             "random_key",
             None,
@@ -595,10 +595,10 @@ class TestClient(unittest.TestCase):
             groups={},
             person_properties={},
             group_properties={},
-            geoip_disable=True,
+            disable_geoip=True,
         )
         patch_decide.reset_mock()
-        client.feature_enabled("random_key", "feature_enabled_distinct_id", geoip_disable=True)
+        client.feature_enabled("random_key", "feature_enabled_distinct_id", disable_geoip=True)
         patch_decide.assert_called_with(
             "random_key",
             None,
@@ -607,7 +607,7 @@ class TestClient(unittest.TestCase):
             groups={},
             person_properties={},
             group_properties={},
-            geoip_disable=True,
+            disable_geoip=True,
         )
         patch_decide.reset_mock()
         client.get_all_flags_and_payloads("all_flags_payloads_id")
@@ -619,7 +619,7 @@ class TestClient(unittest.TestCase):
             groups={},
             person_properties={},
             group_properties={},
-            geoip_disable=False,
+            disable_geoip=False,
         )
 
     @mock.patch("posthog.client.Poller")

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -1975,7 +1975,10 @@ class TestCaptureCalls(unittest.TestCase):
         ]
 
         client.get_feature_flag(
-            "complex-flag", "some-distinct-id", person_properties={"region": "USA", "name": "Aloha"}, geoip_disable=False
+            "complex-flag",
+            "some-distinct-id",
+            person_properties={"region": "USA", "name": "Aloha"},
+            geoip_disable=False,
         )
 
         patch_capture.assert_called_with(

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -1890,7 +1890,7 @@ class TestCaptureCalls(unittest.TestCase):
             "$feature_flag_called",
             {"$feature_flag": "complex-flag", "$feature_flag_response": True, "locally_evaluated": True},
             groups={},
-            geoip_disable=None,
+            disable_geoip=None,
         )
         patch_capture.reset_mock()
 
@@ -1915,7 +1915,7 @@ class TestCaptureCalls(unittest.TestCase):
             "$feature_flag_called",
             {"$feature_flag": "complex-flag", "$feature_flag_response": True, "locally_evaluated": True},
             groups={},
-            geoip_disable=None,
+            disable_geoip=None,
         )
         patch_capture.reset_mock()
 
@@ -1948,14 +1948,14 @@ class TestCaptureCalls(unittest.TestCase):
             "$feature_flag_called",
             {"$feature_flag": "decide-flag", "$feature_flag_response": "decide-value", "locally_evaluated": False},
             groups={"organization": "org1"},
-            geoip_disable=None,
+            disable_geoip=None,
         )
 
     @mock.patch.object(Client, "capture")
     @mock.patch("posthog.client.decide")
-    def test_geoip_disable_get_flag_capture_call(self, patch_decide, patch_capture):
+    def test_disable_geoip_get_flag_capture_call(self, patch_decide, patch_capture):
         patch_decide.return_value = {"featureFlags": {"decide-flag": "decide-value"}}
-        client = Client(FAKE_TEST_API_KEY, personal_api_key=FAKE_TEST_API_KEY, geoip_disable=True)
+        client = Client(FAKE_TEST_API_KEY, personal_api_key=FAKE_TEST_API_KEY, disable_geoip=True)
         client.feature_flags = [
             {
                 "id": 1,
@@ -1978,7 +1978,7 @@ class TestCaptureCalls(unittest.TestCase):
             "complex-flag",
             "some-distinct-id",
             person_properties={"region": "USA", "name": "Aloha"},
-            geoip_disable=False,
+            disable_geoip=False,
         )
 
         patch_capture.assert_called_with(
@@ -1986,7 +1986,7 @@ class TestCaptureCalls(unittest.TestCase):
             "$feature_flag_called",
             {"$feature_flag": "complex-flag", "$feature_flag_response": True, "locally_evaluated": True},
             groups={},
-            geoip_disable=False,
+            disable_geoip=False,
         )
 
     @mock.patch("posthog.client.MAX_DICT_SIZE", 100)
@@ -2020,7 +2020,7 @@ class TestCaptureCalls(unittest.TestCase):
                 "$feature_flag_called",
                 {"$feature_flag": "complex-flag", "$feature_flag_response": True, "locally_evaluated": True},
                 groups={},
-                geoip_disable=None,
+                disable_geoip=None,
             )
 
             self.assertEqual(len(client.distinct_ids_feature_flags_reported), i % 100 + 1)

--- a/posthog/version.py
+++ b/posthog/version.py
@@ -1,4 +1,4 @@
-VERSION = "2.5.0"
+VERSION = "3.0.0"
 
 if __name__ == "__main__":
     print(VERSION, end="")  # noqa: T201


### PR DESCRIPTION
https://github.com/PostHog/posthog/issues/14351

The `$geoip` property on server libraries tends to default to incorrect locations (mainly based from where the server is located and not the user) and causes issues such as incorrect event/user data for analytics and problems with feature flag rollouts based on location.

This fix prevents the `advanced geoip plugin` and the `decide` call in https://github.com/PostHog/posthog/blob/master/posthog/api/decide.py#L144 from overriding user properties with incorrect server library geoip properties by default.

Users who are manually passing in geoip values will have to set `geoip_disable` to `False` to ensure their values are not discarded

related PR: https://github.com/PostHog/posthog/pull/15039