### PR TITLE
feat: add beta parse method support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.12.0 - 2025-02-11
+
+1. Add support for OpenAI beta parse API.
+
 ## 3.11.1 - 2025-02-06
 
 1. Fix LangChain callback handler to capture parent run ID.

--- a/llm_observability_examples.py
+++ b/llm_observability_examples.py
@@ -1,9 +1,10 @@
 import os
 import uuid
 
+from pydantic import BaseModel
+
 import posthog
 from posthog.ai.openai import AsyncOpenAI, OpenAI
-from pydantic import BaseModel
 
 # Example credentials - replace these with your own or use environment variables
 posthog.project_api_key = os.getenv("POSTHOG_PROJECT_API_KEY", "your-project-api-key")

--- a/llm_observability_examples.py
+++ b/llm_observability_examples.py
@@ -22,6 +22,7 @@ async_openai_client = AsyncOpenAI(
     posthog_client=posthog,
 )
 
+
 def main_sync():
     trace_id = str(uuid.uuid4())
     print("Trace ID:", trace_id)
@@ -187,12 +188,11 @@ async def embedding_async_openai_call(posthog_distinct_id, posthog_trace_id, pos
     return response
 
 
-# TODO: add beta client
-
 class CalendarEvent(BaseModel):
     name: str
     date: str
     participants: list[str]
+
 
 def beta_openai_call(distinct_id, trace_id, properties, groups):
     response = openai_client.beta.chat.completions.parse(
@@ -209,6 +209,7 @@ def beta_openai_call(distinct_id, trace_id, properties, groups):
     )
     print(response)
     return response
+
 
 # HOW TO RUN:
 # comment out one of these to run the other

--- a/llm_observability_examples.py
+++ b/llm_observability_examples.py
@@ -3,10 +3,10 @@ import uuid
 
 import posthog
 from posthog.ai.openai import AsyncOpenAI, OpenAI
+from pydantic import BaseModel
 
 # Example credentials - replace these with your own or use environment variables
 posthog.project_api_key = os.getenv("POSTHOG_PROJECT_API_KEY", "your-project-api-key")
-posthog.personal_api_key = os.getenv("POSTHOG_PERSONAL_API_KEY", "your-personal-api-key")
 posthog.host = os.getenv("POSTHOG_HOST", "http://localhost:8000")  # Or https://app.posthog.com
 posthog.debug = True
 # change this to False to see usage events
@@ -22,7 +22,6 @@ async_openai_client = AsyncOpenAI(
     posthog_client=posthog,
 )
 
-
 def main_sync():
     trace_id = str(uuid.uuid4())
     print("Trace ID:", trace_id)
@@ -31,10 +30,11 @@ def main_sync():
     groups = {"company": "test_company"}
 
     try:
-        basic_openai_call(distinct_id, trace_id, properties, groups)
-        streaming_openai_call(distinct_id, trace_id, properties, groups)
-        embedding_openai_call(distinct_id, trace_id, properties, groups)
-        image_openai_call()
+        # basic_openai_call(distinct_id, trace_id, properties, groups)
+        # streaming_openai_call(distinct_id, trace_id, properties, groups)
+        # embedding_openai_call(distinct_id, trace_id, properties, groups)
+        # image_openai_call()
+        beta_openai_call(distinct_id, trace_id, properties, groups)
     except Exception as e:
         print("Error during OpenAI call:", str(e))
 
@@ -187,10 +187,32 @@ async def embedding_async_openai_call(posthog_distinct_id, posthog_trace_id, pos
     return response
 
 
+# TODO: add beta client
+
+class CalendarEvent(BaseModel):
+    name: str
+    date: str
+    participants: list[str]
+
+def beta_openai_call(distinct_id, trace_id, properties, groups):
+    response = openai_client.beta.chat.completions.parse(
+        model="gpt-4o-mini",
+        messages=[
+            {"role": "system", "content": "Extract the event information."},
+            {"role": "user", "content": "Alice and Bob are going to a science fair on Friday."},
+        ],
+        response_format=CalendarEvent,
+        posthog_distinct_id=distinct_id,
+        posthog_trace_id=trace_id,
+        posthog_properties=properties,
+        posthog_groups=groups,
+    )
+    print(response)
+    return response
+
 # HOW TO RUN:
 # comment out one of these to run the other
 
 if __name__ == "__main__":
     main_sync()
-
 # asyncio.run(main_async())

--- a/posthog/ai/openai/openai.py
+++ b/posthog/ai/openai/openai.py
@@ -280,7 +280,6 @@ class WrappedBetaCompletions(openai.resources.beta.chat.completions.Completions)
         posthog_groups: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ):
-        print("kwargs", kwargs)
         return call_llm_and_track_usage(
             posthog_distinct_id,
             self._client._ph_client,

--- a/posthog/ai/openai/openai.py
+++ b/posthog/ai/openai/openai.py
@@ -31,6 +31,7 @@ class OpenAI(openai.OpenAI):
         self._ph_client = posthog_client
         self.chat = WrappedChat(self)
         self.embeddings = WrappedEmbeddings(self)
+        self.beta = WrappedBeta(self)
 
 
 class WrappedChat(openai.resources.chat.Chat):
@@ -249,3 +250,46 @@ class WrappedEmbeddings(openai.resources.embeddings.Embeddings):
             )
 
         return response
+
+
+class WrappedBeta(openai.resources.beta.Beta):
+    _client: OpenAI
+
+    @property
+    def chat(self):
+        return WrappedBetaChat(self._client)
+
+
+class WrappedBetaChat(openai.resources.beta.chat.Chat):
+    _client: OpenAI
+
+    @property
+    def completions(self):
+        return WrappedBetaCompletions(self._client)
+
+
+class WrappedBetaCompletions(openai.resources.beta.chat.completions.Completions):
+    _client: OpenAI
+
+    def parse(
+        self,
+        posthog_distinct_id: Optional[str] = None,
+        posthog_trace_id: Optional[str] = None,
+        posthog_properties: Optional[Dict[str, Any]] = None,
+        posthog_privacy_mode: bool = False,
+        posthog_groups: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ):
+        print("kwargs", kwargs)
+        return call_llm_and_track_usage(
+            posthog_distinct_id,
+            self._client._ph_client,
+            "openai",
+            posthog_trace_id,
+            posthog_properties,
+            posthog_privacy_mode,
+            posthog_groups,
+            self._client.base_url,
+            super().parse,
+            **kwargs,
+        )

--- a/posthog/ai/openai/openai_async.py
+++ b/posthog/ai/openai/openai_async.py
@@ -248,3 +248,44 @@ class WrappedEmbeddings(openai.resources.embeddings.AsyncEmbeddings):
             )
 
         return response
