### PR TITLE
fix: default in_app to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.7.5 - 2024-11-27
+
+1. Fix a bug where `in_app` was occassionally not present on exception stack frames.
+
 ## 3.7.4 - 2024-11-25
 
 1. Fix bug where this SDK incorrectly sent feature flag events with null values when calling `get_feature_flag_payload`.

--- a/posthog/exception_utils.py
+++ b/posthog/exception_utils.py
@@ -733,6 +733,7 @@ def set_in_app_in_frames(frames, in_app_exclude, in_app_include, project_root=No
         # if frame has no abs_path, skip further checks
         abs_path = frame.get("abs_path")
         if abs_path is None:
+            frame["in_app"] = False
             continue
 
         if _is_external_source(abs_path):
@@ -742,6 +743,8 @@ def set_in_app_in_frames(frames, in_app_exclude, in_app_include, project_root=No
         if _is_in_project_root(abs_path, project_root):
             frame["in_app"] = True
             continue
+
+        frame["in_app"] = False
 
     return frames
 

--- a/posthog/version.py
+++ b/posthog/version.py
@@ -1,4 +1,4 @@
-VERSION = "3.7.3"
+VERSION = "3.7.5"
 
 if __name__ == "__main__":
     print(VERSION, end="")  # noqa: T201


### PR DESCRIPTION
Serde fails to parse stack frames when `in_app` is missing. We should default it to `False` if we don't know for certain it is an `in_app` frame