### PR TITLE
feat: increase message and batch sizes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,4 +62,4 @@ jobs:
 
             - name: Run posthog tests
               run: |
-                  python setup.py test
+                  pytest --verbose --timeout=30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.0 - 2023-12-04
+
+1. Increase maximum event size and batch size
+
 ## 3.0.2 - 2023-08-17
 
 1. Returns the current flag property with $feature_flag_called events, to make it easier to use in experiments

--- a/posthog/consumer.py
+++ b/posthog/consumer.py
@@ -17,7 +17,7 @@ MAX_MSG_SIZE = 900 * 1024  # 900KiB per event
 
 # The maximum request body size is currently 20MiB, let's be conservative
 # in case we want to lower it in the future.
-BATCH_SIZE_LIMIT = 5*1024*1024
+BATCH_SIZE_LIMIT = 5 * 1024 * 1024
 
 
 class Consumer(Thread):

--- a/posthog/consumer.py
+++ b/posthog/consumer.py
@@ -105,7 +105,7 @@ class Consumer(Thread):
                 item = queue.get(block=True, timeout=self.flush_interval - elapsed)
                 item_size = len(json.dumps(item, cls=DatetimeSerializer).encode())
                 if item_size > MAX_MSG_SIZE:
-                    self.log.error("Item exceeds 32kb limit, dropping. (%s)", str(item))
+                    self.log.error("Item exceeds 900kib limit, dropping. (%s)", str(item))
                     continue
                 items.append(item)
                 total_size += item_size

--- a/posthog/consumer.py
+++ b/posthog/consumer.py
@@ -12,11 +12,12 @@ try:
 except ImportError:
     from Queue import Empty
 
-MAX_MSG_SIZE = 32 << 10
 
-# Our servers only accept batches less than 500KB. Here limit is set slightly
-# lower to leave space for extra data that will be added later, eg. "sentAt".
-BATCH_SIZE_LIMIT = 475000
+MAX_MSG_SIZE = 900 * 1024  # 900KiB per event
+
+# The maximum request body size is currently 20MiB, let's be conservative
+# in case we want to lower it in the future.
+BATCH_SIZE_LIMIT = 5*1024*1024
 
 
 class Consumer(Thread):

--- a/posthog/test/test_consumer.py
+++ b/posthog/test/test_consumer.py
@@ -157,8 +157,8 @@ class TestConsumer(unittest.TestCase):
             res = mock.Mock()
             res.status_code = 200
             request_size = len(data.encode())
-            # Batches close after the first message bringing it bigger than BATCH_SIZE_LIMIT, let's add 5% of margin
-            self.assertTrue(request_size < (5 * 1024 * 1024) * 1.05, "batch size (%d) higher than limit" % request_size)
+            # Batches close after the first message bringing it bigger than BATCH_SIZE_LIMIT, let's add 10% of margin
+            self.assertTrue(request_size < (5 * 1024 * 1024) * 1.1, "batch size (%d) higher than limit" % request_size)
             return res
 
         with mock.patch("posthog.request._session.post", side_effect=mock_post_fn) as mock_post:

--- a/posthog/version.py
+++ b/posthog/version.py
@@ -1,4 +1,4 @@
-VERSION = "3.0.2"
+VERSION = "3.1.0"
 
 if __name__ == "__main__":
     print(VERSION, end="")  # noqa: T201

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ extras_require = {
         "flake8-print",
         "pre-commit",
     ],
-    "test": ["mock>=2.0.0", "freezegun==0.3.15", "pylint", "flake8", "coverage", "pytest"],
+    "test": ["mock>=2.0.0", "freezegun==0.3.15", "pylint", "flake8", "coverage", "pytest", "pytest-timeout"],
     "sentry": ["sentry-sdk", "django"],
 }
 


### PR DESCRIPTION
Our limits were too conservative, leading to legitimate events being dropped. Let's raise:
  - event size 32KB -> 900KiB (hard limit 1MiB)
  - batch size 500KB -> 5MiB (hard limit 20MiB)