### PR TITLE
feat(llm-observability): LangChain spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 3.10.0 - 2025-01-27
+
+1. Add the `$ai_span` event to the LangChain callback handler to capture the input and output of intermediary chains.
+
+## 3.9.3 - 2025-01-23
+
+1. Fix capturing of multiple traces in the LangChain callback handler.
+
 ## 3.9.2 - 2025-01-22
 
 1. Fix importing of LangChain callback handler under certain circumstances.

--- a/posthog/ai/langchain/callbacks.py
+++ b/posthog/ai/langchain/callbacks.py
@@ -6,6 +6,7 @@ except ImportError:
 import logging
 import time
 import uuid
+from dataclasses import dataclass
 from typing import (
     Any,
     Dict,
@@ -17,13 +18,12 @@ from typing import (
     cast,
 )
 from uuid import UUID
-from dataclasses import dataclass
 
 from langchain.callbacks.base import BaseCallbackHandler
 from langchain.schema.agent import AgentAction, AgentFinish
+from langchain_core.documents import Document
 from langchain_core.messages import AIMessage, BaseMessage, FunctionMessage, HumanMessage, SystemMessage, ToolMessage
 from langchain_core.outputs import ChatGeneration, LLMResult
-from langchain_core.documents import Document
 from pydantic import BaseModel
 
 from posthog import default_client

--- a/posthog/ai/langchain/callbacks.py
+++ b/posthog/ai/langchain/callbacks.py
@@ -438,14 +438,11 @@ class CallbackHandler(BaseCallbackHandler):
             "$ai_trace_id": trace_id,
             "$ai_input_state": with_privacy_mode(self._client, self._privacy_mode, run.input),
             "$ai_latency": run.latency,
+            "$ai_span_name": run.name,
+            "$ai_span_id": run_id,
         }
-
         if parent_run_id is not None:
-            event_properties["$ai_span_id"] = run_id
             event_properties["$ai_parent_id"] = parent_run_id
-            event_properties["$ai_span_name"] = run.name
-        else:
-            event_properties["$ai_trace_name"] = run.name
         if self._properties:
             event_properties.update(self._properties)
 
