### PR TITLE
fix(feature flags): Guard for None values when comparing person Properties

### DIFF
--- a/posthog/feature_flags.py
+++ b/posthog/feature_flags.py
@@ -13,7 +13,8 @@ __LONG_SCALE__ = float(0xFFFFFFFFFFFFFFF)
 
 log = logging.getLogger("posthog")
 
-NONE_VALUES_ALLOWED_OPERATORS = ['is_not']
+NONE_VALUES_ALLOWED_OPERATORS = ["is_not"]
+
 
 class InconclusiveMatchError(Exception):
     pass

--- a/posthog/feature_flags.py
+++ b/posthog/feature_flags.py
@@ -13,6 +13,7 @@ __LONG_SCALE__ = float(0xFFFFFFFFFFFFFFF)
 
 log = logging.getLogger("posthog")
 
+NONE_VALUES_ALLOWED_OPERATORS = ['is_not']
 
 class InconclusiveMatchError(Exception):
     pass
@@ -118,6 +119,9 @@ def match_property(property, property_values) -> bool:
         raise InconclusiveMatchError("can't match properties with operator is_not_set")
 
     override_value = property_values[key]
+
+    if (operator not in NONE_VALUES_ALLOWED_OPERATORS) and override_value is None:
+        return False
 
     if operator in ("exact", "is_not"):
 

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -962,6 +962,76 @@ class TestLocalEvaluation(unittest.TestCase):
 
     @mock.patch("posthog.client.decide")
     @mock.patch("posthog.client.get")
