### PR TITLE
Fix for Case Sensitivity Issue in Python Library When Retrieving Feature Flag Payload

### DIFF
--- a/posthog/client.py
+++ b/posthog/client.py
@@ -670,7 +670,7 @@ class Client(object):
             decide_payloads = self.get_feature_payloads(
                 distinct_id, groups, person_properties, group_properties, disable_geoip
             )
-            response = decide_payloads.get(str(key).lower(), None)
+            response = decide_payloads.get(str(key), None)
 
         return response
 


### PR DESCRIPTION
When trying to retrieve the feature flag payload, it is not possible to do so using uppercase characters because the code always converts the provided feature flag key to lowercase.

This issue occurs only in the Python library. I tried retrieving the payload using other languages, and it works normally.