### PR TITLE
feat: add super properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.7.0 - 2024-10-03
+
+1. Adds a new `super_properties` parameter on the client that are appended to every /capture call.
+
 ## 3.6.7 - 2024-09-24
 
 1. Remove deprecated datetime.utcnow() in favour of datetime.now(tz=tzutc())
@@ -66,7 +70,6 @@
 
 1. Return success/failure with all capture calls from module functions
 
-
 ## 3.3.1 - 2024-01-10
 
 1. Make sure we don't override any existing feature flag properties when adding locally evaluated feature flag properties.
@@ -92,6 +95,7 @@
 
 1. Restore how feature flags work when the client library is disabled: All requests return `None` and no events are sent when the client is disabled.
 2. Add a `feature_flag_definitions()` debug option, which returns currently loaded feature flag definitions. You can use this to more cleverly decide when to request local evaluation of feature flags.
+
 ## 3.0.0 - 2023-04-14
 
 Breaking change:
@@ -132,7 +136,6 @@ posthog = Posthog('api_key', disable_geoip=False)
 1. Log instead of raise error on posthog personal api key errors
 2. Remove upper bound on backoff dependency
 
-
 ## 2.3.0 - 2023-01-31
 
 1. Add support for returning payloads of matched feature flags
@@ -148,6 +151,7 @@ Changes:
 Changes:
 
 1. Fixes issues with date comparison.
+
 ## 2.1.1 - 2022-09-14
 
 Changes:
@@ -160,6 +164,7 @@ Changes:
 
 1. Feature flag defaults have been removed
 2. Setup logging only when debug mode is enabled.
+
 ## 2.0.1 - 2022-08-04
 
 - Make poll_interval configurable
@@ -172,7 +177,7 @@ Breaking changes:
 
 1. The minimum version requirement for PostHog servers is now 1.38. If you're using PostHog Cloud, you satisfy this requirement automatically.
 2. Feature flag defaults apply only when there's an error fetching feature flag results. Earlier, if the default was set to `True`, even if a flag resolved to `False`, the default would override this.
-**Note: These are removed in 2.0.2**
+   **Note: These are removed in 2.0.2**
 3. Feature flag remote evaluation doesn't require a personal API key.
 
 New Changes:
@@ -180,18 +185,20 @@ New Changes:
 1. You can now evaluate feature flags locally (i.e. without sending a request to your PostHog servers) by setting a personal API key, and passing in groups and person properties to `is_feature_enabled` and `get_feature_flag` calls.
 2. Introduces a `get_all_flags` method that returns all feature flags. This is useful for when you want to seed your frontend with some initial flags, given a user ID.
 
-
-
 ## 1.4.9 - 2022-06-13
+
 - Support for sending feature flags with capture calls
 
 ## 1.4.8 - 2022-05-12
+
 - Support multi variate feature flags
 
 ## 1.4.7 - 2022-04-25
+
 - Allow feature flags usage without project_api_key
 
 ## 1.4.1 - 2021-05-28
+
 - Fix packaging issues with Sentry integrations
 
 ## 1.4.0 - 2021-05-18

--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -20,6 +20,7 @@ project_api_key = None  # type: Optional[str]
 poll_interval = 30  # type: int
 disable_geoip = True  # type: bool
 feature_flags_request_timeout_seconds = 3  # type: int
+super_properties = None  # type: Optional[Dict]
 # Currently alpha, use at your own risk
 enable_exception_autocapture = False  # type: bool
 exception_autocapture_integrations = []  # type: List[Integrations]
@@ -504,6 +505,7 @@ def _proxy(method, *args, **kwargs):
             disabled=disabled,
             disable_geoip=disable_geoip,
             feature_flags_request_timeout_seconds=feature_flags_request_timeout_seconds,
+            super_properties=super_properties,
             # TODO: Currently this monitoring begins only when the Client is initialised (which happens when you do something with the SDK)
             # This kind of initialisation is very annoying for exception capture. We need to figure out a way around this,
             # or deprecate this proxy option fully (it's already in the process of deprecation, no new clients should be using this method since like 5-6 months)

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -213,9 +213,6 @@ class Client(object):
         require("properties", properties, dict)
         require("event", event, string_types)
 
