### PR TITLE
Allow specifying the flag in the example script

### DIFF
--- a/example.py
+++ b/example.py
@@ -3,10 +3,10 @@ import argparse
 import posthog
 
 # Add argument parsing
-parser = argparse.ArgumentParser(description='PostHog Python library example')
-parser.add_argument('--flag', 
-                   default='person-on-events-enabled',
-                   help='Feature flag key to check (default: person-on-events-enabled)')
+parser = argparse.ArgumentParser(description="PostHog Python library example")
+parser.add_argument(
+    "--flag", default="person-on-events-enabled", help="Feature flag key to check (default: person-on-events-enabled)"
+)
 args = parser.parse_args()
 
 posthog.debug = True

--- a/example.py
+++ b/example.py
@@ -1,9 +1,13 @@
 # PostHog Python library example
-
-# Import the library
-# import time
-
+import argparse
 import posthog
+
+# Add argument parsing
+parser = argparse.ArgumentParser(description='PostHog Python library example')
+parser.add_argument('--flag', 
+                   default='person-on-events-enabled',
+                   help='Feature flag key to check (default: person-on-events-enabled)')
+args = parser.parse_args()
 
 posthog.debug = True
 
@@ -18,7 +22,7 @@ posthog.poll_interval = 10
 
 print(
     posthog.feature_enabled(
-        "person-on-events-enabled",
+        args.flag,  # Use the flag from command line arguments
         "12345",
         groups={"organization": str("0182ee91-8ef7-0000-4cb9-fedc5f00926a")},
         group_properties={

--- a/example.py
+++ b/example.py
@@ -1,5 +1,6 @@
 # PostHog Python library example
 import argparse
+
 import posthog
 
 # Add argument parsing


### PR DESCRIPTION
This is a little quality of life improvement. When using the example script, it creates an event for the feature flag `person-on-events-enabled`. This change adds an optional argument that lets you change the feature-flag key for the event like so:

```bash
python3 example.py --flag person-on-events-enabled-v1
```

If the flag is omitted, the script behaves the same as it always did.