### PR TITLE
feat(feature-flags): support quota limiting for feature flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 3.14.0 - 2025-02-19
-
-1. Evaluate feature flag payloads with case sensitivity correctly.  Fixes <https://github.com/PostHog/posthog-python/issues/178>
-
 ## 3.13.0 - 2025-02-12
 
 1. Automatically retry connection errors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.14.0 - 2025-02-19
+
+1. Evaluate feature flag payloads with case sensitivity correctly.  Fixes <https://github.com/PostHog/posthog-python/issues/178>
+
 ## 3.13.0 - 2025-02-12
 
 1. Automatically retry connection errors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.15.0 - 2025-02-19
+
+1. Support quota-limited feature flags
+
 ## 3.14.2 - 2025-02-19
 
 1. Evaluate feature flag payloads with case sensitivity correctly.  Fixes <https://github.com/PostHog/posthog-python/issues/178>

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -607,6 +607,12 @@ class Client(object):
                 self.feature_flags_by_key = {}
                 self.group_type_mapping = {}
                 self.cohorts = {}
+                
+                if self.debug:
+                    raise APIError(
+                        status=402,
+                        message="PostHog feature flags quota limited",
+                    )
             else:
                 self.log.error(f"[FEATURE FLAGS] Error loading feature flags: {e}")
         except Exception as e:

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -607,7 +607,7 @@ class Client(object):
                 self.feature_flags_by_key = {}
                 self.group_type_mapping = {}
                 self.cohorts = {}