-        if self.super_properties:
-            properties = {**properties, **self.super_properties}
-
         msg = {
             "properties": properties,
             "timestamp": timestamp,
@@ -447,6 +444,9 @@ class Client(object):
 
         if disable_geoip:
             msg["properties"]["$geoip_disable"] = True
+
+        if self.super_properties:
+            msg["properties"] = {**msg["properties"], **self.super_properties}
 
         msg["distinct_id"] = stringify_id(msg.get("distinct_id", None))
 

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -55,6 +55,7 @@ class Client(object):
         disable_geoip=True,
         historical_migration=False,
         feature_flags_request_timeout_seconds=3,
+        super_properties=None,
         enable_exception_autocapture=False,
         exception_autocapture_integrations=None,
         project_root=None,
@@ -86,6 +87,7 @@ class Client(object):
         self.disabled = disabled
         self.disable_geoip = disable_geoip
         self.historical_migration = historical_migration
+        self.super_properties = super_properties
         self.enable_exception_autocapture = enable_exception_autocapture
         self.exception_autocapture_integrations = exception_autocapture_integrations
         self.exception_capture = None
@@ -210,6 +212,9 @@ class Client(object):
         require("distinct_id", distinct_id, ID_TYPES)
         require("properties", properties, dict)
         require("event", event, string_types)
+
+        if self.super_properties:
+            properties = {**properties, **self.super_properties}
 
         msg = {
             "properties": properties,

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -85,7 +85,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(msg["properties"]["$lib_version"], VERSION)
 
     def test_basic_capture_with_super_properties(self):
-        client = Client(FAKE_TEST_API_KEY, super_properties={'source': 'repo-name', 'environment': 'test'})
+        client = Client(FAKE_TEST_API_KEY, super_properties={"source": "repo-name", "environment": "test"})
 
         _, msg = client.capture("distinct_id", "python test event")
         client.flush()

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -84,15 +84,20 @@ class TestClient(unittest.TestCase):
         self.assertEqual(msg["properties"]["$lib"], "posthog-python")
         self.assertEqual(msg["properties"]["$lib_version"], VERSION)
 
-    def test_basic_capture_with_super_properties(self):
-        client = Client(FAKE_TEST_API_KEY, super_properties={"source": "repo-name", "environment": "test"})
+    def test_basic_super_properties(self):
+        client = Client(FAKE_TEST_API_KEY, super_properties={"source": "repo-name"})
 
         _, msg = client.capture("distinct_id", "python test event")
         client.flush()
 
         self.assertEqual(msg["event"], "python test event")
         self.assertEqual(msg["properties"]["source"], "repo-name")
-        self.assertEqual(msg["properties"]["environment"], "test")
+
+        _, msg = client.identify("distinct_id", {"trait": "value"})
+        client.flush()
+
+        self.assertEqual(msg["$set"]["trait"], "value")
+        self.assertEqual(msg["properties"]["source"], "repo-name")
 
     def test_basic_capture_exception(self):
 

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -84,6 +84,16 @@ class TestClient(unittest.TestCase):
         self.assertEqual(msg["properties"]["$lib"], "posthog-python")
         self.assertEqual(msg["properties"]["$lib_version"], VERSION)
 
+    def test_basic_capture_with_super_properties(self):
+        client = Client(FAKE_TEST_API_KEY, super_properties={'source': 'repo-name', 'environment': 'test'})
+
+        _, msg = client.capture("distinct_id", "python test event")
+        client.flush()
+
+        self.assertEqual(msg["event"], "python test event")
+        self.assertEqual(msg["properties"]["source"], "repo-name")
+        self.assertEqual(msg["properties"]["environment"], "test")
+
     def test_basic_capture_exception(self):
 
         with mock.patch.object(Client, "capture", return_value=None) as patch_capture:

--- a/posthog/version.py
+++ b/posthog/version.py
@@ -1,4 +1,4 @@
-VERSION = "3.6.7"
+VERSION = "3.7.0"
 
 if __name__ == "__main__":
     print(VERSION, end="")  # noqa: T201


### PR DESCRIPTION
### Problem

Customers of error tracking want to know what repository a particular exception came from by filtering in the UI. Rather than adding some specific property (e.g. `exception_source_identifier`) that would then need to be added to the JS SDK and any other language we support in future, I thought it would be easier to reuse the super properties concept found in our other SDKs 

I'm not tied to this approach but "PRs > Slack" and all that... Open to feedback here.

### Changes

- Went with a very basic implementation that allows you to set `super_properties` when initialising the client
  - Could have gone with the `register` method seen elsewhere but didn't want to mislead customers into thinking that properties were somehow stored elsewhere (like they are in local storage). Better to make sure that they're always included when the client is initialised
