### PR TITLE
fix(flags): correctly emit feature flag events with the FF response on `get_feature_flag_payload` calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.7.3 - 2024-11-22
 
-Fix bug where this SDK incorrectly sent feature flag events with null values when calling `get_feature_flag_payload`, even though the actual payload is successfully retrieved and returned to the user.
+1. Fix bug where this SDK incorrectly sent feature flag events with null values when calling `get_feature_flag_payload`.
 
 ## 3.7.2 - 2024-11-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.7.3 - 2024-11-22
+
+Fix bug where this SDK incorrectly sent feature flag events with null values when calling `get_feature_flag_payload`, even though the actual payload is successfully retrieved and returned to the user.
+
 ## 3.7.2 - 2024-11-19
 
 1. Add `type` property to exception stacks.

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -1,6 +1,5 @@
 import atexit
 import logging
-from mailbox import NotEmptyError
 import numbers
 import sys
 from datetime import datetime, timedelta

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -1,5 +1,6 @@
 import atexit
 import logging
+from mailbox import NotEmptyError
 import numbers
 import sys
 from datetime import datetime, timedelta
@@ -160,6 +161,15 @@ class Client(object):
     ):
         resp_data = self.get_decide(distinct_id, groups, person_properties, group_properties, disable_geoip)
         return resp_data["featureFlagPayloads"]
+
+    def get_feature_flags_and_payloads(
+        self, distinct_id, groups=None, person_properties=None, group_properties=None, disable_geoip=None
+    ):
+        resp_data = self.get_decide(distinct_id, groups, person_properties, group_properties, disable_geoip)
+        return {
+            "featureFlags": resp_data["featureFlags"],
+            "featureFlagPayloads": resp_data["featureFlagPayloads"],
+        }
 
     def get_decide(self, distinct_id, groups=None, person_properties=None, group_properties=None, disable_geoip=None):
         require("distinct_id", distinct_id, ID_TYPES)
@@ -723,23 +733,52 @@ class Client(object):
                 groups=groups,
                 person_properties=person_properties,
                 group_properties=group_properties,
-                send_feature_flag_events=send_feature_flag_events,
-                only_evaluate_locally=only_evaluate_locally,
+                send_feature_flag_events=False,
+                # Disable automatic sending of feature flag events because we're manually handling event dispatch.
+                # This prevents sending events with empty data when `get_feature_flag` cannot be evaluated locally.
+                only_evaluate_locally=True,  # Enable local evaluation of feature flags to avoid making multiple requests to `/decide`.
                 disable_geoip=disable_geoip,
             )
 
         response = None
+        payload = None
 
         if match_value is not None:
-            response = self._compute_payload_locally(key, match_value)
+            payload = self._compute_payload_locally(key, match_value)
 
-        if response is None and not only_evaluate_locally:
-            decide_payloads = self.get_feature_payloads(
-                distinct_id, groups, person_properties, group_properties, disable_geoip
+        flag_was_locally_evaluated = payload is not None
+        if not flag_was_locally_evaluated and not only_evaluate_locally:
+            try:
+                responses_and_payloads = self.get_feature_flags_and_payloads(
+                    distinct_id, groups, person_properties, group_properties, disable_geoip
+                )
+                response = responses_and_payloads["featureFlags"].get(key, None)
+                payload = responses_and_payloads["featureFlagPayloads"].get(str(key).lower(), None)
+            except Exception as e:
+                self.log.exception(f"[FEATURE FLAGS] Unable to get feature flags and payloads: {e}")
+
+        feature_flag_reported_key = f"{key}_{str(response)}"
+
+        if (
+            feature_flag_reported_key not in self.distinct_ids_feature_flags_reported[distinct_id]
+            and send_feature_flag_events  # noqa: W503
+        ):
+            self.capture(
+                distinct_id,
+                "$feature_flag_called",
+                {
+                    "$feature_flag": key,
+                    "$feature_flag_response": response,
+                    "$feature_flag_payload": payload,
+                    "locally_evaluated": flag_was_locally_evaluated,
+                    f"$feature/{key}": response,
+                },
+                groups=groups,
+                disable_geoip=disable_geoip,
             )
-            response = decide_payloads.get(str(key).lower(), None)
+            self.distinct_ids_feature_flags_reported[distinct_id].add(feature_flag_reported_key)
 
-        return response
+        return payload
 
     def _compute_payload_locally(self, key, match_value):
         payload = None

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -724,7 +724,7 @@ class Client(object):
                 person_properties=person_properties,
                 group_properties=group_properties,
                 send_feature_flag_events=send_feature_flag_events,
-                only_evaluate_locally=True,
+                only_evaluate_locally=only_evaluate_locally,
                 disable_geoip=disable_geoip,
             )
 

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -2341,13 +2341,9 @@ class TestCaptureCalls(unittest.TestCase):
     @mock.patch.object(Client, "capture")
     @mock.patch("posthog.client.decide")
     def test_capture_is_called_in_get_feature_flag_payload(self, patch_decide, patch_capture):
