### PR TITLE
[FEATURE]Add distinct_id to group_identify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.7.5 - 2025-01-03
+
+1. Add `distinct_id` to group_identify
+
 ## 3.7.4 - 2024-11-25
 
 1. Fix bug where this SDK incorrectly sent feature flag events with null values when calling `get_feature_flag_payload`.

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -304,7 +304,7 @@ class Client(object):
         timestamp=None,
         uuid=None,
         disable_geoip=None,
-        distinct_id=None
+        distinct_id=None,
     ):
         properties = properties or {}
         context = context or {}

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -304,12 +304,18 @@ class Client(object):
         timestamp=None,
         uuid=None,
         disable_geoip=None,
+        distinct_id=None
     ):
         properties = properties or {}
         context = context or {}
         require("group_type", group_type, ID_TYPES)
         require("group_key", group_key, ID_TYPES)
         require("properties", properties, dict)
+
+        if distinct_id:
+            require("distinct_id", distinct_id, ID_TYPES)
+        else:
+            distinct_id = "${}_{}".format(group_type, group_key)
 
         msg = {
             "event": "$groupidentify",
@@ -318,7 +324,7 @@ class Client(object):
                 "$group_key": group_key,
                 "$group_set": properties,
             },
-            "distinct_id": "${}_{}".format(group_type, group_key),
+            "distinct_id": distinct_id,
             "timestamp": timestamp,
             "context": context,
             "uuid": uuid,

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -758,12 +758,19 @@ class TestClient(unittest.TestCase):
 
     def test_advanced_group_identify_with_distinct_id(self):
         success, msg = self.client.group_identify(
-            "organization", "id:5", {"trait": "value"}, {"ip": "192.168.0.1"}, datetime(2014, 9, 3), "new-uuid", distinct_id="distinct_id"
+            "organization",
+            "id:5",
+            {"trait": "value"},
+            {"ip": "192.168.0.1"},
+            datetime(2014, 9, 3),
+            "new-uuid",
+            distinct_id="distinct_id",
         )
 
         self.assertTrue(success)
         self.assertEqual(msg["event"], "$groupidentify")
         self.assertEqual(msg["distinct_id"], "distinct_id")
+
         self.assertEqual(
             msg["properties"],
             {

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -715,6 +715,25 @@ class TestClient(unittest.TestCase):
         self.assertTrue(isinstance(msg["timestamp"], str))
         self.assertIsNone(msg.get("uuid"))
 
+    def test_basic_group_identify_with_distinct_id(self):
+        success, msg = self.client.group_identify("organization", "id:5", distinct_id="distinct_id")
+        self.assertTrue(success)
+        self.assertEqual(msg["event"], "$groupidentify")
+        self.assertEqual(msg["distinct_id"], "distinct_id")
+        self.assertEqual(
+            msg["properties"],
+            {
+                "$group_type": "organization",
+                "$group_key": "id:5",
+                "$group_set": {},
+                "$lib": "posthog-python",
+                "$lib_version": VERSION,
+                "$geoip_disable": True,
+            },
+        )
+        self.assertTrue(isinstance(msg["timestamp"], str))
+        self.assertIsNone(msg.get("uuid"))
+
     def test_advanced_group_identify(self):
         success, msg = self.client.group_identify(
             "organization", "id:5", {"trait": "value"}, {"ip": "192.168.0.1"}, datetime(2014, 9, 3), "new-uuid"
@@ -723,6 +742,28 @@ class TestClient(unittest.TestCase):
         self.assertTrue(success)
         self.assertEqual(msg["event"], "$groupidentify")
         self.assertEqual(msg["distinct_id"], "$organization_id:5")
+        self.assertEqual(
+            msg["properties"],
+            {
+                "$group_type": "organization",
+                "$group_key": "id:5",
+                "$group_set": {"trait": "value"},
+                "$lib": "posthog-python",
+                "$lib_version": VERSION,
+                "$geoip_disable": True,
+            },
+        )
+        self.assertEqual(msg["timestamp"], "2014-09-03T00:00:00+00:00")
+        self.assertEqual(msg["context"]["ip"], "192.168.0.1")
+
+    def test_advanced_group_identify_with_distinct_id(self):
+        success, msg = self.client.group_identify(
+            "organization", "id:5", {"trait": "value"}, {"ip": "192.168.0.1"}, datetime(2014, 9, 3), "new-uuid", distinct_id="distinct_id"
+        )
+
+        self.assertTrue(success)
+        self.assertEqual(msg["event"], "$groupidentify")
+        self.assertEqual(msg["distinct_id"], "distinct_id")
         self.assertEqual(
             msg["properties"],
             {

--- a/posthog/version.py
+++ b/posthog/version.py
@@ -1,4 +1,4 @@
-VERSION = "3.7.4"
+VERSION = "3.7.5"
 
 if __name__ == "__main__":
     print(VERSION, end="")  # noqa: T201


### PR DESCRIPTION
### Feature

-  https://github.com/PostHog/posthog-python/issues/137
- This PR adds the capability of passing distinct_id to the group_identify() function in the PostHog Client
- This allows the users to tag a group identify event to a person ID

**Before**
<img width="1213" alt="Screenshot 2025-01-01 at 5 18 34 PM" src="https://github.com/user-attachments/assets/78f3094d-03d3-40c8-a309-8a0ba0a5f0eb" />


**After**

<img width="1172" alt="Screenshot 2025-01-02 at 8 41 14 AM" src="https://github.com/user-attachments/assets/a8fc16f0-d6e2-4130-9ddd-85a6fd1ee400" />


Sample code :
```python
group_type = "business"
group_key = 2668  # business_id
distinct_id=2675  # user_id
ph_client = posthog.Client(api_key=POSTHOG_API_KEY)
ph_client.group_identify(group_type, group_key, properties, distinct_id=distinct_id)
```