-                
+
                 if self.debug:
                     raise APIError(
                         status=402,

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -859,6 +859,7 @@ class Client(object):
         flag_filters = flag_definition.get("filters") or {}
         flag_payloads = flag_filters.get("payloads") or {}
         payload = flag_payloads.get(str(match_value), None)
+        return payload
 
     def get_all_flags(
         self,

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -600,6 +600,13 @@ class Client(object):
                         "To use feature flags, please set a personal_api_key "
                         "More information: https://posthog.com/docs/api/overview",
                     )
+            elif e.status == 402:
+                self.log.warning("[FEATURE FLAGS] PostHog feature flags quota limited")
+                # Reset all feature flag data when quota limited
+                self.feature_flags = []
+                self.feature_flags_by_key = {}
+                self.group_type_mapping = {}
+                self.cohorts = {}
             else:
                 self.log.error(f"[FEATURE FLAGS] Error loading feature flags: {e}")
         except Exception as e:

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -855,10 +855,14 @@ class Client(object):
         if self.feature_flags_by_key is None:
             return payload
 
-        flag_definition = self.feature_flags_by_key.get(key) or {}
-        flag_filters = flag_definition.get("filters") or {}
-        flag_payloads = flag_filters.get("payloads") or {}
-        payload = flag_payloads.get(str(match_value), None)
+        flag_definition = self.feature_flags_by_key.get(key)
+        if flag_definition:
+            flag_filters = flag_definition.get("filters") or {}
+            flag_payloads = flag_filters.get("payloads") or {}
+            # For boolean flags, convert True to "true"
+            # For multivariate flags, use the variant string as-is
+            lookup_value = "true" if isinstance(match_value, bool) and match_value else str(match_value)
+            payload = flag_payloads.get(lookup_value, None)
         return payload
 
     def get_all_flags(

--- a/posthog/request.py
+++ b/posthog/request.py
@@ -70,7 +70,7 @@ def _process_response(
         log.debug(success_message)
         response = res.json() if return_json else res
         # Handle quota limited decide responses by raising a specific error
-        if isinstance(response, dict) and "quotaLimited" in response and "feature_flags" in response["quotaLimited"]:
+        if isinstance(response, dict) and "quotaLimited" in response and isinstance(response["quotaLimited"], list) and "feature_flags" in response["quotaLimited"]:
             log.warning("PostHog feature flags quota limited")
             raise QuotaLimitError(res.status_code, "Feature flags quota limited")
         return response

--- a/posthog/request.py
+++ b/posthog/request.py
@@ -68,7 +68,12 @@ def _process_response(
     log = logging.getLogger("posthog")
     if res.status_code == 200:
         log.debug(success_message)
-        return res.json() if return_json else res
+        response = res.json() if return_json else res
+        # Handle quota limited decide responses by raising a specific error
+        if isinstance(response, dict) and "quotaLimited" in response and "feature_flags" in response["quotaLimited"]:
+            log.warning("PostHog feature flags quota limited")
+            raise QuotaLimitError(res.status_code, "Feature flags quota limited")
+        return response
     try:
         payload = res.json()
         log.debug("received response: %s", payload)
@@ -105,6 +110,10 @@ class APIError(Exception):
     def __str__(self):
         msg = "[PostHog] {0} ({1})"
         return msg.format(self.message, self.status)
+
+
+class QuotaLimitError(APIError):
+    pass
 
 
 class DatetimeSerializer(json.JSONEncoder):

--- a/posthog/request.py
+++ b/posthog/request.py
@@ -70,7 +70,12 @@ def _process_response(
         log.debug(success_message)
         response = res.json() if return_json else res
         # Handle quota limited decide responses by raising a specific error
-        if isinstance(response, dict) and "quotaLimited" in response and isinstance(response["quotaLimited"], list) and "feature_flags" in response["quotaLimited"]:
+        if (
+            isinstance(response, dict)
+            and "quotaLimited" in response
+            and isinstance(response["quotaLimited"], list)
+            and "feature_flags" in response["quotaLimited"]
+        ):
             log.warning("PostHog feature flags quota limited")
             raise QuotaLimitError(res.status_code, "Feature flags quota limited")
         return response

--- a/posthog/request.py
+++ b/posthog/request.py
@@ -70,6 +70,8 @@ def _process_response(
         log.debug(success_message)
         response = res.json() if return_json else res
         # Handle quota limited decide responses by raising a specific error
+        # NB: other services also put entries into the quotaLimited key, but right now we only care about feature flags
+        # since most of the other services handle quota limiting in other places in the application.
         if (
             isinstance(response, dict)
             and "quotaLimited" in response

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -7,6 +7,7 @@ import mock
 import six
 
 from posthog.client import Client
+from posthog.request import APIError
 from posthog.test.test_utils import FAKE_TEST_API_KEY
 from posthog.version import VERSION
 
@@ -383,6 +384,26 @@ class TestClient(unittest.TestCase):
         assert "$feature/beta-feature-local" not in msg["properties"]
         assert "$feature/false-flag" not in msg["properties"]
         assert "$active_feature_flags" not in msg["properties"]
+
+
+    @mock.patch("posthog.client.get")
+    def test_load_feature_flags_quota_limited(self, patch_get):
+        mock_response = {
+            "type": "quota_limited",
+            "detail": "You have exceeded your feature flag request quota",
+            "code": "payment_required"
+        }
+        patch_get.side_effect = APIError(402, mock_response["detail"])
+        
+        client = Client(FAKE_TEST_API_KEY, personal_api_key="test")
+        with self.assertLogs("posthog", level="WARNING") as logs:
+            client._load_feature_flags()
+            
+            self.assertEqual(client.feature_flags, [])
+            self.assertEqual(client.feature_flags_by_key, {})
+            self.assertEqual(client.group_type_mapping, {})
+            self.assertEqual(client.cohorts, {})
+            self.assertIn("PostHog feature flags quota limited", logs.output[0])
 
     @mock.patch("posthog.client.decide")
     def test_dont_override_capture_with_local_flags(self, patch_decide):

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -385,20 +385,19 @@ class TestClient(unittest.TestCase):
         assert "$feature/false-flag" not in msg["properties"]
         assert "$active_feature_flags" not in msg["properties"]
 
-
     @mock.patch("posthog.client.get")
     def test_load_feature_flags_quota_limited(self, patch_get):
         mock_response = {
             "type": "quota_limited",
             "detail": "You have exceeded your feature flag request quota",
-            "code": "payment_required"
+            "code": "payment_required",
         }
         patch_get.side_effect = APIError(402, mock_response["detail"])
-        
+
         client = Client(FAKE_TEST_API_KEY, personal_api_key="test")
         with self.assertLogs("posthog", level="WARNING") as logs:
             client._load_feature_flags()
-            
+
             self.assertEqual(client.feature_flags, [])
             self.assertEqual(client.feature_flags_by_key, {})
             self.assertEqual(client.group_type_mapping, {})

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -4640,3 +4640,47 @@ class TestConsistency(unittest.TestCase):
                 self.assertEqual(feature_flag_match, results[i])
             else:
                 self.assertFalse(feature_flag_match)
+
+    @mock.patch("posthog.client.decide")
+    def test_feature_flag_case_insensitive(self, mock_decide):
+        client = Client(api_key=FAKE_TEST_API_KEY, personal_api_key=FAKE_TEST_API_KEY)
+        client.feature_flags = [
+            {
+                "id": 1,
+                "key": "Beta-Feature",
+                "active": True,
+                "filters": {
+                    "groups": [{"properties": [], "rollout_percentage": 100}],
+                },
+            }
+        ]
+
+        # Test that flag evaluation works regardless of case
+        self.assertTrue(client.feature_enabled("Beta-Feature", "user1"))
+        self.assertTrue(client.feature_enabled("beta-feature", "user1"))
+        self.assertTrue(client.feature_enabled("BETA-FEATURE", "user1"))
+
+    @mock.patch("posthog.client.decide")
+    def test_feature_flag_mixed_case_consistency(self, mock_decide):
+        client = Client(api_key=FAKE_TEST_API_KEY, personal_api_key=FAKE_TEST_API_KEY)
+        client.feature_flags = [
+            {
+                "id": 1,
+                "key": "Beta-Feature",
+                "active": True,
+                "filters": {
+                    "groups": [{"properties": [], "rollout_percentage": 100}],
+                    "payloads": {
+                        "true": {"some": "value"},
+                    }
+                },
+            }
+        ]
+
+        # Test that flag evaluation and payload retrieval are consistent
+        # regardless of the case used
+        test_cases = ["Beta-Feature", "beta-feature", "BETA-FEATURE", "bEtA-FeAtUrE"]
+        
+        for case in test_cases:
+            # Both the flag evaluation and payload retrieval should work
+            self.assertTrue(client.feature_enabled(case, "user1"))

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -4643,6 +4643,8 @@ class TestConsistency(unittest.TestCase):
 
     @mock.patch("posthog.client.decide")
     def test_feature_flag_case_sensitive(self, mock_decide):
+        mock_decide.return_value = {"featureFlags": {}}  # Ensure decide returns empty flags
+
         client = Client(api_key=FAKE_TEST_API_KEY, personal_api_key=FAKE_TEST_API_KEY)
         client.feature_flags = [
             {

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -4640,6 +4640,7 @@ class TestConsistency(unittest.TestCase):
                 self.assertEqual(feature_flag_match, results[i])
             else:
                 self.assertFalse(feature_flag_match)
+
     @mock.patch("posthog.client.decide")
     def test_feature_flag_case_insensitive(self, mock_decide):
         client = Client(api_key=FAKE_TEST_API_KEY, personal_api_key=FAKE_TEST_API_KEY)
@@ -4663,7 +4664,7 @@ class TestConsistency(unittest.TestCase):
     def test_feature_flag_payload_case_insensitive(self, mock_decide):
         mock_decide.return_value = {
             "featureFlags": {"beta-feature": True},
-            "featureFlagPayloads": {"beta-feature": {"some": "value"}}
+            "featureFlagPayloads": {"beta-feature": {"some": "value"}},
         }
 
         client = Client(api_key=FAKE_TEST_API_KEY, personal_api_key=FAKE_TEST_API_KEY)
@@ -4676,7 +4677,7 @@ class TestConsistency(unittest.TestCase):
                     "groups": [{"properties": [], "rollout_percentage": 100}],
                     "payloads": {
                         "true": {"some": "value"},
-                    }
+                    },
                 },
             }
         ]
@@ -4690,7 +4691,7 @@ class TestConsistency(unittest.TestCase):
     def test_feature_flag_mixed_case_consistency(self, mock_decide):
         mock_decide.return_value = {
             "featureFlags": {"beta-feature": True},
-            "featureFlagPayloads": {"beta-feature": {"some": "value"}}
+            "featureFlagPayloads": {"beta-feature": {"some": "value"}},
         }
 
         client = Client(api_key=FAKE_TEST_API_KEY, personal_api_key=FAKE_TEST_API_KEY)
@@ -4703,14 +4704,14 @@ class TestConsistency(unittest.TestCase):
                     "groups": [{"properties": [], "rollout_percentage": 100}],
                     "payloads": {
                         "true": {"some": "value"},
-                    }
+                    },
                 },
             }
         ]
 
         # Test that flag evaluation and payload retrieval are consistent
         # regardless of the case used
-        test_cases = ["Beta-Feature", "beta-feature", "BETA-FEATURE", "bEtA-FeAtUrE"]        
+        test_cases = ["Beta-Feature", "beta-feature", "BETA-FEATURE", "bEtA-FeAtUrE"]
         for case in test_cases:
             # Both the flag evaluation and payload retrieval should work
             self.assertTrue(client.feature_enabled(case, "user1"))

--- a/posthog/test/test_request.py
+++ b/posthog/test/test_request.py
@@ -48,30 +48,30 @@ class TestRequests(unittest.TestCase):
     def test_quota_limited_response(self):
         mock_response = requests.Response()
         mock_response.status_code = 200
-        mock_response._content = json.dumps({
-            "quotaLimited": ["feature_flags"],
-            "featureFlags": {},
-            "featureFlagPayloads": {},
-            "errorsWhileComputingFlags": False
-        }).encode('utf-8')
+        mock_response._content = json.dumps(
+            {
+                "quotaLimited": ["feature_flags"],
+                "featureFlags": {},
+                "featureFlagPayloads": {},
+                "errorsWhileComputingFlags": False,
+            }
+        ).encode("utf-8")
 
-        with mock.patch('posthog.request._session.post', return_value=mock_response):
+        with mock.patch("posthog.request._session.post", return_value=mock_response):
             with self.assertRaises(QuotaLimitError) as cm:
                 decide("fake_key", "fake_host")
-            
+
             self.assertEqual(cm.exception.status, 200)
             self.assertEqual(cm.exception.message, "Feature flags quota limited")
 
     def test_normal_decide_response(self):
         mock_response = requests.Response()
         mock_response.status_code = 200
-        mock_response._content = json.dumps({
-            "featureFlags": {"flag1": True},
-            "featureFlagPayloads": {},
-            "errorsWhileComputingFlags": False
-        }).encode('utf-8')
+        mock_response._content = json.dumps(
+            {"featureFlags": {"flag1": True}, "featureFlagPayloads": {}, "errorsWhileComputingFlags": False}
+        ).encode("utf-8")
 
-        with mock.patch('posthog.request._session.post', return_value=mock_response):
+        with mock.patch("posthog.request._session.post", return_value=mock_response):
             response = decide("fake_key", "fake_host")
             self.assertEqual(response["featureFlags"], {"flag1": True})
 

--- a/posthog/test/test_request.py
+++ b/posthog/test/test_request.py
@@ -2,11 +2,11 @@ import json
 import unittest
 from datetime import date, datetime
 
+import mock
 import pytest
 import requests
-import mock
 
-from posthog.request import DatetimeSerializer, batch_post, decide, determine_server_host, QuotaLimitError
+from posthog.request import DatetimeSerializer, QuotaLimitError, batch_post, decide, determine_server_host
 from posthog.test.test_utils import TEST_API_KEY
 
 

--- a/posthog/test/test_request.py
+++ b/posthog/test/test_request.py
@@ -4,8 +4,9 @@ from datetime import date, datetime
 
 import pytest
 import requests
+import mock
 
-from posthog.request import DatetimeSerializer, batch_post, determine_server_host
+from posthog.request import DatetimeSerializer, batch_post, decide, determine_server_host, QuotaLimitError
 from posthog.test.test_utils import TEST_API_KEY
 
 
@@ -43,6 +44,36 @@ class TestRequests(unittest.TestCase):
             batch_post(
                 "key", batch=[{"distinct_id": "distinct_id", "event": "python event", "type": "track"}], timeout=0.0001
             )
+
+    def test_quota_limited_response(self):
+        mock_response = requests.Response()
+        mock_response.status_code = 200
+        mock_response._content = json.dumps({
+            "quotaLimited": ["feature_flags"],
+            "featureFlags": {},
+            "featureFlagPayloads": {},
+            "errorsWhileComputingFlags": False
+        }).encode('utf-8')
+
+        with mock.patch('posthog.request._session.post', return_value=mock_response):
+            with self.assertRaises(QuotaLimitError) as cm:
+                decide("fake_key", "fake_host")
+            
+            self.assertEqual(cm.exception.status, 200)
+            self.assertEqual(cm.exception.message, "Feature flags quota limited")
+
+    def test_normal_decide_response(self):
+        mock_response = requests.Response()
+        mock_response.status_code = 200
+        mock_response._content = json.dumps({
+            "featureFlags": {"flag1": True},
+            "featureFlagPayloads": {},
+            "errorsWhileComputingFlags": False
+        }).encode('utf-8')
+
+        with mock.patch('posthog.request._session.post', return_value=mock_response):
+            response = decide("fake_key", "fake_host")
+            self.assertEqual(response["featureFlags"], {"flag1": True})
 
 
 @pytest.mark.parametrize(

--- a/posthog/version.py
+++ b/posthog/version.py
@@ -1,4 +1,4 @@
-VERSION = "3.14.0"
+VERSION = "3.13.0"
 
 if __name__ == "__main__":
     print(VERSION, end="")  # noqa: T201

--- a/posthog/version.py
+++ b/posthog/version.py
@@ -1,4 +1,4 @@
-VERSION = "3.14.2"
+VERSION = "3.15.0"
 
 if __name__ == "__main__":
     print(VERSION, end="")  # noqa: T201

--- a/posthog/version.py
+++ b/posthog/version.py
@@ -1,4 +1,4 @@
-VERSION = "3.13.0"
+VERSION = "3.14.0"
 
 if __name__ == "__main__":
     print(VERSION, end="")  # noqa: T201


### PR DESCRIPTION
with [this PR](https://github.com/PostHog/posthog/pull/28564), we now start to respond different with the `/decide` and `/local_evaluation` APIs if users have gone over their quota limit.  This change is an example for how our SDKs can deal with that.  I'll make the same type of changes to all of the SDKs, but wanted to start with this one as an example.