-        # Mock the decide response
         patch_decide.return_value = {"featureFlags": {"decide-flag": "decide-value"}, "featureFlagPayloads": {"person-flag": 300}}
-        
-        # Initialize the Client with necessary keys
         client = Client(api_key=FAKE_TEST_API_KEY, personal_api_key=FAKE_TEST_API_KEY)
         
-        # Set up feature flags
         client.feature_flags = [
             {
                 "id": 1,
@@ -2373,10 +2369,8 @@ class TestCaptureCalls(unittest.TestCase):
             person_properties={"region": "USA", "name": "Aloha"}
         )
         
-        # Assert that capture was called once
+        # Assert that capture was called once, with the correct parameters
         self.assertEqual(patch_capture.call_count, 1)
-        
-        # Verify the capture was called with the correct parameters
         patch_capture.assert_called_with(
             "some-distinct-id",
             "$feature_flag_called",
@@ -2394,7 +2388,7 @@ class TestCaptureCalls(unittest.TestCase):
         patch_capture.reset_mock()
         patch_decide.reset_mock()
         
-        # Call get_feature_flag_payload again for the same user; capture should not be called again
+        # Call get_feature_flag_payload again for the same user; capture should not be called again because we've already reported an event for this distinct_id + flag
         client.get_feature_flag_payload(
             key="complex-flag",
             distinct_id="some-distinct-id",
@@ -2411,7 +2405,6 @@ class TestCaptureCalls(unittest.TestCase):
             person_properties={"region": "USA", "name": "Aloha"}
         )
         
-        # self.assertIsNotNone(payload)
         self.assertEqual(patch_capture.call_count, 1)
         patch_capture.assert_called_with(
             "some-distinct-id2",

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -1648,7 +1648,7 @@ class TestLocalEvaluation(unittest.TestCase):
             ),
             300,
         )
-        self.assertEqual(patch_decide.call_count, 2)
+        self.assertEqual(patch_decide.call_count, 3)
 
     @mock.patch("posthog.client.decide")
     def test_multivariate_feature_flag_payloads(self, patch_decide):

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -2337,13 +2337,15 @@ class TestCaptureCalls(unittest.TestCase):
             disable_geoip=None,
         )
 
-    
     @mock.patch.object(Client, "capture")
     @mock.patch("posthog.client.decide")
     def test_capture_is_called_in_get_feature_flag_payload(self, patch_decide, patch_capture):
-        patch_decide.return_value = {"featureFlags": {"decide-flag": "decide-value"}, "featureFlagPayloads": {"person-flag": 300}}
+        patch_decide.return_value = {
+            "featureFlags": {"decide-flag": "decide-value"},
+            "featureFlagPayloads": {"person-flag": 300},
+        }
         client = Client(api_key=FAKE_TEST_API_KEY, personal_api_key=FAKE_TEST_API_KEY)
-        
+
         client.feature_flags = [
             {
                 "id": 1,
@@ -2361,14 +2363,12 @@ class TestCaptureCalls(unittest.TestCase):
                 },
             }
         ]
-        
+
         # Call get_feature_flag_payload with match_value=None to trigger get_feature_flag
         client.get_feature_flag_payload(
-            key="complex-flag",
-            distinct_id="some-distinct-id",
-            person_properties={"region": "USA", "name": "Aloha"}
+            key="complex-flag", distinct_id="some-distinct-id", person_properties={"region": "USA", "name": "Aloha"}
         )
