### PR TITLE
Distribute py.typed to utilize the annotated types

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
     maintainer_email="hey@posthog.com",
     test_suite="posthog.test.all",
     packages=["posthog", "posthog.test", "posthog.sentry"],
+    package_data={"posthog": ["py.typed"]},
     license="MIT License",
     install_requires=install_requires,
     extras_require=extras_require,


### PR DESCRIPTION
This is needed for the library users to use the annotated types. See https://peps.python.org/pep-0561/#packaging-type-information for details.