### PR TITLE
Use casefold to compare strings case insensitively

### DIFF
--- a/posthog/feature_flags.py
+++ b/posthog/feature_flags.py
@@ -129,8 +129,8 @@ def match_property(property, property_values) -> bool:
 
         def compute_exact_match(value, override_value):
             if isinstance(value, list):
-                return str(override_value).lower() in [str(val).lower() for val in value]
-            return str(value).lower() == str(override_value).lower()
+                return str(override_value).casefold() in [str(val).casefold() for val in value]
+            return str(value).casefold() == str(override_value).casefold()
 
         if operator == "exact":
             return compute_exact_match(value, override_value)
@@ -141,10 +141,10 @@ def match_property(property, property_values) -> bool:
         return key in property_values
 
     if operator == "icontains":
-        return str(value).lower() in str(override_value).lower()
+        return str(value).casefold() in str(override_value).casefold()
 
     if operator == "not_icontains":
-        return str(value).lower() not in str(override_value).lower()
+        return str(value).casefold() not in str(override_value).casefold()
 
     if operator == "regex":
         return is_valid_regex(str(value)) and re.compile(str(value)).search(str(override_value)) is not None

--- a/posthog/feature_flags.py
+++ b/posthog/feature_flags.py
@@ -131,7 +131,7 @@ def match_property(property, property_values) -> bool:
         def compute_exact_match(value, override_value):
             if isinstance(value, list):
                 return str(override_value).casefold() in [str(val).casefold() for val in value]
-            return utils.str_icontains(value, override_value)
+            return utils.str_iequals(value, override_value)
 
         if operator == "exact":
             return compute_exact_match(value, override_value)

--- a/posthog/feature_flags.py
+++ b/posthog/feature_flags.py
@@ -7,6 +7,7 @@ from typing import Optional
 from dateutil import parser
 from dateutil.relativedelta import relativedelta
 
+from posthog import utils
 from posthog.utils import convert_to_datetime_aware, is_valid_regex
 
 __LONG_SCALE__ = float(0xFFFFFFFFFFFFFFF)
@@ -130,7 +131,7 @@ def match_property(property, property_values) -> bool:
         def compute_exact_match(value, override_value):
             if isinstance(value, list):
                 return str(override_value).casefold() in [str(val).casefold() for val in value]
-            return str(value).casefold() == str(override_value).casefold()
+            return utils.str_icontains(value, override_value)
 
         if operator == "exact":
             return compute_exact_match(value, override_value)
@@ -141,10 +142,10 @@ def match_property(property, property_values) -> bool:
         return key in property_values
 
     if operator == "icontains":
-        return str(value).casefold() in str(override_value).casefold()
+        return utils.str_icontains(override_value, value)
 
     if operator == "not_icontains":
-        return str(value).casefold() not in str(override_value).casefold()
+        return not utils.str_icontains(override_value, value)
 
     if operator == "regex":
         return is_valid_regex(str(value)) and re.compile(str(value)).search(str(override_value)) is not None

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -32,7 +32,7 @@ class TestLocalEvaluation(unittest.TestCase):
         self.client = Client(FAKE_TEST_API_KEY, on_error=self.set_fail)
 
     @mock.patch("posthog.client.get")
-    def test_flag_person_properties(self):
+    def test_flag_person_properties(self, patch_get):
         self.client.feature_flags = [
             {
                 "id": 1,

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -125,3 +125,43 @@ def convert_to_datetime_aware(date_obj):
     if date_obj.tzinfo is None:
         date_obj = date_obj.replace(tzinfo=timezone.utc)
     return date_obj
+
+
+def str_icontains(source, search):
+    """
+    Check if a string contains another string, ignoring case.
+
+    Args:
+        source: The string to search within
+        search: The substring to search for
+
+    Returns:
+        bool: True if search is a substring of source (case-insensitive), False otherwise
+
+    Examples:
+        >>> str_icontains("Hello World", "WORLD")
+        True
+        >>> str_icontains("Hello World", "python")
+        False
+    """
+    return str(search).casefold() in str(source).casefold()
+
+
+def str_iequals(value, comparand):
+    """
+    Check if a string equals another string, ignoring case.
+
+    Args:
+        value: The string to compare
+        comparand: The string to compare with
+
+    Returns:
+        bool: True if value and comparand are equal (case-insensitive), False otherwise
+
+    Examples:
+        >>> str_iequals("Hello World", "hello world")
+        True
+        >>> str_iequals("Hello World", "hello")
+        False
+    """
+    return str(value).casefold() == str(comparand).casefold()


### PR DESCRIPTION
Calling `lower()` on two strings in order to compare them is incorrect in some cases (297 as of Unicode 13.0.0). For example, the lower case of `Straße` has two correct values: `straße` and `strasse`.

This PR adds a failing unit test that demonstrates the problem. Then it replaces string comparisons using `lower()` with `casefold()` to ensure the test passes.

This aligns with the official Python [docs on casefold](https://docs.python.org/3/library/stdtypes.html#str.casefold) which notes (emphasis mine): 

> Return a casefolded copy of the string. __Casefolded strings may be used for caseless matching.__

Contrast this with what the Unicode standard [Section 3.13](https://www.unicode.org/versions/Unicode13.0.0/ch03.pdf) has to say about changing the case vs case folding:

> Case folding is related to case conversion. However, the main purpose of case folding is to contribute to caseless matching of strings, whereas the main purpose of case conversion is to put strings into a particular cased form.

If this change is accepted, I can follow-up with some of the other libraries to see if they run afoul of this issue.