-        
+
         # Assert that capture was called once, with the correct parameters
         self.assertEqual(patch_capture.call_count, 1)
         patch_capture.assert_called_with(
@@ -2383,28 +2383,24 @@ class TestCaptureCalls(unittest.TestCase):
             groups={},
             disable_geoip=None,
         )
-        
+
         # Reset mocks for further tests
         patch_capture.reset_mock()
         patch_decide.reset_mock()
-        
+
         # Call get_feature_flag_payload again for the same user; capture should not be called again because we've already reported an event for this distinct_id + flag
         client.get_feature_flag_payload(
-            key="complex-flag",
-            distinct_id="some-distinct-id",
-            person_properties={"region": "USA", "name": "Aloha"}
+            key="complex-flag", distinct_id="some-distinct-id", person_properties={"region": "USA", "name": "Aloha"}
         )
-        
+
         self.assertEqual(patch_capture.call_count, 0)
         patch_capture.reset_mock()
-        
+
         # Call get_feature_flag_payload for a different user; capture should be called
         client.get_feature_flag_payload(
-            key="complex-flag",
-            distinct_id="some-distinct-id2",
-            person_properties={"region": "USA", "name": "Aloha"}
+            key="complex-flag", distinct_id="some-distinct-id2", person_properties={"region": "USA", "name": "Aloha"}
         )
-        
+
         self.assertEqual(patch_capture.call_count, 1)
         patch_capture.assert_called_with(
             "some-distinct-id2",
@@ -2418,9 +2414,9 @@ class TestCaptureCalls(unittest.TestCase):
             groups={},
             disable_geoip=None,
         )
-        
+
         patch_capture.reset_mock()
-    
+
     @mock.patch.object(Client, "capture")
     @mock.patch("posthog.client.decide")
     def test_disable_geoip_get_flag_capture_call(self, patch_decide, patch_capture):

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -1651,18 +1651,6 @@ class TestLocalEvaluation(unittest.TestCase):
         )
         self.assertEqual(patch_decide.call_count, 3)
         self.assertEqual(patch_capture.call_count, 1)
-        # patch_capture.assert_called_with(
-        #     "some-distinct-id",
-        #     "$feature_flag_called",
-        #     {
-        #         "$feature_flag": "person-flag",
-        #         "$feature_flag_response": True,
-        #         "locally_evaluated": False,
-        #         "$feature/complex-flag": True,
-        #     },
-        #     groups={},
-        #     disable_geoip=None,
-        # )
         patch_capture.reset_mock()
 
     @mock.patch("posthog.client.decide")

--- a/posthog/version.py
+++ b/posthog/version.py
@@ -1,4 +1,4 @@
-VERSION = "3.7.2"
+VERSION = "3.7.3"
 
 if __name__ == "__main__":
     print(VERSION, end="")  # noqa: T201


### PR DESCRIPTION
## Issue
The Python SDK incorrectly sends feature flag events with null values when calling `get_feature_flag_payload()`, even though the actual payload is successfully retrieved and returned to the user.

## Behavior
When calling `get_feature_flag_payload()`, the following sequence occurs:

1. `get_feature_flag_payload()` internally calls `get_feature_flag()` to get the match value
2. During this call, `get_feature_flag()` is forced to use `only_evaluate_locally=True` (different from the default passed to `get_feature_flag_payload`)
3. An event is sent immediately with null values:
```json
{
    "properties": {
        "$feature_flag": "config-right-brain",
        "$feature_flag_response": null,
        "locally_evaluated": false,
        "$feature/config-right-brain": null
    },
    "event": "$feature_flag_called"
}
```

The code then proceeds to call `/decide` to get the actual payload
The correct payload is returned to the user, but no updated event is sent

## Root Cause
The issue stems from forcing `only_evaluate_locally=True` when getting the match value in `get_feature_flag_payload()`. This causes the SDK to:

- Try local evaluation first
- Send an event immediately with null values
- Then fall back to remote evaluation to get the payload
- Never update the originally sent event with the actual values

## Fix
Removed the forced `only_evaluate_locally=True` setting in `get_feature_flag_payload()` and instead use the value passed to the method. This ensures the event is sent with the correct feature flag response after evaluation is complete.


This fixes the issue described here: https://posthoghelp.zendesk.com/agent/tickets/20416 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/25047)