### PR TITLE
fix: serialize pydantic models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.11.0 - 2025-01-27
+
+1. Fix serialiazation of Pydantic models in methods.
+
 ## 3.10.0 - 2025-01-24
 
 1. Add `$ai_error` and `$ai_is_error` properties to LangChain callback handler, OpenAI, and Anthropic.

--- a/posthog/test/test_utils.py
+++ b/posthog/test/test_utils.py
@@ -1,13 +1,13 @@
-from typing import Optional
 import unittest
 from datetime import date, datetime, timedelta
 from decimal import Decimal
+from typing import Optional
 from uuid import UUID
-from pydantic import BaseModel
-from pydantic.v1 import BaseModel as BaseModelV1
 
 import six
 from dateutil.tz import tzutc
+from pydantic import BaseModel
+from pydantic.v1 import BaseModel as BaseModelV1
 
 from posthog import utils
 

--- a/posthog/test/test_utils.py
+++ b/posthog/test/test_utils.py
@@ -1,7 +1,10 @@
+from typing import Optional
 import unittest
 from datetime import date, datetime, timedelta
 from decimal import Decimal
 from uuid import UUID
+from pydantic import BaseModel
+from pydantic.v1 import BaseModel as BaseModelV1
 
 import six
 from dateutil.tz import tzutc
@@ -80,6 +83,32 @@ class TestUtils(unittest.TestCase):
     def test_remove_slash(self):
         self.assertEqual("http://posthog.io", utils.remove_trailing_slash("http://posthog.io/"))
         self.assertEqual("http://posthog.io", utils.remove_trailing_slash("http://posthog.io"))
+
+    def test_clean_pydantic(self):
+        class ModelV2(BaseModel):
+            foo: str
+            bar: int
+            baz: Optional[str] = None
+
+        class ModelV1(BaseModelV1):
+            foo: int
+            bar: str
+
+        class NestedModel(BaseModel):
+            foo: ModelV2
+
+        self.assertEqual(utils.clean(ModelV2(foo="1", bar=2)), {"foo": "1", "bar": 2, "baz": None})
+        self.assertEqual(utils.clean(ModelV1(foo=1, bar="2")), {"foo": 1, "bar": "2"})
+        self.assertEqual(
+            utils.clean(NestedModel(foo=ModelV2(foo="1", bar=2, baz="3"))), {"foo": {"foo": "1", "bar": 2, "baz": "3"}}
+        )
+
+        class Dummy:
+            def model_dump(self, required_param):
+                pass
+
+        # Skips a class with a defined non-Pydantic `model_dump` method.
+        self.assertEqual(utils.clean({"test": Dummy()}), {})
 
 
 class TestSizeLimitedDict(unittest.TestCase):

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -51,14 +51,23 @@ def clean(item):
         return float(item)
     if isinstance(item, UUID):
         return str(item)
-    elif isinstance(item, (six.string_types, bool, numbers.Number, datetime, date, type(None))):
+    if isinstance(item, (six.string_types, bool, numbers.Number, datetime, date, type(None))):
         return item
-    elif isinstance(item, (set, list, tuple)):
+    if isinstance(item, (set, list, tuple)):
         return _clean_list(item)
-    elif isinstance(item, dict):
+    # Pydantic model
+    try:
+        # v2+
+        if hasattr(item, "model_dump") and callable(item.model_dump):
+            item = item.model_dump()
+        # v1
+        elif hasattr(item, "dict") and callable(item.dict):
+            item = item.dict()
+    except:
+        pass
+    if isinstance(item, dict):
         return _clean_dict(item)
-    else:
-        return _coerce_unicode(item)
+    return _coerce_unicode(item)
 
 
 def _clean_list(list_):

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -63,7 +63,8 @@ def clean(item):
         # v1
         elif hasattr(item, "dict") and callable(item.dict):
             item = item.dict()
-    except:
+    except TypeError as e:
+        log.debug(f"Could not serialize Pydantic-like model: {e}")
         pass
     if isinstance(item, dict):
         return _clean_dict(item)

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ extras_require = {
         "langchain-community>=0.2.0",
         "langchain-openai>=0.2.0",
         "langchain-anthropic>=0.2.0",
+        "pydantic",
     ],
     "sentry": ["sentry-sdk", "django"],
     "langchain": ["langchain>=0.2.0"],


### PR DESCRIPTION
## Problem

Pydantic models are skipped by default. This behavior is annoying and unclear for customers.

## Changes

Serialize Pydantic objects to dicts:
- For v1, use the `dict` method.
- For v2, use the `model_dump` method.

If something goes wrong during serialization, omit the key.