### PR TITLE
fix(llm-observability): flatten langchain's additional_kwargs

### DIFF
--- a/posthog/ai/langchain/callbacks.py
+++ b/posthog/ai/langchain/callbacks.py
@@ -333,10 +333,8 @@ def _convert_message_to_dict(message: BaseMessage) -> Dict[str, Any]:
     else:
         message_dict = {"role": message.type, "content": str(message.content)}
 
-    if "name" in message.additional_kwargs:
-        message_dict["name"] = message.additional_kwargs["name"]
     if message.additional_kwargs:
-        message_dict["additional_kwargs"] = message.additional_kwargs
+        message_dict.update(message.additional_kwargs)
 
     return message_dict
 

--- a/posthog/test/ai/langchain/test_callbacks.py
+++ b/posthog/test/ai/langchain/test_callbacks.py
@@ -679,7 +679,6 @@ def test_tool_calls(mock_client):
 
     assert mock_client.capture.call_count == 1
     call = mock_client.capture.call_args[1]
-    print(call["properties"]["$ai_output"]["choices"])
     assert call["properties"]["$ai_output"]["choices"][0]["tool_calls"] == [
         {
             "type": "function",


### PR DESCRIPTION
## Problem

OpenAI wrappers send data as:
```json
{
    "role": "assistant",
    "content": "",
    "tool_calls": [
        {
            "type": "function",
            "id": "123",
            "function": {
                "name": "test",
                "args": "{\"a\": 1}",
            },
        }
    ]
}
```
But the Langchain integration adds the tool calls into the `additional_kwargs` field:
```json
{
    "role": "assistant",
    "content": "",
    "additional_kwargs": {
        "tool_calls": [
            {
                "type": "function",
                "id": "123",
                "function": {
                    "name": "test",
                    "args": "{\"a\": 1}"
                }
            }
        ]
    }
}
```
## Changes

Flatten `additional_kwargs` to mirror the OpenAI wrapper to remove the discrepancies.