@@ -490,7 +487,8 @@ class CallbackHandler(BaseCallbackHandler):
     ):
         event_properties = {
             "$ai_trace_id": trace_id,
-            "$ai_generation_id": run_id,
+            "$ai_span_id": run_id,
+            "$ai_span_name": run.name,
             "$ai_parent_id": parent_run_id,
             "$ai_provider": run.provider,
             "$ai_model": run.model,

--- a/posthog/ai/langchain/callbacks.py
+++ b/posthog/ai/langchain/callbacks.py
@@ -419,7 +419,7 @@ class CallbackHandler(BaseCallbackHandler):
         if not run:
             return
         if isinstance(run, GenerationMetadata):
-            log.warning(f"Run {run_id} is not a generation but attempted to be captured as a trace or span.")
+            log.warning(f"Run {run_id} is a generation, but attempted to be captured as a trace or span.")
             return
         self._capture_trace_or_span(
             trace_id, run_id, run, outputs, self._get_parent_run_id(trace_id, run_id, parent_run_id)
@@ -471,7 +471,7 @@ class CallbackHandler(BaseCallbackHandler):
         if not run:
             return
         if not isinstance(run, GenerationMetadata):
-            log.warning(f"Run {run_id} is not a generation but attempted to be captured as a generation.")
+            log.warning(f"Run {run_id} is not a generation, but attempted to be captured as a generation.")
             return
         self._capture_generation(
             trace_id, run_id, run, response, self._get_parent_run_id(trace_id, run_id, parent_run_id)

--- a/posthog/ai/langchain/callbacks.py
+++ b/posthog/ai/langchain/callbacks.py
@@ -469,7 +469,7 @@ class CallbackHandler(BaseCallbackHandler):
         trace_id: Any,
         run_id: UUID,
         run: GenerationMetadata,
-        output: Union[LLMResult | BaseException],
+        output: Union[LLMResult, BaseException],
         parent_run_id: Optional[UUID] = None,
     ):
         event_properties = {

--- a/posthog/ai/langchain/callbacks.py
+++ b/posthog/ai/langchain/callbacks.py
@@ -62,8 +62,8 @@ class GenerationMetadata(SpanMetadata):
     """Base URL of the provider's API used in the run."""
 
 
-RunMetadataUnion = Union[SpanMetadata, GenerationMetadata]
-RunMetadataStorage = Dict[UUID, RunMetadataUnion]
+RunMetadata = Union[SpanMetadata, GenerationMetadata]
+RunMetadataStorage = Dict[UUID, RunMetadata]
 
 
 class CallbackHandler(BaseCallbackHandler):
@@ -388,7 +388,7 @@ class CallbackHandler(BaseCallbackHandler):
             pass
         self._runs[run_id] = generation
 
-    def _pop_run_metadata(self, run_id: UUID) -> Optional[RunMetadataUnion]:
+    def _pop_run_metadata(self, run_id: UUID) -> Optional[RunMetadata]:
         end_time = time.time()
         try:
             run = self._runs.pop(run_id)

--- a/posthog/test/ai/langchain/test_callbacks.py
+++ b/posthog/test/ai/langchain/test_callbacks.py
@@ -4,20 +4,20 @@ import math
 import os
 import time
 import uuid
-from typing import List, Optional, TypedDict, Union, Literal
+from typing import List, Literal, Optional, TypedDict, Union
 from unittest.mock import patch
 
 import pytest
 from langchain_anthropic.chat_models import ChatAnthropic
 from langchain_community.chat_models.fake import FakeMessagesListChatModel
 from langchain_community.llms.fake import FakeListLLM, FakeStreamingListLLM
-from langchain_core.messages import AIMessage, HumanMessage, ToolCall
+from langchain_core.messages import AIMessage, HumanMessage
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.runnables import RunnableLambda
+from langchain_core.tools import tool
 from langchain_openai.chat_models import ChatOpenAI
 from langgraph.graph.state import END, START, StateGraph
 from langgraph.prebuilt import create_react_agent
-from langchain_core.tools import tool
 
 from posthog.ai.langchain import CallbackHandler
 from posthog.ai.langchain.callbacks import GenerationMetadata, SpanMetadata
@@ -1257,7 +1257,7 @@ def test_langgraph_agent(mock_client):
     graph = create_react_agent(model, tools=tools)
     inputs = {"messages": [("user", "what is the weather in sf")]}
     cb = CallbackHandler(mock_client, trace_id="test-trace-id", distinct_id="test-distinct-id")
-    res = graph.invoke(inputs, config={"callbacks": [cb]})
+    graph.invoke(inputs, config={"callbacks": [cb]})
     calls = [call[1] for call in mock_client.capture.call_args_list]
     assert len(calls) == 21
     for call in calls:

--- a/posthog/test/ai/langchain/test_callbacks.py
+++ b/posthog/test/ai/langchain/test_callbacks.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import math
 import os
@@ -67,7 +68,7 @@ def test_metadata_capture(mock_client):
     callbacks = CallbackHandler(mock_client)
     run_id = uuid.uuid4()
     with patch("time.time", return_value=1234567890):
-        callbacks._set_run_metadata(
+        callbacks._set_llm_metadata(
             {"kwargs": {"openai_api_base": "https://us.posthog.com"}},
             run_id,
             messages=[{"role": "user", "content": "Who won the world series in 2020?"}],
@@ -76,7 +77,7 @@ def test_metadata_capture(mock_client):
         )
     expected = {
         "model": "hog-mini",
-        "messages": [{"role": "user", "content": "Who won the world series in 2020?"}],
+        "input": [{"role": "user", "content": "Who won the world series in 2020?"}],
         "start_time": 1234567890,
         "model_params": {"temperature": 0.5},
         "provider": "posthog",
@@ -88,6 +89,19 @@ def test_metadata_capture(mock_client):
     assert run == {**expected, "end_time": 1234567891}
     assert callbacks._runs == {}
     callbacks._pop_run_metadata(uuid.uuid4())  # should not raise
+
+
+def test_run_metadata_capture(mock_client):
+    callbacks = CallbackHandler(mock_client)
+    run_id = uuid.uuid4()
+    with patch("time.time", return_value=1234567890):
+        callbacks._set_span_metadata(run_id, "test", 1)
+    expected = {
+        "name": "test",
+        "input": 1,
+        "start_time": 1234567890,
+    }
+    assert callbacks._runs[run_id] == expected
 
 
 @pytest.mark.parametrize("stream", [True, False])
@@ -514,7 +528,11 @@ def test_callbacks_logic(mock_client):
     assert callbacks._parent_tree == {}
 
     def assert_intermediary_run(m):
-        assert callbacks._runs == {}
+        assert len(callbacks._runs) != 0
+        run = next(iter(callbacks._runs.values()))
+        assert run["name"] == "RunnableSequence"
+        assert run["input"] == {}
+        assert run["start_time"] is not None
         assert len(callbacks._parent_tree.items()) == 1
         return [m]
 
@@ -981,3 +999,33 @@ def test_tool_calls(mock_client):
         }
     ]
     assert "additional_kwargs" not in generation_call["properties"]["$ai_output_choices"][0]
+
+
+async def test_async_traces(mock_client):
+    async def sleep(x):  # -> Any:
+        await asyncio.sleep(0.1)
+        return x
+
+    prompt = ChatPromptTemplate.from_messages([("user", "Foo")])
+    chain1 = RunnableLambda(sleep)
+    chain2 = prompt | FakeMessagesListChatModel(responses=[AIMessage(content="Bar")])
+
+    cb = CallbackHandler(mock_client)
+
+    start_time = time.time()
+    await asyncio.gather(
+        chain1.ainvoke({}, config={"callbacks": [cb]}),
+        chain2.ainvoke({}, config={"callbacks": [cb]}),
+    )
+    approximate_latency = math.floor(time.time() - start_time)
+    assert mock_client.capture.call_count == 3
+
+    first_call, second_call, third_call = mock_client.capture.call_args_list
+    assert first_call[1]["event"] == "$ai_generation"
+    assert second_call[1]["event"] == "$ai_trace"
+    assert second_call[1]["properties"]["$ai_trace_name"] == "RunnableSequence"
+    assert third_call[1]["event"] == "$ai_trace"
+    assert third_call[1]["properties"]["$ai_trace_name"] == "sleep"
+    assert (
+        min(approximate_latency - 1, 0) <= math.floor(third_call[1]["properties"]["$ai_latency"]) <= approximate_latency
+    )

--- a/posthog/version.py
+++ b/posthog/version.py
@@ -1,4 +1,4 @@
-VERSION = "3.9.2"
+VERSION = "3.9.3"
 
 if __name__ == "__main__":
     print(VERSION, end="")  # noqa: T201

--- a/posthog/version.py
+++ b/posthog/version.py
@@ -1,4 +1,4 @@
-VERSION = "3.9.3"
+VERSION = "3.10.0"
 
 if __name__ == "__main__":
     print(VERSION, end="")  # noqa: T201

--- a/posthog/version.py
+++ b/posthog/version.py
@@ -1,4 +1,4 @@
-VERSION = "3.10.0"
+VERSION = "3.11.0"
 
 if __name__ == "__main__":
     print(VERSION, end="")  # noqa: T201


### PR DESCRIPTION
## Problem

We want to capture the input and output of intermediary chains during agent workflows.

## Changes

- Add the spans support for the LangChain callback handler.
- Replace the RunMetadata dict with dataclasses.
- Fix tests.

New fields:
- `$ai_parent_id` to capture a parent ID and build a tree.
- `$ai_generation_id` to capture a generation ID and unify API.
- `$ai_span_id` to capture an ID for a span.