+    def test_feature_flags_local_evaluation_None_values(self, patch_get, patch_decide):
+        client = Client(FAKE_TEST_API_KEY, personal_api_key=FAKE_TEST_API_KEY)
+        client.feature_flags = [
+            {
+                id: 1,
+                "name": 'Beta Feature',
+                "key": 'beta-feature',
+                "is_simple_flag": True,
+                "active": True,
+                "filters": {
+                    "groups": [
+                        {
+                            "variant": None,
+                            "properties": [
+                                {
+                                    "key": "latestBuildVersion",
+                                    "type": "person",
+                                    "value": ".+",
+                                    "operator": "regex"
+                                },
+                                {
+                                    "key": "latestBuildVersionMajor",
+                                    "type": "person",
+                                    "value": "23",
+                                    "operator": "gt"
+                                },
+                                {
+                                    "key": "latestBuildVersionMinor",
+                                    "type": "person",
+                                    "value": "31",
+                                    "operator": "gt"
+                                },
+                                {
+                                    "key": "latestBuildVersionPatch",
+                                    "type": "person",
+                                    "value": "0",
+                                    "operator": "gt"
+                                }
+                            ],
+                            "rollout_percentage": 100
+                        }
+                    ],
+                },
+            },
+        ]
+
+        feature_flag_match = client.get_feature_flag(
+            "beta-feature", "some-distinct-id", person_properties={
+                "latestBuildVersion": None,
+                "latestBuildVersionMajor": None,
+                "latestBuildVersionMinor": None,
+                "latestBuildVersionPatch": None,
+            }
+        )
+
+        self.assertEqual(feature_flag_match, False)
+        self.assertEqual(patch_decide.call_count, 0)
+        self.assertEqual(patch_get.call_count, 0)
+
+        feature_flag_match = client.get_feature_flag(
+            "beta-feature", "some-distinct-id", person_properties={
+                "latestBuildVersion": "24.32..1",
+                "latestBuildVersionMajor": "24",
+                "latestBuildVersionMinor": "32",
+                "latestBuildVersionPatch": "1",
+            }
+        )
+
+    @mock.patch("posthog.client.decide")
+    @mock.patch("posthog.client.get")
     def test_feature_flags_local_evaluation_for_cohorts(self, patch_get, patch_decide):
         client = Client(FAKE_TEST_API_KEY, personal_api_key=FAKE_TEST_API_KEY)
         client.feature_flags = [
@@ -1714,7 +1784,7 @@ class TestMatchProperties(unittest.TestCase):
         self.assertTrue(match_property(property_a, {"key": "value"}))
         self.assertTrue(match_property(property_a, {"key": "value2"}))
         self.assertTrue(match_property(property_a, {"key": ""}))
-        self.assertTrue(match_property(property_a, {"key": None}))
+        self.assertFalse(match_property(property_a, {"key": None}))
 
         with self.assertRaises(InconclusiveMatchError):
             match_property(property_a, {"key2": "value"})
@@ -1980,20 +2050,20 @@ class TestMatchProperties(unittest.TestCase):
         self.assertTrue(match_property(property_a, {"key": "non"}))
 
         property_b = self.property(key="key", value=None, operator="is_set")
-        self.assertTrue(match_property(property_b, {"key": None}))
+        self.assertFalse(match_property(property_b, {"key": None}))
 
         property_c = self.property(key="key", value="no", operator="icontains")
-        self.assertTrue(match_property(property_c, {"key": None}))
+        self.assertFalse(match_property(property_c, {"key": None}))
         self.assertFalse(match_property(property_c, {"key": "smh"}))
 
         property_d = self.property(key="key", value="No", operator="regex")
-        self.assertTrue(match_property(property_d, {"key": None}))
+        self.assertFalse(match_property(property_d, {"key": None}))
 
         property_d_lower_case = self.property(key="key", value="no", operator="regex")
         self.assertFalse(match_property(property_d_lower_case, {"key": None}))
 
         property_e = self.property(key="key", value=1, operator="gt")
-        self.assertTrue(match_property(property_e, {"key": None}))
+        self.assertFalse(match_property(property_e, {"key": None}))
 
         property_f = self.property(key="key", value=1, operator="lt")
         self.assertFalse(match_property(property_f, {"key": None}))
@@ -2002,15 +2072,13 @@ class TestMatchProperties(unittest.TestCase):
         self.assertFalse(match_property(property_g, {"key": None}))
 
         property_h = self.property(key="key", value="Oo", operator="lte")
-        self.assertTrue(match_property(property_h, {"key": None}))
+        self.assertFalse(match_property(property_h, {"key": None}))
 
         property_i = self.property(key="key", value="2022-05-01", operator="is_date_before")
-        with self.assertRaises(InconclusiveMatchError):
-            self.assertFalse(match_property(property_i, {"key": None}))
+        self.assertFalse(match_property(property_i, {"key": None}))
 
         property_j = self.property(key="key", value="2022-05-01", operator="is_date_after")
-        with self.assertRaises(InconclusiveMatchError):
-            self.assertFalse(match_property(property_j, {"key": None}))
+        self.assertFalse(match_property(property_j, {"key": None}))
 
         property_k = self.property(key="key", value="2022-05-01", operator="is_date_before")
         with self.assertRaises(InconclusiveMatchError):

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -967,8 +967,8 @@ class TestLocalEvaluation(unittest.TestCase):
         client.feature_flags = [
             {
                 id: 1,
-                "name": 'Beta Feature',
-                "key": 'beta-feature',
+                "name": "Beta Feature",
+                "key": "beta-feature",
                 "is_simple_flag": True,
                 "active": True,
                 "filters": {
@@ -976,32 +976,12 @@ class TestLocalEvaluation(unittest.TestCase):
                         {
                             "variant": None,
                             "properties": [
-                                {
-                                    "key": "latestBuildVersion",
-                                    "type": "person",
-                                    "value": ".+",
-                                    "operator": "regex"
-                                },
-                                {
-                                    "key": "latestBuildVersionMajor",
-                                    "type": "person",
-                                    "value": "23",
-                                    "operator": "gt"
-                                },
-                                {
-                                    "key": "latestBuildVersionMinor",
-                                    "type": "person",
-                                    "value": "31",
-                                    "operator": "gt"
-                                },
-                                {
-                                    "key": "latestBuildVersionPatch",
-                                    "type": "person",
-                                    "value": "0",
-                                    "operator": "gt"
-                                }
+                                {"key": "latestBuildVersion", "type": "person", "value": ".+", "operator": "regex"},
+                                {"key": "latestBuildVersionMajor", "type": "person", "value": "23", "operator": "gt"},
+                                {"key": "latestBuildVersionMinor", "type": "person", "value": "31", "operator": "gt"},
+                                {"key": "latestBuildVersionPatch", "type": "person", "value": "0", "operator": "gt"},
                             ],
-                            "rollout_percentage": 100
+                            "rollout_percentage": 100,
                         }
                     ],
                 },
@@ -1009,12 +989,14 @@ class TestLocalEvaluation(unittest.TestCase):
         ]
 
         feature_flag_match = client.get_feature_flag(
-            "beta-feature", "some-distinct-id", person_properties={
+            "beta-feature",
+            "some-distinct-id",
+            person_properties={
                 "latestBuildVersion": None,
                 "latestBuildVersionMajor": None,
                 "latestBuildVersionMinor": None,
                 "latestBuildVersionPatch": None,
-            }
+            },
         )
 
         self.assertEqual(feature_flag_match, False)
@@ -1022,12 +1004,14 @@ class TestLocalEvaluation(unittest.TestCase):
         self.assertEqual(patch_get.call_count, 0)
 
         feature_flag_match = client.get_feature_flag(
-            "beta-feature", "some-distinct-id", person_properties={
+            "beta-feature",
+            "some-distinct-id",
+            person_properties={
                 "latestBuildVersion": "24.32..1",
                 "latestBuildVersionMajor": "24",
                 "latestBuildVersionMinor": "32",
                 "latestBuildVersionPatch": "1",
-            }
+            },
         )
 
     @mock.patch("posthog.client.decide")


### PR DESCRIPTION

## Problem

Porting over the fix from `posthog-node` to `posthog-python` : https://github.com/PostHog/posthog-js-lite/pull/249

The current behavior of stringifying `None` values to compare with operators can lead to invalid results in local evaluation. 

This causes local evaluation to return `true`, while the `/decide` API does the right thing and returns false for `undefined` values in these properties.  

Customer reported that local evaluation always evaluates a condition to true, when it should evaluate to false. 
The conditions in question are : 

``` json
[
    {
        "key": "latestBuildVersion",
        "type": "person",
        "value": ".+",
        "operator": "regex"
    },
    {
        "key": "latestBuildVersionMajor",
        "type": "person",
        "value": "23",
        "operator": "gt"
    },
    {
        "key": "latestBuildVersionMinor",
        "type": "person",
        "value": "31",
        "operator": "gt"
    },
    {
        "key": "latestBuildVersionPatch",
        "type": "person",
        "value": "0",
        "operator": "gt"
    }
]
```

And the person properties passed into local evaluation are : 

``` python
{
    "personProperties": {
        "latestBuildVersion": None,
        "latestBuildVersionMajor": None,
        "latestBuildVersionMinor": None,
        "latestBuildVersionPatch": None
    }
}
```

Since we stringify all of the `None` values, the above call returns `true` when it should return `false` because the property values are undefined and not the string `None`. 




## Changes

Add a `NONE_VALUES_ALLOWED_OPERATORS` array of operators that allow NONE values which is just `is_not` right now . Any other operator will fail if the overrideValue is `NONE`

