### PR TITLE
fix(flags): Update relative date op names

### DIFF
--- a/posthog/client.py
+++ b/posthog/client.py
@@ -756,7 +756,7 @@ class Client(object):
         return self.feature_flags
 
     def _add_local_person_and_group_properties(self, distinct_id, groups, person_properties, group_properties):
-        all_person_properties = {"$current_distinct_id": distinct_id, **(person_properties or {})}
+        all_person_properties = {"distinct_id": distinct_id, **(person_properties or {})}
 
         all_group_properties = {}
         if groups:

--- a/posthog/feature_flags.py
+++ b/posthog/feature_flags.py
@@ -175,11 +175,11 @@ def match_property(property, property_values) -> bool:
         else:
             return compare(str(override_value), str(value), operator)
 
-    if operator in ["is_date_before", "is_date_after", "is_relative_date_before", "is_relative_date_after"]:
+    if operator in ["is_date_before", "is_date_after"]:
         try:
-            if operator in ["is_relative_date_before", "is_relative_date_after"]:
-                parsed_date = relative_date_parse_for_feature_flag_matching(str(value))
-            else:
+            parsed_date = relative_date_parse_for_feature_flag_matching(str(value))
+
+            if not parsed_date:
                 parsed_date = parser.parse(str(value))
                 parsed_date = convert_to_datetime_aware(parsed_date)
         except Exception as e:
@@ -190,12 +190,12 @@ def match_property(property, property_values) -> bool:
 
         if isinstance(override_value, datetime.datetime):
             override_date = convert_to_datetime_aware(override_value)
-            if operator in ("is_date_before", "is_relative_date_before"):
+            if operator == "is_date_before":
                 return override_date < parsed_date
             else:
                 return override_date > parsed_date
         elif isinstance(override_value, datetime.date):
-            if operator in ("is_date_before", "is_relative_date_before"):
+            if operator == "is_date_before":
                 return override_value < parsed_date.date()
             else:
                 return override_value > parsed_date.date()
@@ -203,7 +203,7 @@ def match_property(property, property_values) -> bool:
             try:
                 override_date = parser.parse(override_value)
                 override_date = convert_to_datetime_aware(override_date)
-                if operator in ("is_date_before", "is_relative_date_before"):
+                if operator == "is_date_before":
                     return override_date < parsed_date
                 else:
                     return override_date > parsed_date

--- a/posthog/feature_flags.py
+++ b/posthog/feature_flags.py
@@ -302,7 +302,7 @@ def match_property_group(property_group, property_values, cohort_properties) -> 
 
 
 def relative_date_parse_for_feature_flag_matching(value: str) -> Optional[datetime.datetime]:
-    regex = r"^(?P<number>[0-9]+)(?P<interval>[a-z])$"
+    regex = r"^-?(?P<number>[0-9]+)(?P<interval>[a-z])$"
     match = re.search(regex, value)
     parsed_dt = datetime.datetime.now(datetime.timezone.utc)
     if match:

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -783,7 +783,7 @@ class TestClient(unittest.TestCase):
             timeout=10,
             distinct_id="some_id",
             groups={},
-            person_properties={"$current_distinct_id": "some_id"},
+            person_properties={"distinct_id": "some_id"},
             group_properties={},
             disable_geoip=True,
         )
@@ -795,7 +795,7 @@ class TestClient(unittest.TestCase):
             timeout=10,
             distinct_id="feature_enabled_distinct_id",
             groups={},
-            person_properties={"$current_distinct_id": "feature_enabled_distinct_id"},
+            person_properties={"distinct_id": "feature_enabled_distinct_id"},
             group_properties={},
             disable_geoip=True,
         )
@@ -807,7 +807,7 @@ class TestClient(unittest.TestCase):
             timeout=10,
             distinct_id="all_flags_payloads_id",
             groups={},
-            person_properties={"$current_distinct_id": "all_flags_payloads_id"},
+            person_properties={"distinct_id": "all_flags_payloads_id"},
             group_properties={},
             disable_geoip=False,
         )
@@ -843,7 +843,7 @@ class TestClient(unittest.TestCase):
             timeout=10,
             distinct_id="some_id",
             groups={"company": "id:5", "instance": "app.posthog.com"},
