### PR TITLE
fix(llm-observability): include the ai packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.8.2 - 2025-01-14
+
+1. Fix setuptools to include the `posthog.ai.openai` and `posthog.ai.langchain` packages.
+
 ## 3.8.1 - 2025-01-14
 
 1. Add LLM Observability with support for OpenAI and Langchain callbacks.

--- a/posthog/version.py
+++ b/posthog/version.py
@@ -1,4 +1,4 @@
-VERSION = "3.8.1"
+VERSION = "3.8.2"
 
 if __name__ == "__main__":
     print(VERSION, end="")  # noqa: T201

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,8 @@ setup(
     packages=[
         "posthog",
         "posthog.ai",
+        "posthog.ai.langchain",
+        "posthog.ai.openai",
         "posthog.test",
         "posthog.sentry",
         "posthog.exception_integrations",


### PR DESCRIPTION
The distributed package only has the `posthog.ai` module without the `posthog.ai.openai` and `posthog.ai.langchain` modules since they're not exported from `posthog/ai/__init__.py`.