### PR TITLE
Stop capturing all feature flags on `$feature_flag_called` event.

### DIFF
--- a/posthog/client.py
+++ b/posthog/client.py
@@ -245,7 +245,7 @@ class Client(object):
             except Exception as e:
                 self.log.exception(f"[FEATURE FLAGS] Unable to get feature variants: {e}")
 
-        elif self.feature_flags:
+        elif self.feature_flags and event != "$feature_flag_called":
             # Local evaluation is enabled, flags are loaded, so try and get all flags we can without going to the server
             feature_variants = self.get_all_flags(
                 distinct_id, groups=(groups or {}), disable_geoip=disable_geoip, only_evaluate_locally=True

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -2339,6 +2339,58 @@ class TestCaptureCalls(unittest.TestCase):
             disable_geoip=None,
         )
 
+    @mock.patch("posthog.client.decide")
+    def test_capture_is_called_but_does_not_add_all_flags(self, patch_decide):
+        patch_decide.return_value = {"featureFlags": {"decide-flag": "decide-value"}}
+        client = Client(FAKE_TEST_API_KEY, personal_api_key=FAKE_TEST_API_KEY)
+        client.feature_flags = [
+            {
+                "id": 1,
+                "name": "Beta Feature",
+                "key": "complex-flag",
+                "active": True,
+                "filters": {
+                    "groups": [
+                        {
+                            "properties": [{"key": "region", "value": "USA"}],
+                            "rollout_percentage": 100,
+                        },
+                    ],
+                },
+            },
+            {
+                "id": 2,
+                "name": "Gamma Feature",
+                "key": "simple-flag",
+                "active": True,
+                "filters": {
+                    "groups": [
+                        {
+                            "properties": [],
+                            "rollout_percentage": 100,
+                        },
+                    ],
+                },
+            }
+        ]
+
+        self.assertTrue(
+            client.get_feature_flag(
+                "complex-flag", "some-distinct-id", person_properties={"region": "USA"}
+            )
+        )
+
+        # Grab the capture message that was just added to the queue
+        msg = client.queue.get(block=False)
+        assert msg["event"] == "$feature_flag_called"
+        assert msg["properties"]["$feature_flag"] == "complex-flag"
+        assert msg["properties"]["$feature_flag_response"] is True
+        assert msg["properties"]["locally_evaluated"] is True
+        assert msg["properties"]["$feature/complex-flag"] is True
+        assert "$feature/simple-flag" not in msg["properties"]
+        assert "$active_feature_flags" not in msg["properties"]
+
+
     @mock.patch.object(Client, "capture")
     @mock.patch("posthog.client.decide")
     def test_capture_is_called_in_get_feature_flag_payload(self, patch_decide, patch_capture):

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -2371,13 +2371,11 @@ class TestCaptureCalls(unittest.TestCase):
                         },
                     ],
                 },
-            }
+            },
         ]
 
         self.assertTrue(
-            client.get_feature_flag(
-                "complex-flag", "some-distinct-id", person_properties={"region": "USA"}
-            )
+            client.get_feature_flag("complex-flag", "some-distinct-id", person_properties={"region": "USA"})
         )
 
         # Grab the capture message that was just added to the queue
@@ -2389,7 +2387,6 @@ class TestCaptureCalls(unittest.TestCase):
         assert msg["properties"]["$feature/complex-flag"] is True
         assert "$feature/simple-flag" not in msg["properties"]
         assert "$active_feature_flags" not in msg["properties"]
-
 
     @mock.patch.object(Client, "capture")
     @mock.patch("posthog.client.decide")


### PR DESCRIPTION
The `client.get_feature_flag` method will by default call `client.capture` with the event named `$feature_flag_called`. 

Some time ago (in e60d52c199ef75ac4e7b0aa962a2c892c94c9efc), the `capture` method was changed to enrich the event with all locally cached feature flags even if `send_feature_flags` is `False`.

What this leads to is `client.get_feature_flag` -> `client.capture` -> `client.get_all_flags`. But the call to `client.get_all_flags` isn't passed the original `person_properties` that were passed to `client.get_feature_flag`. This leads to inconsistency in the enriched data. This can also cause confusion because it's unclear which feature flag is the one being called because the event adds "all" the locally cached feature flags.

This PR takes the simplest path by not enriching the captured event with all feature flags for the `$feature_flag_called` event.

Note that this didn't show up in the tests because most of the tests of `get_feature_flag` apply `@mock.patch.object(Client, "capture")` to the test, which hides this unexpected behavior.