### PR TITLE
Module functions to also return the same as its Client equivalent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.3.2 - 2024-01-19
+
+1. Return success/failure with all capture calls from module functions
+
+
 ## 3.3.1 - 2024-01-10
 
 1. Make sure we don't override any existing feature flag properties when adding locally evaluated feature flag properties.

--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -1,5 +1,5 @@
 import datetime  # noqa: F401
-from typing import Callable, Dict, Optional  # noqa: F401
+from typing import Callable, Dict, Optional, Tuple  # noqa: F401
 
 from posthog.client import Client
 from posthog.version import VERSION
@@ -33,7 +33,7 @@ def capture(
     send_feature_flags=False,
     disable_geoip=None,  # type: Optional[bool]
 ):
-    # type: (...) -> None
+     # type: (...) -> Tuple[bool, str]
     """
     Capture allows you to capture anything a user does within your system, which you can later use in PostHog to find patterns in usage, work out which features to improve or where people are giving up.
 
@@ -54,7 +54,7 @@ def capture(
     posthog.capture('distinct id', 'purchase', groups={'company': 'id:5'})
     ```
     """
-    _proxy(
+    return _proxy(
         "capture",
         distinct_id=distinct_id,
         event=event,
@@ -76,7 +76,7 @@ def identify(
     uuid=None,  # type: Optional[str]
     disable_geoip=None,  # type: Optional[bool]
 ):
-    # type: (...) -> None
+     # type: (...) -> Tuple[bool, str]
     """
     Identify lets you add metadata on your users so you can more easily identify who they are in PostHog, and even do things like segment users by these properties.
 
@@ -92,7 +92,7 @@ def identify(
     })
     ```
     """
-    _proxy(
+    return _proxy(
         "identify",
         distinct_id=distinct_id,
         properties=properties,
@@ -111,7 +111,7 @@ def set(
     uuid=None,  # type: Optional[str]
     disable_geoip=None,  # type: Optional[bool]
 ):
-    # type: (...) -> None
+     # type: (...) -> Tuple[bool, str]
     """
     Set properties on a user record.
     This will overwrite previous people property values, just like `identify`.
@@ -127,7 +127,7 @@ def set(
      })
      ```
     """
-    _proxy(
+    return _proxy(
         "set",
         distinct_id=distinct_id,
         properties=properties,
@@ -146,7 +146,7 @@ def set_once(
     uuid=None,  # type: Optional[str]
     disable_geoip=None,  # type: Optional[bool]
 ):
-    # type: (...) -> None
+     # type: (...) -> Tuple[bool, str]
     """
     Set properties on a user record, only if they do not yet exist.
     This will not overwrite previous people property values, unlike `identify`.
@@ -162,7 +162,7 @@ def set_once(
      })
      ```
     """
-    _proxy(
+    return _proxy(
         "set_once",
         distinct_id=distinct_id,
         properties=properties,
@@ -182,7 +182,7 @@ def group_identify(
     uuid=None,  # type: Optional[str]
     disable_geoip=None,  # type: Optional[bool]
 ):
-    # type: (...) -> None
+     # type: (...) -> Tuple[bool, str]
     """
     Set properties on a group
 
@@ -198,7 +198,7 @@ def group_identify(
      })
      ```
     """
-    _proxy(
+    return _proxy(
         "group_identify",
         group_type=group_type,
         group_key=group_key,
@@ -218,7 +218,7 @@ def alias(
     uuid=None,  # type: Optional[str]
     disable_geoip=None,  # type: Optional[bool]
 ):
-    # type: (...) -> None
+    # type: (...) -> Tuple[bool, str]
     """
     To marry up whatever a user does before they sign up or log in with what they do after you need to make an alias call. This will allow you to answer questions like "Which marketing channels leads to users churning after a month?" or "What do users do on our website before signing up?"
 
@@ -235,7 +235,7 @@ def alias(
     posthog.alias('anonymous session id', 'distinct id')
     ```
     """
-    _proxy(
+    return _proxy(
         "alias",
         previous_id=previous_id,
         distinct_id=distinct_id,

--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -33,7 +33,7 @@ def capture(
     send_feature_flags=False,
     disable_geoip=None,  # type: Optional[bool]
 ):
-     # type: (...) -> Tuple[bool, dict]
+    # type: (...) -> Tuple[bool, dict]
     """
     Capture allows you to capture anything a user does within your system, which you can later use in PostHog to find patterns in usage, work out which features to improve or where people are giving up.
 
@@ -76,7 +76,7 @@ def identify(
     uuid=None,  # type: Optional[str]
     disable_geoip=None,  # type: Optional[bool]
 ):
-     # type: (...) -> Tuple[bool, dict]
+    # type: (...) -> Tuple[bool, dict]
     """
     Identify lets you add metadata on your users so you can more easily identify who they are in PostHog, and even do things like segment users by these properties.
 
@@ -111,7 +111,7 @@ def set(
     uuid=None,  # type: Optional[str]
     disable_geoip=None,  # type: Optional[bool]
 ):
-     # type: (...) -> Tuple[bool, dict]
+    # type: (...) -> Tuple[bool, dict]
     """
     Set properties on a user record.
     This will overwrite previous people property values, just like `identify`.
@@ -146,7 +146,7 @@ def set_once(
     uuid=None,  # type: Optional[str]
     disable_geoip=None,  # type: Optional[bool]
 ):
-     # type: (...) -> Tuple[bool, dict]
+    # type: (...) -> Tuple[bool, dict]
     """
     Set properties on a user record, only if they do not yet exist.
     This will not overwrite previous people property values, unlike `identify`.
@@ -182,7 +182,7 @@ def group_identify(
     uuid=None,  # type: Optional[str]
     disable_geoip=None,  # type: Optional[bool]
 ):
-     # type: (...) -> Tuple[bool, dict]
+    # type: (...) -> Tuple[bool, dict]
     """
     Set properties on a group
 

--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -33,7 +33,7 @@ def capture(
     send_feature_flags=False,
     disable_geoip=None,  # type: Optional[bool]
 ):
-     # type: (...) -> Tuple[bool, str]
+     # type: (...) -> Tuple[bool, dict]
     """
     Capture allows you to capture anything a user does within your system, which you can later use in PostHog to find patterns in usage, work out which features to improve or where people are giving up.
 
@@ -76,7 +76,7 @@ def identify(
     uuid=None,  # type: Optional[str]
     disable_geoip=None,  # type: Optional[bool]
 ):
-     # type: (...) -> Tuple[bool, str]
+     # type: (...) -> Tuple[bool, dict]
     """
     Identify lets you add metadata on your users so you can more easily identify who they are in PostHog, and even do things like segment users by these properties.
 
@@ -111,7 +111,7 @@ def set(
     uuid=None,  # type: Optional[str]
     disable_geoip=None,  # type: Optional[bool]
 ):
-     # type: (...) -> Tuple[bool, str]
+     # type: (...) -> Tuple[bool, dict]
     """
     Set properties on a user record.
     This will overwrite previous people property values, just like `identify`.
@@ -146,7 +146,7 @@ def set_once(
     uuid=None,  # type: Optional[str]
     disable_geoip=None,  # type: Optional[bool]
 ):
-     # type: (...) -> Tuple[bool, str]
+     # type: (...) -> Tuple[bool, dict]
     """
     Set properties on a user record, only if they do not yet exist.
     This will not overwrite previous people property values, unlike `identify`.
@@ -182,7 +182,7 @@ def group_identify(
     uuid=None,  # type: Optional[str]
     disable_geoip=None,  # type: Optional[bool]
 ):
-     # type: (...) -> Tuple[bool, str]
+     # type: (...) -> Tuple[bool, dict]
     """
     Set properties on a group
 
@@ -218,7 +218,7 @@ def alias(
     uuid=None,  # type: Optional[str]
     disable_geoip=None,  # type: Optional[bool]
 ):
-    # type: (...) -> Tuple[bool, str]
+    # type: (...) -> Tuple[bool, dict]
     """
     To marry up whatever a user does before they sign up or log in with what they do after you need to make an alias call. This will allow you to answer questions like "Which marketing channels leads to users churning after a month?" or "What do users do on our website before signing up?"
 

--- a/posthog/test/test_module.py
+++ b/posthog/test/test_module.py
@@ -7,7 +7,6 @@ class TestModule(unittest.TestCase):
     posthog = None
 
     def _assert_enqueue_result(self, result):
-        print(result)
         self.assertEqual(type(result[0]), bool)
         self.assertEqual(type(result[1]), dict)
 

--- a/posthog/test/test_module.py
+++ b/posthog/test/test_module.py
@@ -6,6 +6,11 @@ from posthog import Posthog
 class TestModule(unittest.TestCase):
     posthog = None
 
+    def _assert_enqueue_result(self, result):
+        print(result)
+        self.assertEqual(type(result[0]), bool)
+        self.assertEqual(type(result[1]), dict)
+
     def failed(self):
         self.failed = True
 
@@ -22,15 +27,18 @@ class TestModule(unittest.TestCase):
         self.assertRaises(Exception, self.posthog.capture)
 
     def test_track(self):
-        self.posthog.capture("distinct_id", "python module event")
+        res = self.posthog.capture("distinct_id", "python module event")
+        self._assert_enqueue_result(res)
         self.posthog.flush()
 
     def test_identify(self):
-        self.posthog.identify("distinct_id", {"email": "user@email.com"})
+        res = self.posthog.identify("distinct_id", {"email": "user@email.com"})
+        self._assert_enqueue_result(res)
         self.posthog.flush()
 
     def test_alias(self):
-        self.posthog.alias("previousId", "distinct_id")
+        res = self.posthog.alias("previousId", "distinct_id")
+        self._assert_enqueue_result(res)
         self.posthog.flush()
 
     def test_page(self):

--- a/posthog/version.py
+++ b/posthog/version.py
@@ -1,4 +1,4 @@
-VERSION = "3.3.1"
+VERSION = "3.3.2"
 
 if __name__ == "__main__":
     print(VERSION, end="")  # noqa: T201


### PR DESCRIPTION
### This PR proposes the following:
Emulating the behavior of the Client by returning the result of the `Client.__enqueue()` method when called through `_proxy()` at the module level.

### Why:
This can be particularly useful to debug eventual issues when one is not using the client but the functions available at the module.