### PR TITLE
fix: langchain tool parent add

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.11.1 - 2025-02-06
+
+1. Fix LangChain callback handler to capture parent run ID.
+
 ## 3.11.0 - 2025-01-28
 
 1. Add the `$ai_span` event to the LangChain callback handler to capture the input and output of intermediary chains.

--- a/posthog/ai/langchain/callbacks.py
+++ b/posthog/ai/langchain/callbacks.py
@@ -239,6 +239,7 @@ class CallbackHandler(BaseCallbackHandler):
         **kwargs: Any,
     ) -> Any:
         self._log_debug_event("on_tool_start", run_id, parent_run_id, input_str=input_str)
+        self._set_parent_of_run(run_id, parent_run_id)
         self._set_trace_or_span_metadata(serialized, input_str, run_id, parent_run_id, **kwargs)
 
     def on_tool_end(
@@ -275,6 +276,7 @@ class CallbackHandler(BaseCallbackHandler):
         **kwargs: Any,
     ) -> Any:
         self._log_debug_event("on_retriever_start", run_id, parent_run_id, query=query)
+        self._set_parent_of_run(run_id, parent_run_id)
         self._set_trace_or_span_metadata(serialized, query, run_id, parent_run_id, **kwargs)
 
     def on_retriever_end(

--- a/posthog/version.py
+++ b/posthog/version.py
@@ -1,4 +1,4 @@
-VERSION = "3.11.0"
+VERSION = "3.11.1"
 
 if __name__ == "__main__":
     print(VERSION, end="")  # noqa: T201


### PR DESCRIPTION
I believe we should have:

self._set_parent_of_run(run_id, parent_run_id)

on each of the callbackStart methods