### PR TITLE
Move accessing variants outside of loop

### DIFF
--- a/posthog/client.py
+++ b/posthog/client.py
@@ -683,7 +683,6 @@ class Client(object):
             self.load_feature_flags()
         response = None
 
-        # If loading in previous line failed
         if self.feature_flags:
             for flag in self.feature_flags:
                 if flag["key"] == key:

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -701,6 +701,7 @@ class Client(object):
                     except Exception as e:
                         self.log.exception(f"[FEATURE FLAGS] Error while computing variant locally: {e}")
                         continue
+                    break
 
         flag_was_locally_evaluated = response is not None
         if not flag_was_locally_evaluated and not only_evaluate_locally:

--- a/posthog/feature_flags.py
+++ b/posthog/feature_flags.py
@@ -53,6 +53,8 @@ def match_feature_flag_properties(flag, distinct_id, properties, cohort_properti
     flag_conditions = (flag.get("filters") or {}).get("groups") or []
     is_inconclusive = False
     cohort_properties = cohort_properties or {}
+    # Some filters can be explicitly set to null, which require accessing variants like so
+    flag_variants = ((flag.get("filters") or {}).get("multivariate") or {}).get("variants") or []
 
     # Stable sort conditions with variant overrides to the top. This ensures that if overrides are present, they are
     # evaluated first, and the variant override is applied to the first matching condition.
@@ -67,8 +69,6 @@ def match_feature_flag_properties(flag, distinct_id, properties, cohort_properti
             # the matching variant
             if is_condition_match(flag, distinct_id, condition, properties, cohort_properties):
                 variant_override = condition.get("variant")
-                # Some filters can be explicitly set to null, which require accessing variants like so
-                flag_variants = ((flag.get("filters") or {}).get("multivariate") or {}).get("variants") or []
                 if variant_override and variant_override in [variant["key"] for variant in flag_variants]:
                     variant = variant_override
                 else:

--- a/posthog/feature_flags.py
+++ b/posthog/feature_flags.py
@@ -55,6 +55,7 @@ def match_feature_flag_properties(flag, distinct_id, properties, cohort_properti
     cohort_properties = cohort_properties or {}
     # Some filters can be explicitly set to null, which require accessing variants like so
     flag_variants = ((flag.get("filters") or {}).get("multivariate") or {}).get("variants") or []
+    valid_variant_keys = [variant["key"] for variant in flag_variants]
 
     # Stable sort conditions with variant overrides to the top. This ensures that if overrides are present, they are
     # evaluated first, and the variant override is applied to the first matching condition.
@@ -69,7 +70,7 @@ def match_feature_flag_properties(flag, distinct_id, properties, cohort_properti
             # the matching variant
             if is_condition_match(flag, distinct_id, condition, properties, cohort_properties):
                 variant_override = condition.get("variant")
-                if variant_override and variant_override in [variant["key"] for variant in flag_variants]:
+                if variant_override and variant_override in valid_variant_keys:
                     variant = variant_override
                 else:
                     variant = get_matching_variant(flag, distinct_id)

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -1007,12 +1007,14 @@ class TestLocalEvaluation(unittest.TestCase):
             "beta-feature",
             "some-distinct-id",
             person_properties={
-                "latestBuildVersion": "24.32..1",
+                "latestBuildVersion": "24.32.1",
                 "latestBuildVersionMajor": "24",
                 "latestBuildVersionMinor": "32",
                 "latestBuildVersionPatch": "1",
             },
         )
+
+        self.assertEqual(feature_flag_match, True)
 
     @mock.patch("posthog.client.decide")
     @mock.patch("posthog.client.get")

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -472,7 +472,7 @@ class TestLocalEvaluation(unittest.TestCase):
             }
         ]
         # decide called always because experience_continuity is set
-        self.assertTrue(client.get_feature_flag("beta-feature", "distinct_id"), "decide-fallback-value")
+        self.assertEqual(client.get_feature_flag("beta-feature", "distinct_id"), "decide-fallback-value")
         self.assertEqual(patch_decide.call_count, 1)
 
     @mock.patch.object(Client, "capture")


### PR DESCRIPTION
`flag_variants` doesn't depend on condition so it doesn't make sense to declare it in the loop.