### PR TITLE
fix: disable behaviour for feature flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.1 - 2023-04-21
+
+Restore how feature flags work when the client library is disabled: All requests return `None` and no events are sent when the client is disabled.
 ## 3.0.0 - 2023-04-14
 
 Breaking change:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.0.1 - 2023-04-21
 
-Restore how feature flags work when the client library is disabled: All requests return `None` and no events are sent when the client is disabled.
+1. Restore how feature flags work when the client library is disabled: All requests return `None` and no events are sent when the client is disabled.
+2. Add a `feature_flag_definitions()` debug option, which returns currently loaded feature flag definitions. You can use this to more cleverly decide when to request local evaluation of feature flags.
 ## 3.0.0 - 2023-04-14
 
 Breaking change:

--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -399,6 +399,10 @@ def get_all_flags_and_payloads(
         disable_geoip=disable_geoip,
     )
 
+def feature_flag_definitions():
+    """Returns loaded feature flags, if any. Helpful for debugging what flag information you have loaded."""
+    return _proxy("feature_flag_definitions")
+
 
 def page(*args, **kwargs):
     """Send a page call."""

--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -399,6 +399,7 @@ def get_all_flags_and_payloads(
         disable_geoip=disable_geoip,
     )
 
+
 def feature_flag_definitions():
     """Returns loaded feature flags, if any. Helpful for debugging what flag information you have loaded."""
     return _proxy("feature_flag_definitions")

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -611,7 +611,6 @@ class Client(object):
         send_feature_flag_events=True,
         disable_geoip=None,
     ):
-        
         if self.disabled:
             return None
 

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -739,6 +739,9 @@ class Client(object):
 
         return flags, payloads, fallback_to_decide
 
+    def feature_flag_definitions(self):
+        return self.feature_flags
+
 
 def require(name, field, data_type):
     """Require that the named `field` has the right `data_type`"""

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -535,6 +535,9 @@ class Client(object):
         require("distinct_id", distinct_id, ID_TYPES)
         require("groups", groups, dict)
 
+        if self.disabled:
+            return None
+
         if self.feature_flags is None and self.personal_api_key:
             self.load_feature_flags()
         response = None
@@ -608,6 +611,10 @@ class Client(object):
         send_feature_flag_events=True,
         disable_geoip=None,
     ):
+        
+        if self.disabled:
+            return None
+
         if match_value is None:
             match_value = self.get_feature_flag(
                 key,
@@ -675,6 +682,9 @@ class Client(object):
         only_evaluate_locally=False,
         disable_geoip=None,
     ):
+        if self.disabled:
+            return {"featureFlags": None, "featureFlagPayloads": None}
+
         flags, payloads, fallback_to_decide = self._get_all_flags_and_payloads_locally(
             distinct_id, groups=groups, person_properties=person_properties, group_properties=group_properties
         )

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -536,7 +536,7 @@ class TestClient(unittest.TestCase):
         self.assertFalse(self.failed)
 
         self.assertEqual(msg, "disabled")
-    
+
     @mock.patch("posthog.client.decide")
     def test_disabled_with_feature_flags(self, patch_decide):
         client = Client(FAKE_TEST_API_KEY, on_error=self.set_fail, disabled=True)
@@ -560,7 +560,6 @@ class TestClient(unittest.TestCase):
         response = client.get_all_flags_and_payloads("12345")
         self.assertEqual(response, {"featureFlags": None, "featureFlagPayloads": None})
         patch_decide.assert_not_called()
-
 
         # no capture calls
         self.assertTrue(client.queue.empty())

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -536,6 +536,34 @@ class TestClient(unittest.TestCase):
         self.assertFalse(self.failed)
 
         self.assertEqual(msg, "disabled")
+    
+    @mock.patch("posthog.client.decide")
+    def test_disabled_with_feature_flags(self, patch_decide):
+        client = Client(FAKE_TEST_API_KEY, on_error=self.set_fail, disabled=True)
+
+        response = client.get_feature_flag("beta-feature", "12345")
+        self.assertIsNone(response)
+        patch_decide.assert_not_called()
+
+        response = client.feature_enabled("beta-feature", "12345")
+        self.assertIsNone(response)
+        patch_decide.assert_not_called()
+
+        response = client.get_all_flags("12345")
+        self.assertIsNone(response)
+        patch_decide.assert_not_called()
+
+        response = client.get_feature_flag_payload("key", "12345")
+        self.assertIsNone(response)
+        patch_decide.assert_not_called()
+
+        response = client.get_all_flags_and_payloads("12345")
+        self.assertEqual(response, {"featureFlags": None, "featureFlagPayloads": None})
+        patch_decide.assert_not_called()
+
+
+        # no capture calls
+        self.assertTrue(client.queue.empty())
 
     def test_enabled_to_disabled(self):
         client = Client(FAKE_TEST_API_KEY, on_error=self.set_fail, disabled=False)

--- a/posthog/version.py
+++ b/posthog/version.py
@@ -1,4 +1,4 @@
-VERSION = "3.0.0"
+VERSION = "3.0.1"
 
 if __name__ == "__main__":
     print(VERSION, end="")  # noqa: T201


### PR DESCRIPTION
Disable used to return none for feature flags as well, but this behaviour broke with the client refactor.

Noticed while trying to update client to latest version