### PR TITLE
Add historical_migration option to toplevel Client

### DIFF
--- a/posthog/client.py
+++ b/posthog/client.py
@@ -49,6 +49,7 @@ class Client(object):
         project_api_key=None,
         disabled=False,
         disable_geoip=True,
+        historical_migration=False,
     ):
         self.queue = queue.Queue(max_queue_size)
 
@@ -73,6 +74,7 @@ class Client(object):
         self.distinct_ids_feature_flags_reported = SizeLimitedDict(MAX_DICT_SIZE, set)
         self.disabled = disabled
         self.disable_geoip = disable_geoip
+        self.historical_migration = historical_migration
 
         # personal_api_key: This should be a generated Personal API Key, private
         self.personal_api_key = personal_api_key
@@ -107,6 +109,7 @@ class Client(object):
                     gzip=gzip,
                     retries=max_retries,
                     timeout=timeout,
+                    historical_migration=historical_migration,
                 )
                 self.consumers.append(consumer)
 
@@ -374,7 +377,14 @@ class Client(object):
 
         if self.sync_mode:
             self.log.debug("enqueued with blocking %s.", msg["event"])
-            batch_post(self.api_key, self.host, gzip=self.gzip, timeout=self.timeout, batch=[msg])
+            batch_post(
+                self.api_key,
+                self.host,
+                gzip=self.gzip,
+                timeout=self.timeout,
+                batch=[msg],
+                historical_migration=self.historical_migration,
+            )
 
             return True, msg
 

--- a/posthog/consumer.py
+++ b/posthog/consumer.py
@@ -36,6 +36,7 @@ class Consumer(Thread):
         gzip=False,
         retries=10,
         timeout=15,
+        historical_migration=False,
     ):
         """Create a consumer thread."""
         Thread.__init__(self)
@@ -55,6 +56,7 @@ class Consumer(Thread):
         self.running = True
         self.retries = retries
         self.timeout = timeout
+        self.historical_migration = historical_migration
 
     def run(self):
         """Runs the consumer."""
@@ -134,6 +136,13 @@ class Consumer(Thread):
 
         @backoff.on_exception(backoff.expo, Exception, max_tries=self.retries + 1, giveup=fatal_exception)
         def send_request():
-            batch_post(self.api_key, self.host, gzip=self.gzip, timeout=self.timeout, batch=batch)
+            batch_post(
+                self.api_key,
+                self.host,
+                gzip=self.gzip,
+                timeout=self.timeout,
+                batch=batch,
+                historical_migration=self.historical_migration,
+            )
 
         send_request()


### PR DESCRIPTION
[`**kwargs` is turned into `body` and just JSON serialized](https://github.com/PostHog/posthog-python/blob/ba7a77c21b5f5a15241bf3e7cf518c41601fd318/posthog/request.py#L39-L44). That's how `batch` even gets into the body, which is a sibling to `historical_migration` as we'd expect.

The idea is we'd just pass `historical_migration=True` in the migration script here: https://github.com/PostHog/posthog-migration-tools/blob/ae2429c58bff15801eeace078b259ba2dfc9b9fd/migrate.py#L172