+
+class WrappedBeta(openai.resources.beta.Beta):
+    _client: AsyncOpenAI
+
+    @property
+    def chat(self):
+        return WrappedBetaChat(self._client)
+
+
+class WrappedBetaChat(openai.resources.beta.chat.Chat):
+    _client: AsyncOpenAI
+
+    @property
+    def completions(self):
+        return WrappedBetaCompletions(self._client)
+
+
+class WrappedBetaCompletions(openai.resources.beta.chat.completions.Completions):
+    _client: AsyncOpenAI
+
+    def parse(
+        self,
+        posthog_distinct_id: Optional[str] = None,
+        posthog_trace_id: Optional[str] = None,
+        posthog_properties: Optional[Dict[str, Any]] = None,
+        posthog_privacy_mode: bool = False,
+        posthog_groups: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ):
+        return call_llm_and_track_usage_async(
+            posthog_distinct_id,
+            self._client._ph_client,
+            "openai",
+            posthog_trace_id,
+            posthog_properties,
+            posthog_privacy_mode,
+            posthog_groups,
+            self._client.base_url,
+            super().parse,
+            **kwargs,
+        )

--- a/posthog/ai/openai/openai_async.py
+++ b/posthog/ai/openai/openai_async.py
@@ -30,6 +30,7 @@ class AsyncOpenAI(openai.AsyncOpenAI):
         self._ph_client = posthog_client
         self.chat = WrappedChat(self)
         self.embeddings = WrappedEmbeddings(self)
+        self.beta = WrappedBeta(self)
 
 
 class WrappedChat(openai.resources.chat.AsyncChat):
@@ -250,7 +251,7 @@ class WrappedEmbeddings(openai.resources.embeddings.AsyncEmbeddings):
         return response
 
 
-class WrappedBeta(openai.resources.beta.Beta):
+class WrappedBeta(openai.resources.beta.AsyncBeta):
     _client: AsyncOpenAI
 
     @property
@@ -258,7 +259,7 @@ class WrappedBeta(openai.resources.beta.Beta):
         return WrappedBetaChat(self._client)
 
 
-class WrappedBetaChat(openai.resources.beta.chat.Chat):
+class WrappedBetaChat(openai.resources.beta.chat.AsyncChat):
     _client: AsyncOpenAI
 
     @property
@@ -266,10 +267,10 @@ class WrappedBetaChat(openai.resources.beta.chat.Chat):
         return WrappedBetaCompletions(self._client)
 
 
-class WrappedBetaCompletions(openai.resources.beta.chat.completions.Completions):
+class WrappedBetaCompletions(openai.resources.beta.chat.completions.AsyncCompletions):
     _client: AsyncOpenAI
 
-    def parse(
+    async def parse(
         self,
         posthog_distinct_id: Optional[str] = None,
         posthog_trace_id: Optional[str] = None,
@@ -278,7 +279,7 @@ class WrappedBetaCompletions(openai.resources.beta.chat.completions.Completions)
         posthog_groups: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ):
-        return call_llm_and_track_usage_async(
+        return await call_llm_and_track_usage_async(
             posthog_distinct_id,
             self._client._ph_client,
             "openai",

--- a/posthog/ai/openai/openai_async.py
+++ b/posthog/ai/openai/openai_async.py
@@ -249,6 +249,7 @@ class WrappedEmbeddings(openai.resources.embeddings.AsyncEmbeddings):
 
         return response
 
+
 class WrappedBeta(openai.resources.beta.Beta):
     _client: AsyncOpenAI
 

--- a/posthog/version.py
+++ b/posthog/version.py
@@ -1,4 +1,4 @@
-VERSION = "3.11.1"
+VERSION = "3.12.0"
 
 if __name__ == "__main__":
     print(VERSION, end="")  # noqa: T201


### PR DESCRIPTION
Add support for the  `client.beta.chat.completions.parse` method

Example:

`
class CalendarEvent(BaseModel):
    name: str
    date: str
    participants: list[str]

def beta_openai_call(distinct_id, trace_id, properties, groups):
    response = openai_client.beta.chat.completions.parse(
        model="gpt-4o-mini",
        messages=[
            {"role": "system", "content": "Extract the event information."},
            {"role": "user", "content": "Alice and Bob are going to a science fair on Friday."},
        ],
        response_format=CalendarEvent,
        posthog_distinct_id=distinct_id,
        posthog_trace_id=trace_id,
        posthog_properties=properties,
        posthog_groups=groups,
    )
    print(response)
    return response
`