-            person_properties={"$current_distinct_id": "some_id", "x1": "y1"},
+            person_properties={"distinct_id": "some_id", "x1": "y1"},
             group_properties={
                 "company": {"$group_key": "id:5", "x": "y"},
                 "instance": {"$group_key": "app.posthog.com"},
@@ -856,7 +856,7 @@ class TestClient(unittest.TestCase):
             "random_key",
             "some_id",
             groups={"company": "id:5", "instance": "app.posthog.com"},
-            person_properties={"$current_distinct_id": "override"},
+            person_properties={"distinct_id": "override"},
             group_properties={
                 "company": {
                     "$group_key": "group_override",
@@ -869,7 +869,7 @@ class TestClient(unittest.TestCase):
             timeout=10,
             distinct_id="some_id",
             groups={"company": "id:5", "instance": "app.posthog.com"},
-            person_properties={"$current_distinct_id": "override"},
+            person_properties={"distinct_id": "override"},
             group_properties={
                 "company": {"$group_key": "group_override"},
                 "instance": {"$group_key": "app.posthog.com"},
@@ -886,7 +886,7 @@ class TestClient(unittest.TestCase):
             timeout=10,
             distinct_id="some_id",
             groups={},
-            person_properties={"$current_distinct_id": "some_id"},
+            person_properties={"distinct_id": "some_id"},
             group_properties={},
             disable_geoip=False,
         )

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -1873,7 +1873,7 @@ class TestMatchProperties(unittest.TestCase):
 
     @freeze_time("2022-05-01")
     def test_match_property_relative_date_operators(self):
-        property_a = self.property(key="key", value="6h", operator="is_date_before")
+        property_a = self.property(key="key", value="-6h", operator="is_date_before")
         self.assertTrue(match_property(property_a, {"key": "2022-03-01"}))
         self.assertTrue(match_property(property_a, {"key": "2022-04-30"}))
         self.assertTrue(match_property(property_a, {"key": datetime.datetime(2022, 4, 30, 1, 2, 3)}))
@@ -1915,8 +1915,8 @@ class TestMatchProperties(unittest.TestCase):
         with self.assertRaises(InconclusiveMatchError):
             self.assertFalse(match_property(property_c, {"key": 1}))
 
-        with self.assertRaises(InconclusiveMatchError):
-            self.assertFalse(match_property(property_c, {"key": "2022-05-30"}))
+        # parsed as 1234-05-01 for some reason?
+        self.assertTrue(match_property(property_c, {"key": "2022-05-30"}))
 
         # # Timezone aware property
         property_d = self.property(key="key", value="12d", operator="is_date_before")
@@ -1933,7 +1933,7 @@ class TestMatchProperties(unittest.TestCase):
         self.assertFalse(match_property(property_e, {"key": "2022-05-01 00:00:00"}))
         self.assertTrue(match_property(property_e, {"key": "2022-04-30 22:00:00"}))
 
-        property_f = self.property(key="key", value="1d", operator="is_date_before")
+        property_f = self.property(key="key", value="-1d", operator="is_date_before")
         self.assertTrue(match_property(property_f, {"key": "2022-04-29 23:59:00"}))
         self.assertFalse(match_property(property_f, {"key": "2022-04-30 00:00:01"}))
 
@@ -1959,7 +1959,7 @@ class TestMatchProperties(unittest.TestCase):
         self.assertTrue(match_property(property_k, {"key": "2022-04-29 00:00:01"}))
         self.assertFalse(match_property(property_k, {"key": "2022-04-29 00:00:00"}))
 
-        property_l = self.property(key="key", value="02w", operator="is_date_after")
+        property_l = self.property(key="key", value="-02w", operator="is_date_after")
         self.assertTrue(match_property(property_l, {"key": "2022-05-01 00:00:00"}))
         self.assertFalse(match_property(property_l, {"key": "2022-04-16 00:00:00"}))
 

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -1873,7 +1873,7 @@ class TestMatchProperties(unittest.TestCase):
 
     @freeze_time("2022-05-01")
     def test_match_property_relative_date_operators(self):
-        property_a = self.property(key="key", value="6h", operator="is_relative_date_before")
+        property_a = self.property(key="key", value="6h", operator="is_date_before")
         self.assertTrue(match_property(property_a, {"key": "2022-03-01"}))
         self.assertTrue(match_property(property_a, {"key": "2022-04-30"}))
         self.assertTrue(match_property(property_a, {"key": datetime.datetime(2022, 4, 30, 1, 2, 3)}))
@@ -1898,7 +1898,7 @@ class TestMatchProperties(unittest.TestCase):
         with self.assertRaises(InconclusiveMatchError):
             match_property(property_a, {"key": "abcdef"})
 
-        property_b = self.property(key="key", value="1h", operator="is_relative_date_after")
+        property_b = self.property(key="key", value="1h", operator="is_date_after")
         self.assertTrue(match_property(property_b, {"key": "2022-05-02"}))
         self.assertTrue(match_property(property_b, {"key": "2022-05-30"}))
         self.assertTrue(match_property(property_b, {"key": datetime.datetime(2022, 5, 30)}))
@@ -1910,7 +1910,7 @@ class TestMatchProperties(unittest.TestCase):
             self.assertFalse(match_property(property_b, {"key": "abcdef"}))
 
         # Invalid flag property
-        property_c = self.property(key="key", value=1234, operator="is_relative_date_after")
+        property_c = self.property(key="key", value=1234, operator="is_date_after")
 
         with self.assertRaises(InconclusiveMatchError):
             self.assertFalse(match_property(property_c, {"key": 1}))
@@ -1919,7 +1919,7 @@ class TestMatchProperties(unittest.TestCase):
             self.assertFalse(match_property(property_c, {"key": "2022-05-30"}))
 
         # # Timezone aware property
-        property_d = self.property(key="key", value="12d", operator="is_relative_date_before")
+        property_d = self.property(key="key", value="12d", operator="is_date_before")
         self.assertFalse(match_property(property_d, {"key": "2022-05-30"}))
 
         self.assertTrue(match_property(property_d, {"key": "2022-03-30"}))
@@ -1929,45 +1929,45 @@ class TestMatchProperties(unittest.TestCase):
         self.assertFalse(match_property(property_d, {"key": "2022-04-19 02:00:01+02:00"}))
 
         # Try all possible relative dates
-        property_e = self.property(key="key", value="1h", operator="is_relative_date_before")
+        property_e = self.property(key="key", value="1h", operator="is_date_before")
         self.assertFalse(match_property(property_e, {"key": "2022-05-01 00:00:00"}))
         self.assertTrue(match_property(property_e, {"key": "2022-04-30 22:00:00"}))
 
-        property_f = self.property(key="key", value="1d", operator="is_relative_date_before")
+        property_f = self.property(key="key", value="1d", operator="is_date_before")
         self.assertTrue(match_property(property_f, {"key": "2022-04-29 23:59:00"}))
         self.assertFalse(match_property(property_f, {"key": "2022-04-30 00:00:01"}))
 
-        property_g = self.property(key="key", value="1w", operator="is_relative_date_before")
+        property_g = self.property(key="key", value="1w", operator="is_date_before")
         self.assertTrue(match_property(property_g, {"key": "2022-04-23 00:00:00"}))
         self.assertFalse(match_property(property_g, {"key": "2022-04-24 00:00:00"}))
         self.assertFalse(match_property(property_g, {"key": "2022-04-24 00:00:01"}))
 
-        property_h = self.property(key="key", value="1m", operator="is_relative_date_before")
+        property_h = self.property(key="key", value="1m", operator="is_date_before")
         self.assertTrue(match_property(property_h, {"key": "2022-03-01 00:00:00"}))
         self.assertFalse(match_property(property_h, {"key": "2022-04-05 00:00:00"}))
 
-        property_i = self.property(key="key", value="1y", operator="is_relative_date_before")
+        property_i = self.property(key="key", value="1y", operator="is_date_before")
         self.assertTrue(match_property(property_i, {"key": "2021-04-28 00:00:00"}))
         self.assertFalse(match_property(property_i, {"key": "2021-05-01 00:00:01"}))
 
-        property_j = self.property(key="key", value="122h", operator="is_relative_date_after")
+        property_j = self.property(key="key", value="122h", operator="is_date_after")
         self.assertTrue(match_property(property_j, {"key": "2022-05-01 00:00:00"}))
         self.assertFalse(match_property(property_j, {"key": "2022-04-23 01:00:00"}))
 
-        property_k = self.property(key="key", value="2d", operator="is_relative_date_after")
+        property_k = self.property(key="key", value="2d", operator="is_date_after")
         self.assertTrue(match_property(property_k, {"key": "2022-05-01 00:00:00"}))
         self.assertTrue(match_property(property_k, {"key": "2022-04-29 00:00:01"}))
         self.assertFalse(match_property(property_k, {"key": "2022-04-29 00:00:00"}))
 
-        property_l = self.property(key="key", value="02w", operator="is_relative_date_after")
+        property_l = self.property(key="key", value="02w", operator="is_date_after")
         self.assertTrue(match_property(property_l, {"key": "2022-05-01 00:00:00"}))
         self.assertFalse(match_property(property_l, {"key": "2022-04-16 00:00:00"}))
 
-        property_m = self.property(key="key", value="1m", operator="is_relative_date_after")
+        property_m = self.property(key="key", value="1m", operator="is_date_after")
         self.assertTrue(match_property(property_m, {"key": "2022-04-01 00:00:01"}))
         self.assertFalse(match_property(property_m, {"key": "2022-04-01 00:00:00"}))
 
-        property_n = self.property(key="key", value="1y", operator="is_relative_date_after")
+        property_n = self.property(key="key", value="1y", operator="is_date_after")
         self.assertTrue(match_property(property_n, {"key": "2022-05-01 00:00:00"}))
         self.assertTrue(match_property(property_n, {"key": "2021-05-01 00:00:01"}))
         self.assertFalse(match_property(property_n, {"key": "2021-05-01 00:00:00"}))


### PR DESCRIPTION
Allow -ve sign in relative dates, combine with regular date operator, and rename $current_distinct_id to distinct_id