### PR TITLE
fix(setup): Make sure all packages are bundled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.6.2 - 2024-09-03
+
+1. Make sure setup.py discovers the new exception integration package.
+
 ## 3.6.1 - 2024-09-03
 
 1. Adds django integration to exception autocapture in alpha state. This feature is not yet stable and may change in future versions.

--- a/posthog/version.py
+++ b/posthog/version.py
@@ -1,4 +1,4 @@
-VERSION = "3.6.1"
+VERSION = "3.6.2"
 
 if __name__ == "__main__":
     print(VERSION, end="")  # noqa: T201

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     maintainer="PostHog",
     maintainer_email="hey@posthog.com",
     test_suite="posthog.test.all",
-    packages=["posthog", "posthog.test", "posthog.sentry"],
+    packages=["posthog", "posthog.test", "posthog.sentry", "posthog.exception_integrations"],
     license="MIT License",
     install_requires=install_requires,
     extras_require=extras_require,


### PR DESCRIPTION
I want to replace this with `find_packages()` so it doesn't happen again, but ugh backwards compatibility