### PR TITLE
fix(flags): remove `lower()` when evaluating feature flag payloads – these payloads are case-sensitive!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.14.0 - 2025-02-19
+
+1. Evaluate feature flag payloads with case sensitivity correctly.  Fixes <https://github.com/PostHog/posthog-python/issues/178>
+
 ## 3.13.0 - 2025-02-12
 
 1. Automatically retry connection errors

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -859,6 +859,7 @@ class Client(object):
         flag_filters = flag_definition.get("filters") or {}
         flag_payloads = flag_filters.get("payloads") or {}
         payload = flag_payloads.get(str(match_value), None)
+        return payload
 
     def get_all_flags(
         self,

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -855,10 +855,14 @@ class Client(object):
         if self.feature_flags_by_key is None:
             return payload
 
-        flag_definition = self.feature_flags_by_key.get(key) or {}
-        flag_filters = flag_definition.get("filters") or {}
-        flag_payloads = flag_filters.get("payloads") or {}
-        payload = flag_payloads.get(str(match_value), None)
+        flag_definition = self.feature_flags_by_key.get(key)
+        if flag_definition:
+            flag_filters = flag_definition.get("filters") or {}
+            flag_payloads = flag_filters.get("payloads") or {}
+            # For boolean flags, convert True to "true"
+            # For multivariate flags, use the variant string as-is
+            lookup_value = "true" if isinstance(match_value, bool) and match_value else str(match_value)
+            payload = flag_payloads.get(lookup_value, None)
         return payload
 
     def get_all_flags(

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -4640,3 +4640,47 @@ class TestConsistency(unittest.TestCase):
                 self.assertEqual(feature_flag_match, results[i])
             else:
                 self.assertFalse(feature_flag_match)
+
+    @mock.patch("posthog.client.decide")
+    def test_feature_flag_case_insensitive(self, mock_decide):
+        client = Client(api_key=FAKE_TEST_API_KEY, personal_api_key=FAKE_TEST_API_KEY)
+        client.feature_flags = [
+            {
+                "id": 1,
+                "key": "Beta-Feature",
+                "active": True,
+                "filters": {
+                    "groups": [{"properties": [], "rollout_percentage": 100}],
+                },
+            }
+        ]
+
+        # Test that flag evaluation works regardless of case
+        self.assertTrue(client.feature_enabled("Beta-Feature", "user1"))
+        self.assertTrue(client.feature_enabled("beta-feature", "user1"))
+        self.assertTrue(client.feature_enabled("BETA-FEATURE", "user1"))
+
+    @mock.patch("posthog.client.decide")
+    def test_feature_flag_mixed_case_consistency(self, mock_decide):
+        client = Client(api_key=FAKE_TEST_API_KEY, personal_api_key=FAKE_TEST_API_KEY)
+        client.feature_flags = [
+            {
+                "id": 1,
+                "key": "Beta-Feature",
+                "active": True,
+                "filters": {
+                    "groups": [{"properties": [], "rollout_percentage": 100}],
+                    "payloads": {
+                        "true": {"some": "value"},
+                    }
+                },
+            }
+        ]
+
+        # Test that flag evaluation and payload retrieval are consistent
+        # regardless of the case used
+        test_cases = ["Beta-Feature", "beta-feature", "BETA-FEATURE", "bEtA-FeAtUrE"]
+        
+        for case in test_cases:
+            # Both the flag evaluation and payload retrieval should work
+            self.assertTrue(client.feature_enabled(case, "user1"))

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -4643,6 +4643,8 @@ class TestConsistency(unittest.TestCase):
 
     @mock.patch("posthog.client.decide")
     def test_feature_flag_case_sensitive(self, mock_decide):
+        mock_decide.return_value = {"featureFlags": {}}  # Ensure decide returns empty flags
+
         client = Client(api_key=FAKE_TEST_API_KEY, personal_api_key=FAKE_TEST_API_KEY)
         client.feature_flags = [
             {

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -4640,6 +4640,7 @@ class TestConsistency(unittest.TestCase):
                 self.assertEqual(feature_flag_match, results[i])
             else:
                 self.assertFalse(feature_flag_match)
+
     @mock.patch("posthog.client.decide")
     def test_feature_flag_case_insensitive(self, mock_decide):
         client = Client(api_key=FAKE_TEST_API_KEY, personal_api_key=FAKE_TEST_API_KEY)
@@ -4663,7 +4664,7 @@ class TestConsistency(unittest.TestCase):
     def test_feature_flag_payload_case_insensitive(self, mock_decide):
         mock_decide.return_value = {
             "featureFlags": {"beta-feature": True},
-            "featureFlagPayloads": {"beta-feature": {"some": "value"}}
+            "featureFlagPayloads": {"beta-feature": {"some": "value"}},
         }
 
         client = Client(api_key=FAKE_TEST_API_KEY, personal_api_key=FAKE_TEST_API_KEY)
@@ -4676,7 +4677,7 @@ class TestConsistency(unittest.TestCase):
                     "groups": [{"properties": [], "rollout_percentage": 100}],
                     "payloads": {
                         "true": {"some": "value"},
-                    }
+                    },
                 },
             }
         ]
@@ -4690,7 +4691,7 @@ class TestConsistency(unittest.TestCase):
     def test_feature_flag_mixed_case_consistency(self, mock_decide):
         mock_decide.return_value = {
             "featureFlags": {"beta-feature": True},
-            "featureFlagPayloads": {"beta-feature": {"some": "value"}}
+            "featureFlagPayloads": {"beta-feature": {"some": "value"}},
         }
 
         client = Client(api_key=FAKE_TEST_API_KEY, personal_api_key=FAKE_TEST_API_KEY)
@@ -4703,14 +4704,14 @@ class TestConsistency(unittest.TestCase):
                     "groups": [{"properties": [], "rollout_percentage": 100}],
                     "payloads": {
                         "true": {"some": "value"},
-                    }
+                    },
                 },
             }
         ]
 
         # Test that flag evaluation and payload retrieval are consistent
         # regardless of the case used
-        test_cases = ["Beta-Feature", "beta-feature", "BETA-FEATURE", "bEtA-FeAtUrE"]        
+        test_cases = ["Beta-Feature", "beta-feature", "BETA-FEATURE", "bEtA-FeAtUrE"]
         for case in test_cases:
             # Both the flag evaluation and payload retrieval should work
             self.assertTrue(client.feature_enabled(case, "user1"))

--- a/posthog/version.py
+++ b/posthog/version.py
@@ -1,4 +1,4 @@
-VERSION = "3.13.0"
+VERSION = "3.14.0"
 
 if __name__ == "__main__":
     print(VERSION, end="")  # noqa: T201


### PR DESCRIPTION
Remove `lower()` when evaluating feature flags + feature flag payloads – feature flags are case-sensitive.  Closes https://github.com/PostHog/posthog-python/issues/178