### PR TITLE
feat(flags): Add more details such as version, id, and reason to `$feature_flag_called` events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.22.0 – 2025-03-26
+
+1. Add more information to `$feature_flag_called` events.
+2. Support for the `/decide?v=3` endpoint which contains more information about feature flags.
+
 ## 3.21.0 – 2025-03-17
 
 1. Support serializing dataclasses.
@@ -193,6 +198,7 @@
 ## 3.3.4 - 2024-01-30
 
 1. Update type hints for module variables to work with newer versions of mypy
+
 
 ## 3.3.3 - 2024-01-26
 

--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -5,7 +5,7 @@ from typing import Callable, Dict, List, Optional, Tuple  # noqa: F401
 from posthog.client import Client
 from posthog.exception_capture import Integrations  # noqa: F401
 from posthog.version import VERSION
-
+from posthog.types import FlagsAndPayloads
 __version__ = VERSION
 
 """Settings."""
@@ -403,7 +403,7 @@ def get_feature_flag(
     only_evaluate_locally=False,  # type: bool
     send_feature_flag_events=True,  # type: bool
     disable_geoip=None,  # type: Optional[bool]
-):
+) -> str | bool | None:
     """
     Get feature flag variant for users. Used with experiments.
     Example:
@@ -446,7 +446,7 @@ def get_all_flags(
     group_properties={},  # type: dict
     only_evaluate_locally=False,  # type: bool
     disable_geoip=None,  # type: Optional[bool]
-):
+) -> dict[str, str | bool] | None:
     """
     Get all flags for a given user.
     Example:
@@ -477,7 +477,7 @@ def get_feature_flag_payload(
     only_evaluate_locally=False,
     send_feature_flag_events=True,
     disable_geoip=None,  # type: Optional[bool]
-):
+) -> str:
     return _proxy(
         "get_feature_flag_payload",
         key=key,
@@ -519,7 +519,7 @@ def get_all_flags_and_payloads(
     group_properties={},
     only_evaluate_locally=False,
     disable_geoip=None,  # type: Optional[bool]
-):
+) -> FlagsAndPayloads:
     return _proxy(
         "get_all_flags_and_payloads",
         distinct_id=distinct_id,

--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -4,8 +4,9 @@ from typing import Callable, Dict, List, Optional, Tuple  # noqa: F401
 
 from posthog.client import Client
 from posthog.exception_capture import Integrations  # noqa: F401
+from posthog.types import FeatureFlag, FlagsAndPayloads
 from posthog.version import VERSION
-from posthog.types import FlagsAndPayloads
+
 __version__ = VERSION
 
 """Settings."""
@@ -403,7 +404,7 @@ def get_feature_flag(
     only_evaluate_locally=False,  # type: bool
     send_feature_flag_events=True,  # type: bool
     disable_geoip=None,  # type: Optional[bool]
-) -> str | bool | None:
+) -> Optional[FeatureFlag]:
     """
     Get feature flag variant for users. Used with experiments.
     Example:
@@ -446,7 +447,7 @@ def get_all_flags(
     group_properties={},  # type: dict
     only_evaluate_locally=False,  # type: bool
     disable_geoip=None,  # type: Optional[bool]
-) -> dict[str, str | bool] | None:
+) -> Optional[dict[str, FeatureFlag]]:
     """
     Get all flags for a given user.
     Example:
@@ -477,7 +478,7 @@ def get_feature_flag_payload(
     only_evaluate_locally=False,
     send_feature_flag_events=True,
     disable_geoip=None,  # type: Optional[bool]
-) -> str:
+) -> Optional[str]:
     return _proxy(
         "get_feature_flag_payload",
         key=key,

--- a/posthog/feature_flags.py
+++ b/posthog/feature_flags.py
@@ -8,6 +8,7 @@ from dateutil import parser
 from dateutil.relativedelta import relativedelta
 
 from posthog import utils
+from posthog.types import FlagValue
 from posthog.utils import convert_to_datetime_aware, is_valid_regex
 
 __LONG_SCALE__ = float(0xFFFFFFFFFFFFFFF)
@@ -25,7 +26,7 @@ class InconclusiveMatchError(Exception):
 # Given the same distinct_id and key, it'll always return the same float. These floats are
 # uniformly distributed between 0 and 1, so if we want to show this feature to 20% of traffic
 # we can do _hash(key, distinct_id) < 0.2
-def _hash(key, distinct_id, salt=""):
+def _hash(key: str, distinct_id: str, salt: str = "") -> float:
     hash_key = f"{key}.{distinct_id}{salt}"
     hash_val = int(hashlib.sha1(hash_key.encode("utf-8")).hexdigest()[:15], 16)
     return hash_val / __LONG_SCALE__
@@ -50,7 +51,7 @@ def variant_lookup_table(feature_flag):
     return lookup_table
 
 
-def match_feature_flag_properties(flag, distinct_id, properties, cohort_properties=None):
+def match_feature_flag_properties(flag, distinct_id, properties, cohort_properties=None) -> FlagValue:
     flag_conditions = (flag.get("filters") or {}).get("groups") or []
     is_inconclusive = False
     cohort_properties = cohort_properties or {}
@@ -87,7 +88,7 @@ def match_feature_flag_properties(flag, distinct_id, properties, cohort_properti
     return False
 
 
-def is_condition_match(feature_flag, distinct_id, condition, properties, cohort_properties):
+def is_condition_match(feature_flag, distinct_id, condition, properties, cohort_properties) -> bool:
     rollout_percentage = condition.get("rollout_percentage")
     if len(condition.get("properties") or []) > 0:
         for prop in condition.get("properties"):

--- a/posthog/request.py
+++ b/posthog/request.py
@@ -3,12 +3,11 @@ import logging
 from datetime import date, datetime
 from gzip import GzipFile
 from io import BytesIO
-from typing import Any, Optional, Union, cast
+from typing import Any, Optional, Union
 
 import requests
 from dateutil.tz import tzutc
 
-from posthog.types import DecideResponse, FeatureFlag, FlagValue
 from posthog.utils import remove_trailing_slash
 from posthog.version import VERSION
 

--- a/posthog/request.py
+++ b/posthog/request.py
@@ -93,7 +93,7 @@ def _process_response(
 
 def decide(api_key: str, host: Optional[str] = None, gzip: bool = False, timeout: int = 15, **kwargs) -> Any:
     """Post the `kwargs to the decide API endpoint"""
-    res = post(api_key, host, "/decide/?v=3", gzip, timeout, **kwargs)
+    res = post(api_key, host, "/decide/?v=4", gzip, timeout, **kwargs)
     return _process_response(res, success_message="Feature flags decided successfully")
 
 

--- a/posthog/request.py
+++ b/posthog/request.py
@@ -8,7 +8,7 @@ from typing import Any, Optional, Union, cast
 import requests
 from dateutil.tz import tzutc
 
-from posthog.types import DecideResponse, FeatureFlag
+from posthog.types import DecideResponse, FeatureFlag, FlagValue
 from posthog.utils import remove_trailing_slash
 from posthog.version import VERSION
 
@@ -97,20 +97,6 @@ def decide(api_key: str, host: Optional[str] = None, gzip: bool = False, timeout
     res = post(api_key, host, "/decide/?v=3", gzip, timeout, **kwargs)
     return _process_response(res, success_message="Feature flags decided successfully")
 
-def normalize_decide_response(resp: any) -> DecideResponse:
-    if "requestId" not in resp:
-        resp["requestId"] = None
-    if "flags" not in resp:
-        featureFlags = resp.get("featureFlags", {})
-        featureFlagPayloads = resp.get("featureFlagPayloads", {})
-        resp.pop("featureFlags", None)
-        resp.pop("featureFlagPayloads", None)
-        # look at each key in featureFlags and create a FeatureFlag object
-        flags = {}
-        for key, value in featureFlags.items():
-            flags[key] = FeatureFlag.from_value_and_payload(key, value, featureFlagPayloads.get(key, None))
-        resp["flags"] = flags
-    return cast(DecideResponse, resp)
 
 def remote_config(personal_api_key: str, host: Optional[str] = None, key: str = "", timeout: int = 15) -> Any:
     """Get remote config flag value from remote_config API endpoint"""

--- a/posthog/test/ai/openai/test_openai.py
+++ b/posthog/test/ai/openai/test_openai.py
@@ -83,6 +83,7 @@ def mock_openai_response_with_responses_api():
         usage=ResponseUsage(
             input_tokens=10,
             output_tokens=10,
+            input_tokens_details={"prompt_tokens": 10, "cached_tokens": 0},
             output_tokens_details={"reasoning_tokens": 15},
             total_tokens=20,
         ),

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -10,8 +10,9 @@ from parameterized import parameterized
 from posthog.client import Client
 from posthog.request import APIError
 from posthog.test.test_utils import FAKE_TEST_API_KEY
-from posthog.version import VERSION
 from posthog.types import FeatureFlag, LegacyFlagMetadata
+from posthog.version import VERSION
+
 
 class TestClient(unittest.TestCase):
     @classmethod
@@ -1213,11 +1214,11 @@ class TestClient(unittest.TestCase):
 
                 assert context == expected_context
 
-    @mock.patch("posthog.client.decide")    
+    @mock.patch("posthog.client.decide")
     def test_get_decide_returns_normalized_decide_response(self, patch_decide):
         patch_decide.return_value = {
             "featureFlags": {"beta-feature": "random-variant", "alpha-feature": True, "off-feature": False},
-            "featureFlagPayloads": {"beta-feature": "{\"some\": \"data\"}"},
+            "featureFlagPayloads": {"beta-feature": '{"some": "data"}'},
             "errorsWhileComputingFlags": False,
             "requestId": "test-id",
         }
@@ -1226,9 +1227,9 @@ class TestClient(unittest.TestCase):
         distinct_id = "test_distinct_id"
         groups = {"test_group_type": "test_group_id"}
         person_properties = {"test_property": "test_value"}
-        
+
         response = client.get_decide(distinct_id, groups, person_properties)
-        
+
         assert response == {
             "flags": {
                 "beta-feature": FeatureFlag(
@@ -1237,8 +1238,8 @@ class TestClient(unittest.TestCase):
                     variant="random-variant",
                     reason=None,
                     metadata=LegacyFlagMetadata(
-                        payload="{\"some\": \"data\"}",
-                    )
+                        payload='{"some": "data"}',
+                    ),
                 ),
                 "alpha-feature": FeatureFlag(
                     key="alpha-feature",
@@ -1247,7 +1248,7 @@ class TestClient(unittest.TestCase):
                     reason=None,
                     metadata=LegacyFlagMetadata(
                         payload=None,
-                    )
+                    ),
                 ),
                 "off-feature": FeatureFlag(
                     key="off-feature",
@@ -1256,8 +1257,8 @@ class TestClient(unittest.TestCase):
                     reason=None,
                     metadata=LegacyFlagMetadata(
                         payload=None,
-                    )
-                )
+                    ),
+                ),
             },
             "errorsWhileComputingFlags": False,
             "requestId": "test-id",

--- a/posthog/test/test_feature_flag.py
+++ b/posthog/test/test_feature_flag.py
@@ -1,0 +1,33 @@
+import pytest
+from posthog.types import FeatureFlag
+
+
+def test_from_value_and_payload_boolean_true_value():
+    # Test with boolean value
+    flag = FeatureFlag.from_value_and_payload(key="my-flag", value=True, payload='{"some": "data"}')
+
+    assert flag.key == "my-flag"
+    assert flag.enabled is True
+    assert flag.variant is None
+    assert flag.metadata.payload == '{"some": "data"}'
+
+
+def test_from_value_and_payload_boolean_false_value():
+    # Test with False value
+    flag = FeatureFlag.from_value_and_payload(key="my-flag", value=False, payload=None)
+
+    assert flag.key == "my-flag"
+    assert flag.enabled is False
+    assert flag.variant is None
+    assert flag.metadata.payload is None
+
+
+def test_from_value_and_payload_string_variant():
+    flag = FeatureFlag.from_value_and_payload(
+        key="my-flag", value="test-variant", payload='{"variant": "test-variant"}'
+    )
+
+    assert flag.key == "my-flag"
+    assert flag.enabled is True  # String values should make enabled True
+    assert flag.variant == "test-variant"
+    assert flag.metadata.payload == '{"variant": "test-variant"}'

--- a/posthog/test/test_feature_flag.py
+++ b/posthog/test/test_feature_flag.py
@@ -1,33 +1,142 @@
-import pytest
-from posthog.types import FeatureFlag
+import unittest
+
+from posthog.types import FeatureFlag, FlagMetadata, FlagReason, LegacyFlagMetadata
 
 
-def test_from_value_and_payload_boolean_true_value():
-    # Test with boolean value
-    flag = FeatureFlag.from_value_and_payload(key="my-flag", value=True, payload='{"some": "data"}')
+class TestFeatureFlag(unittest.TestCase):
+    def test_feature_flag_from_json(self):
+        # Test with full metadata
+        resp = {
+            "key": "test-flag",
+            "enabled": True,
+            "variant": "test-variant",
+            "reason": {"code": "matched_condition", "condition_index": 0, "description": "Matched condition set 1"},
+            "metadata": {"id": 1, "payload": '{"some": "json"}', "version": 2, "description": "test-description"},
+        }
 
-    assert flag.key == "my-flag"
-    assert flag.enabled is True
-    assert flag.variant is None
-    assert flag.metadata.payload == '{"some": "data"}'
+        flag = FeatureFlag.from_json(resp)
+        self.assertEqual(flag.key, "test-flag")
+        self.assertTrue(flag.enabled)
+        self.assertEqual(flag.variant, "test-variant")
+        self.assertEqual(flag.get_value(), "test-variant")
+        self.assertEqual(
+            flag.reason, FlagReason(code="matched_condition", condition_index=0, description="Matched condition set 1")
+        )
+        self.assertEqual(
+            flag.metadata, FlagMetadata(id=1, payload='{"some": "json"}', version=2, description="test-description")
+        )
 
+    def test_feature_flag_from_json_minimal(self):
+        # Test with minimal required fields
+        resp = {"key": "test-flag", "enabled": True}
 
-def test_from_value_and_payload_boolean_false_value():
-    # Test with False value
-    flag = FeatureFlag.from_value_and_payload(key="my-flag", value=False, payload=None)
+        flag = FeatureFlag.from_json(resp)
+        self.assertEqual(flag.key, "test-flag")
+        self.assertTrue(flag.enabled)
+        self.assertIsNone(flag.variant)
+        self.assertEqual(flag.get_value(), True)
+        self.assertIsNone(flag.reason)
+        self.assertEqual(flag.metadata, LegacyFlagMetadata(payload=None))
 
-    assert flag.key == "my-flag"
-    assert flag.enabled is False
-    assert flag.variant is None
-    assert flag.metadata.payload is None
+    def test_feature_flag_from_json_without_metadata(self):
+        # Test with reason but no metadata
+        resp = {
+            "key": "test-flag",
+            "enabled": True,
+            "variant": "test-variant",
+            "reason": {"code": "matched_condition", "condition_index": 0, "description": "Matched condition set 1"},
+        }
 
+        flag = FeatureFlag.from_json(resp)
+        self.assertEqual(flag.key, "test-flag")
+        self.assertTrue(flag.enabled)
+        self.assertEqual(flag.variant, "test-variant")
+        self.assertEqual(flag.get_value(), "test-variant")
+        self.assertEqual(
+            flag.reason, FlagReason(code="matched_condition", condition_index=0, description="Matched condition set 1")
+        )
+        self.assertEqual(flag.metadata, LegacyFlagMetadata(payload=None))
 
-def test_from_value_and_payload_string_variant():
-    flag = FeatureFlag.from_value_and_payload(
-        key="my-flag", value="test-variant", payload='{"variant": "test-variant"}'
-    )
+    def test_flag_reason_from_json(self):
+        # Test with complete data
+        resp = {"code": "user_in_segment", "condition_index": 1, "description": "User is in segment 'beta_users'"}
+        reason = FlagReason.from_json(resp)
+        self.assertEqual(reason.code, "user_in_segment")
+        self.assertEqual(reason.condition_index, 1)
+        self.assertEqual(reason.description, "User is in segment 'beta_users'")
 
-    assert flag.key == "my-flag"
-    assert flag.enabled is True  # String values should make enabled True
-    assert flag.variant == "test-variant"
-    assert flag.metadata.payload == '{"variant": "test-variant"}'
+        # Test with partial data
+        resp = {"code": "user_in_segment"}
+        reason = FlagReason.from_json(resp)
+        self.assertEqual(reason.code, "user_in_segment")
+        self.assertEqual(reason.condition_index, 0)  # default value
+        self.assertEqual(reason.description, "")  # default value
+
+        # Test with None
+        self.assertIsNone(FlagReason.from_json(None))
+
+    def test_flag_metadata_from_json(self):
+        # Test with complete data
+        resp = {"id": 123, "payload": {"key": "value"}, "version": 1, "description": "Test flag"}
+        metadata = FlagMetadata.from_json(resp)
+        self.assertEqual(metadata.id, 123)
+        self.assertEqual(metadata.payload, {"key": "value"})
+        self.assertEqual(metadata.version, 1)
+        self.assertEqual(metadata.description, "Test flag")
+
+        # Test with partial data
+        resp = {"id": 123}
+        metadata = FlagMetadata.from_json(resp)
+        self.assertEqual(metadata.id, 123)
+        self.assertIsNone(metadata.payload)
+        self.assertEqual(metadata.version, 0)  # default value
+        self.assertEqual(metadata.description, "")  # default value
+
+        # Test with None
+        self.assertIsInstance(FlagMetadata.from_json(None), LegacyFlagMetadata)
+
+    def test_feature_flag_from_json_complete(self):
+        # Test with complete data
+        resp = {
+            "key": "test-flag",
+            "enabled": True,
+            "variant": "control",
+            "reason": {
+                "code": "user_in_segment",
+                "condition_index": 1,
+                "description": "User is in segment 'beta_users'",
+            },
+            "metadata": {"id": 123, "payload": {"key": "value"}, "version": 1, "description": "Test flag"},
+        }
+        flag = FeatureFlag.from_json(resp)
+        self.assertEqual(flag.key, "test-flag")
+        self.assertTrue(flag.enabled)
+        self.assertEqual(flag.variant, "control")
+        self.assertIsInstance(flag.reason, FlagReason)
+        self.assertEqual(flag.reason.code, "user_in_segment")
+        self.assertIsInstance(flag.metadata, FlagMetadata)
+        self.assertEqual(flag.metadata.id, 123)
+        self.assertEqual(flag.metadata.payload, {"key": "value"})
+
+    def test_feature_flag_from_json_minimal_data(self):
+        # Test with minimal data
+        resp = {"key": "test-flag", "enabled": False}
+        flag = FeatureFlag.from_json(resp)
+        self.assertEqual(flag.key, "test-flag")
+        self.assertFalse(flag.enabled)
+        self.assertIsNone(flag.variant)
+        self.assertIsNone(flag.reason)
+        self.assertIsInstance(flag.metadata, LegacyFlagMetadata)
+        self.assertIsNone(flag.metadata.payload)
+
+    def test_feature_flag_from_json_with_reason(self):
+        # Test with reason but no metadata
+        resp = {"key": "test-flag", "enabled": True, "reason": {"code": "user_in_segment"}}
+        flag = FeatureFlag.from_json(resp)
+        self.assertEqual(flag.key, "test-flag")
+        self.assertTrue(flag.enabled)
+        self.assertIsNone(flag.variant)
+        self.assertIsInstance(flag.reason, FlagReason)
+        self.assertEqual(flag.reason.code, "user_in_segment")
+        self.assertIsInstance(flag.metadata, LegacyFlagMetadata)
+        self.assertIsNone(flag.metadata.payload)

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -642,8 +642,9 @@ class TestLocalEvaluation(unittest.TestCase):
             },
         ]
         # beta-feature value overridden by /decide
+        flags_and_payloads = client.get_all_flags_and_payloads("distinct_id")
         self.assertEqual(
-            client.get_all_flags_and_payloads("distinct_id")["featureFlagPayloads"],
+            client.to_payloads(flags_and_payloads),
             {
                 "beta-feature": 100,
                 "beta-feature2": 300,
@@ -675,8 +676,9 @@ class TestLocalEvaluation(unittest.TestCase):
         client = self.client
         client.feature_flags = []
         # beta-feature value overridden by /decide
+        flags_and_payloads = client.get_all_flags_and_payloads("distinct_id")
         self.assertEqual(
-            client.get_all_flags_and_payloads("distinct_id")["featureFlagPayloads"],
+            client.to_payloads(flags_and_payloads),
             {"beta-feature": 100, "beta-feature2": 300},
         )
         self.assertEqual(patch_decide.call_count, 1)
@@ -726,7 +728,6 @@ class TestLocalEvaluation(unittest.TestCase):
     @mock.patch.object(Client, "capture")
     @mock.patch("posthog.client.decide")
     def test_get_all_flags_and_payloads_with_no_fallback(self, patch_decide, patch_capture):
-        patch_decide.return_value = {"featureFlags": {"beta-feature": "variant-1", "beta-feature2": "variant-2"}}
         client = self.client
         basic_flag = {
             "id": 1,
@@ -768,8 +769,9 @@ class TestLocalEvaluation(unittest.TestCase):
             disabled_flag,
         ]
         client.feature_flags_by_key = {"beta-feature": basic_flag, "disabled-feature": disabled_flag}
+        all_flags_and_payloads = client.get_all_flags_and_payloads("distinct_id")
         self.assertEqual(
-            client.get_all_flags_and_payloads("distinct_id")["featureFlagPayloads"], {"beta-feature": "new"}
+            client.to_payloads(all_flags_and_payloads), {"beta-feature": "new"}
         )
         # decide not called because this can be evaluated locally
         self.assertEqual(patch_decide.call_count, 0)
@@ -900,8 +902,9 @@ class TestLocalEvaluation(unittest.TestCase):
         ]
         client.feature_flags_by_key = {"beta-feature": flag_1, "disabled-feature": flag_2, "beta-feature2": flag_3}
         # beta-feature2 has no value
+        flags_and_payloads = client.get_all_flags_and_payloads("distinct_id", only_evaluate_locally=True)
         self.assertEqual(
-            client.get_all_flags_and_payloads("distinct_id", only_evaluate_locally=True)["featureFlagPayloads"],
+            client.to_payloads(flags_and_payloads),
             {"beta-feature": "some-payload"},
         )
         self.assertEqual(patch_decide.call_count, 0)

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -642,9 +642,8 @@ class TestLocalEvaluation(unittest.TestCase):
             },
         ]
         # beta-feature value overridden by /decide
-        flags_and_payloads = client.get_all_flags_and_payloads("distinct_id")
         self.assertEqual(
-            client.to_payloads(flags_and_payloads),
+            client.get_all_flags_and_payloads("distinct_id")["featureFlagPayloads"],
             {
                 "beta-feature": 100,
                 "beta-feature2": 300,
@@ -676,9 +675,8 @@ class TestLocalEvaluation(unittest.TestCase):
         client = self.client
         client.feature_flags = []
         # beta-feature value overridden by /decide
-        flags_and_payloads = client.get_all_flags_and_payloads("distinct_id")
         self.assertEqual(
-            client.to_payloads(flags_and_payloads),
+            client.get_all_flags_and_payloads("distinct_id")["featureFlagPayloads"],
             {"beta-feature": 100, "beta-feature2": 300},
         )
         self.assertEqual(patch_decide.call_count, 1)
@@ -768,9 +766,9 @@ class TestLocalEvaluation(unittest.TestCase):
             basic_flag,
             disabled_flag,
         ]
-        all_flags_and_payloads = client.get_all_flags_and_payloads("distinct_id")
         self.assertEqual(
-            client.to_payloads(all_flags_and_payloads), {"beta-feature": "new"}
+            client.get_all_flags_and_payloads("distinct_id")["featureFlagPayloads"],
+            {"beta-feature": "new"}
         )
         # decide not called because this can be evaluated locally
         self.assertEqual(patch_decide.call_count, 0)
@@ -900,9 +898,8 @@ class TestLocalEvaluation(unittest.TestCase):
             flag_3,
         ]
         # beta-feature2 has no value
-        flags_and_payloads = client.get_all_flags_and_payloads("distinct_id", only_evaluate_locally=True)
         self.assertEqual(
-            client.to_payloads(flags_and_payloads),
+            client.get_all_flags_and_payloads("distinct_id", only_evaluate_locally=True)["featureFlagPayloads"],
             {"beta-feature": "some-payload"},
         )
         self.assertEqual(patch_decide.call_count, 0)

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -767,8 +767,7 @@ class TestLocalEvaluation(unittest.TestCase):
             disabled_flag,
         ]
         self.assertEqual(
-            client.get_all_flags_and_payloads("distinct_id")["featureFlagPayloads"],
-            {"beta-feature": "new"}
+            client.get_all_flags_and_payloads("distinct_id")["featureFlagPayloads"], {"beta-feature": "new"}
         )
         # decide not called because this can be evaluated locally
         self.assertEqual(patch_decide.call_count, 0)
@@ -1624,7 +1623,7 @@ class TestLocalEvaluation(unittest.TestCase):
             },
         }
         self.client.feature_flags = [basic_flag]
-        
+
         self.assertEqual(
             self.client.get_feature_flag_payload(
                 "person-flag", "some-distinct-id", person_properties={"region": "USA"}
@@ -1691,7 +1690,7 @@ class TestLocalEvaluation(unittest.TestCase):
             },
         }
         self.client.feature_flags = [multivariate_flag]
-        
+
         self.assertEqual(
             self.client.get_feature_flag_payload(
                 "beta-feature", "test_id", person_properties={"email": "test@posthog.com"}
@@ -2362,7 +2361,7 @@ class TestCaptureCalls(unittest.TestCase):
             },
             "requestId": "18043bf7-9cf6-44cd-b959-9662ee20d371",
         }
-        client = Client(FAKE_TEST_API_KEY)        
+        client = Client(FAKE_TEST_API_KEY)
 
         self.assertEqual(client.get_feature_flag("decide-flag", "some-distinct-id"), "decide-variant")
         self.assertEqual(patch_capture.call_count, 1)
@@ -2400,15 +2399,17 @@ class TestCaptureCalls(unittest.TestCase):
                     "metadata": {
                         "id": 23,
                         "version": 42,
-                        "payload": "{\"foo\": \"bar\"}",
+                        "payload": '{"foo": "bar"}',
                     },
                 }
             },
             "requestId": "18043bf7-9cf6-44cd-b959-9662ee20d371",
         }
-        client = Client(FAKE_TEST_API_KEY)        
+        client = Client(FAKE_TEST_API_KEY)
 
-        self.assertEqual(client.get_feature_flag_payload("decide-flag-with-payload", "some-distinct-id"), "{\"foo\": \"bar\"}")
+        self.assertEqual(
+            client.get_feature_flag_payload("decide-flag-with-payload", "some-distinct-id"), '{"foo": "bar"}'
+        )
         self.assertEqual(patch_capture.call_count, 1)
         patch_capture.assert_called_with(
             "some-distinct-id",
@@ -2422,12 +2423,11 @@ class TestCaptureCalls(unittest.TestCase):
                 "$feature_flag_id": 23,
                 "$feature_flag_version": 42,
                 "$feature_flag_request_id": "18043bf7-9cf6-44cd-b959-9662ee20d371",
-                "$feature_flag_payload": "{\"foo\": \"bar\"}",
+                "$feature_flag_payload": '{"foo": "bar"}',
             },
             groups={},
             disable_geoip=None,
         )
-
 
     @mock.patch("posthog.client.decide")
     def test_capture_is_called_but_does_not_add_all_flags(self, patch_decide):

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -768,7 +768,6 @@ class TestLocalEvaluation(unittest.TestCase):
             basic_flag,
             disabled_flag,
         ]
-        client.feature_flags_by_key = {"beta-feature": basic_flag, "disabled-feature": disabled_flag}
         all_flags_and_payloads = client.get_all_flags_and_payloads("distinct_id")
         self.assertEqual(
             client.to_payloads(all_flags_and_payloads), {"beta-feature": "new"}
@@ -900,7 +899,6 @@ class TestLocalEvaluation(unittest.TestCase):
             flag_2,
             flag_3,
         ]
-        client.feature_flags_by_key = {"beta-feature": flag_1, "disabled-feature": flag_2, "beta-feature2": flag_3}
         # beta-feature2 has no value
         flags_and_payloads = client.get_all_flags_and_payloads("distinct_id", only_evaluate_locally=True)
         self.assertEqual(
@@ -1629,8 +1627,7 @@ class TestLocalEvaluation(unittest.TestCase):
             },
         }
         self.client.feature_flags = [basic_flag]
-        self.client.feature_flags_by_key = {"person-flag": basic_flag}
-
+        
         self.assertEqual(
             self.client.get_feature_flag_payload(
                 "person-flag", "some-distinct-id", person_properties={"region": "USA"}
@@ -1697,8 +1694,7 @@ class TestLocalEvaluation(unittest.TestCase):
             },
         }
         self.client.feature_flags = [multivariate_flag]
-        self.client.feature_flags_by_key = {"beta-feature": multivariate_flag}
-
+        
         self.assertEqual(
             self.client.get_feature_flag_payload(
                 "beta-feature", "test_id", person_properties={"email": "test@posthog.com"}

--- a/posthog/test/test_request.py
+++ b/posthog/test/test_request.py
@@ -1,22 +1,13 @@
 import json
 import unittest
 from datetime import date, datetime
-from unittest.mock import patch, MagicMock
-from parameterized import parameterized
 
 import mock
 import pytest
 import requests
 
-from posthog.request import (
-    DatetimeSerializer,
-    QuotaLimitError,
-    batch_post,
-    decide,
-    determine_server_host,
-)
+from posthog.request import DatetimeSerializer, QuotaLimitError, batch_post, decide, determine_server_host
 from posthog.test.test_utils import TEST_API_KEY
-from posthog.types import FeatureFlag, FlagMetadata, FlagReason, LegacyFlagMetadata
 
 
 class TestRequests(unittest.TestCase):
@@ -83,6 +74,7 @@ class TestRequests(unittest.TestCase):
         with mock.patch("posthog.request._session.post", return_value=mock_response):
             response = decide("fake_key", "fake_host")
             self.assertEqual(response["featureFlags"], {"flag1": True})
+
 
 @pytest.mark.parametrize(
     "host, expected",

--- a/posthog/test/test_request.py
+++ b/posthog/test/test_request.py
@@ -14,7 +14,6 @@ from posthog.request import (
     batch_post,
     decide,
     determine_server_host,
-    normalize_decide_response,
 )
 from posthog.test.test_utils import TEST_API_KEY
 from posthog.types import FeatureFlag, FlagMetadata, FlagReason, LegacyFlagMetadata
@@ -84,91 +83,6 @@ class TestRequests(unittest.TestCase):
         with mock.patch("posthog.request._session.post", return_value=mock_response):
             response = decide("fake_key", "fake_host")
             self.assertEqual(response["featureFlags"], {"flag1": True})
-
-    @parameterized.expand([(True,), (False,)])
-    def test_normalize_decide_response_v4(self, has_errors: bool):
-        resp = {
-            "flags": {
-                "my-flag": FeatureFlag(
-                    key="my-flag",
-                    enabled=True,
-                    variant="test-variant",
-                    reason=FlagReason(
-                        code="matched_condition", condition_index=0, description="Matched condition set 1"
-                    ),
-                    metadata=FlagMetadata(id=1, payload='{"some": "json"}', version=2, description="test-description"),
-                )
-            },
-            "errorsWhileComputingFlags": has_errors,
-            "requestId": "test-id",
-        }
-
-        result = normalize_decide_response(resp)
-        
-        flag = result["flags"]["my-flag"]
-        self.assertEqual(flag.key, "my-flag")
-        self.assertTrue(flag.enabled)
-        self.assertEqual(flag.variant, "test-variant")
-        self.assertEqual(flag.get_value(), "test-variant")
-        self.assertEqual(
-            flag.reason, FlagReason(code="matched_condition", condition_index=0, description="Matched condition set 1")
-        )
-        self.assertEqual(
-            flag.metadata, FlagMetadata(id=1, payload='{"some": "json"}', version=2, description="test-description")
-        )
-        self.assertEqual(result["errorsWhileComputingFlags"], has_errors)
-        self.assertEqual(result["requestId"], "test-id")
-
-    def test_normalize_decide_response_legacy(self):
-        # Test legacy response format with "featureFlags" and "featureFlagPayloads"
-        resp = {
-            "featureFlags": {"my-flag": "test-variant"},
-            "featureFlagPayloads": {"my-flag": "{\"some\": \"json-payload\"}"},
-            "errorsWhileComputingFlags": False,
-            "requestId": "test-id",
-        }
-
-        result = normalize_decide_response(resp)
-
-        flag = result["flags"]["my-flag"]
-        self.assertEqual(flag.key, "my-flag")
-        self.assertTrue(flag.enabled)
-        self.assertEqual(flag.variant, "test-variant")
-        self.assertEqual(flag.get_value(), "test-variant")
-        self.assertIsNone(flag.reason)
-        self.assertEqual(
-            flag.metadata, LegacyFlagMetadata(payload='{"some": "json-payload"}')
-        )
-        self.assertFalse(result["errorsWhileComputingFlags"])
-        self.assertEqual(result["requestId"], "test-id")
-        # Verify legacy fields are removed
-        self.assertNotIn("featureFlags", result)
-        self.assertNotIn("featureFlagPayloads", result)
-
-    def test_normalize_decide_response_boolean_flag(self):
-        # Test legacy response with boolean flag
-        resp = {
-            "featureFlags": {"my-flag": True},
-            "errorsWhileComputingFlags": False
-        }
-
-        result = normalize_decide_response(resp)
-
-        self.assertIn("requestId", result)
-        self.assertIsNone(result["requestId"])
-
-        flag = result["flags"]["my-flag"]
-        self.assertEqual(flag.key, "my-flag")
-        self.assertTrue(flag.enabled)
-        self.assertIsNone(flag.variant)
-        self.assertIsNone(flag.reason)
-        self.assertEqual(
-            flag.metadata, LegacyFlagMetadata(payload=None)
-        )
-        self.assertFalse(result["errorsWhileComputingFlags"])
-        self.assertNotIn("featureFlags", result)
-        self.assertNotIn("featureFlagPayloads", result)
-
 
 @pytest.mark.parametrize(
     "host, expected",

--- a/posthog/test/test_types.py
+++ b/posthog/test/test_types.py
@@ -1,0 +1,145 @@
+import unittest
+from parameterized import parameterized
+from posthog.types import FeatureFlag, FlagMetadata, FlagReason, LegacyFlagMetadata, normalize_decide_response, to_flags_and_payloads
+
+class TestTypes(unittest.TestCase):
+    @parameterized.expand([(True,), (False,)])
+    def test_normalize_decide_response_v4(self, has_errors: bool):
+        resp = {
+            "flags": {
+                "my-flag": FeatureFlag(
+                    key="my-flag",
+                    enabled=True,
+                    variant="test-variant",
+                    reason=FlagReason(
+                        code="matched_condition", condition_index=0, description="Matched condition set 1"
+                    ),
+                    metadata=FlagMetadata(id=1, payload='{"some": "json"}', version=2, description="test-description"),
+                )
+            },
+            "errorsWhileComputingFlags": has_errors,
+            "requestId": "test-id",
+        }
+
+        result = normalize_decide_response(resp)
+        
+        flag = result["flags"]["my-flag"]
+        self.assertEqual(flag.key, "my-flag")
+        self.assertTrue(flag.enabled)
+        self.assertEqual(flag.variant, "test-variant")
+        self.assertEqual(flag.get_value(), "test-variant")
+        self.assertEqual(
+            flag.reason, FlagReason(code="matched_condition", condition_index=0, description="Matched condition set 1")
+        )
+        self.assertEqual(
+            flag.metadata, FlagMetadata(id=1, payload='{"some": "json"}', version=2, description="test-description")
+        )
+        self.assertEqual(result["errorsWhileComputingFlags"], has_errors)
+        self.assertEqual(result["requestId"], "test-id")
+
+    def test_normalize_decide_response_legacy(self):
+        # Test legacy response format with "featureFlags" and "featureFlagPayloads"
+        resp = {
+            "featureFlags": {"my-flag": "test-variant"},
+            "featureFlagPayloads": {"my-flag": "{\"some\": \"json-payload\"}"},
+            "errorsWhileComputingFlags": False,
+            "requestId": "test-id",
+        }
+
+        result = normalize_decide_response(resp)
+
+        flag = result["flags"]["my-flag"]
+        self.assertEqual(flag.key, "my-flag")
+        self.assertTrue(flag.enabled)
+        self.assertEqual(flag.variant, "test-variant")
+        self.assertEqual(flag.get_value(), "test-variant")
+        self.assertIsNone(flag.reason)
+        self.assertEqual(
+            flag.metadata, LegacyFlagMetadata(payload='{"some": "json-payload"}')
+        )
+        self.assertFalse(result["errorsWhileComputingFlags"])
+        self.assertEqual(result["requestId"], "test-id")
+        # Verify legacy fields are removed
+        self.assertNotIn("featureFlags", result)
+        self.assertNotIn("featureFlagPayloads", result)
+
+    def test_normalize_decide_response_boolean_flag(self):
+        # Test legacy response with boolean flag
+        resp = {
+            "featureFlags": {"my-flag": True},
+            "errorsWhileComputingFlags": False
+        }
+
+        result = normalize_decide_response(resp)
+
+        self.assertIn("requestId", result)
+        self.assertIsNone(result["requestId"])
+
+        flag = result["flags"]["my-flag"]
+        self.assertEqual(flag.key, "my-flag")
+        self.assertTrue(flag.enabled)
+        self.assertIsNone(flag.variant)
+        self.assertIsNone(flag.reason)
+        self.assertEqual(
+            flag.metadata, LegacyFlagMetadata(payload=None)
+        )
+        self.assertFalse(result["errorsWhileComputingFlags"])
+        self.assertNotIn("featureFlags", result)
+        self.assertNotIn("featureFlagPayloads", result)
+
+    def test_to_flags_and_payloads_v4(self):
+        # Test v4 response format
+        resp = {
+            "flags": {
+                "my-variant-flag": FeatureFlag(
+                    key="my-variant-flag",
+                    enabled=True,
+                    variant="test-variant",
+                    reason=FlagReason(
+                        code="matched_condition", condition_index=0, description="Matched condition set 1"
+                    ),
+                    metadata=FlagMetadata(id=1, payload='{"some": "json"}', version=2, description="test-description"),
+                ),
+                "my-boolean-flag": FeatureFlag(
+                    key="my-boolean-flag",
+                    enabled=True,
+                    variant=None,
+                    reason=FlagReason(
+                        code="matched_condition", condition_index=0, description="Matched condition set 1"
+                    ),
+                    metadata=FlagMetadata(id=1, payload=None, version=2, description="test-description"),
+                ),
+                "disabled-flag": FeatureFlag(
+                    key="disabled-flag",
+                    enabled=False,
+                    variant=None,
+                    reason=None,
+                    metadata=LegacyFlagMetadata(payload=None),
+                )
+            },
+            "errorsWhileComputingFlags": False,
+            "requestId": "test-id",
+        }
+
+        result = to_flags_and_payloads(resp)
+        
+        self.assertEqual(result["featureFlags"]["my-variant-flag"], "test-variant")
+        self.assertEqual(result["featureFlags"]["my-boolean-flag"], True)
+        self.assertEqual(result["featureFlags"]["disabled-flag"], False)
+        self.assertEqual(result["featureFlagPayloads"]["my-variant-flag"], '{"some": "json"}')
+        self.assertEqual(result["featureFlagPayloads"]["my-boolean-flag"], None)
+        self.assertNotIn("disabled-flag", result["featureFlagPayloads"])
+
+
+    def test_to_flags_and_payloads_empty(self):
+        # Test empty response
+        resp = {
+            "flags": {},
+            "errorsWhileComputingFlags": False,
+            "requestId": "test-id",
+        }
+
+        result = to_flags_and_payloads(resp)
+        
+        self.assertEqual(result["featureFlags"], {})
+        self.assertEqual(result["featureFlagPayloads"], {})

--- a/posthog/types.py
+++ b/posthog/types.py
@@ -36,10 +36,11 @@ class FeatureFlag:
 
     @classmethod
     def from_value_and_payload(cls, key: str, value: any, payload: any) -> "FeatureFlag":
+        enabled, variant = (True, value) if isinstance(value, str) else (value, None)
         return cls(
             key=key,
-            enabled=True if isinstance(value, str) else value,
-            variant=value if isinstance(value, str) else None,
+            enabled=enabled,
+            variant=variant,
             reason=None,
             metadata=LegacyFlagMetadata(
                 payload=payload,

--- a/posthog/types.py
+++ b/posthog/types.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
-from typing import Dict, List, TypedDict, Any
+from typing import List, TypedDict, Any, TypeAlias, cast
 
+FlagValue: TypeAlias = bool | str
 
 @dataclass(frozen=True)
 class FlagReason(TypedDict):
@@ -30,12 +31,12 @@ class FeatureFlag:
     reason: FlagReason | None
     metadata: FlagMetadata | LegacyFlagMetadata
 
-    def get_value(self):
+    def get_value(self) -> FlagValue:
         assert self.variant is None or self.enabled
         return self.variant or self.enabled
 
     @classmethod
-    def from_value_and_payload(cls, key: str, value: any, payload: any) -> "FeatureFlag":
+    def from_value_and_payload(cls, key: str, value: FlagValue, payload: Any) -> "FeatureFlag":
         enabled, variant = (True, value) if isinstance(value, str) else (value, None)
         return cls(
             key=key,
@@ -43,13 +44,72 @@ class FeatureFlag:
             variant=variant,
             reason=None,
             metadata=LegacyFlagMetadata(
-                payload=payload,
+                payload=payload if payload else None,
             ),
         )
 
 
 class DecideResponse(TypedDict, total=False):
-    flags: Dict[str, FeatureFlag]
+    flags: dict[str, FeatureFlag]
     errorsWhileComputingFlags: bool
     requestId: str
     quotaLimit: List[str] | None
+
+
+class FlagsAndPayloads(TypedDict, total=True):
+    featureFlags: dict[str, FlagValue] | None
+    featureFlagPayloads: dict[str, Any] | None
+
+def normalize_decide_response(resp: Any) -> DecideResponse:
+    """
+    Normalize the response from the decide API endpoint into a v4 DecideResponse.
+
+    Args:
+        resp: A v3 or v4 response from the decide API endpoint.
+
+    Returns:
+        A DecideResponse containing feature flags and their details.
+    """
+    if "requestId" not in resp:
+        resp["requestId"] = None
+    if "flags" not in resp:
+        featureFlags = resp.get("featureFlags", {})
+        featureFlagPayloads = resp.get("featureFlagPayloads", {})
+        resp.pop("featureFlags", None)
+        resp.pop("featureFlagPayloads", None)
+        # look at each key in featureFlags and create a FeatureFlag object
+        flags = {}
+        for key, value in featureFlags.items():
+            flags[key] = FeatureFlag.from_value_and_payload(key, value, featureFlagPayloads.get(key, None))
+        resp["flags"] = flags
+    return cast(DecideResponse, resp)
+
+def to_flags_and_payloads(resp: DecideResponse) -> tuple[dict[str, FlagValue], dict[str, Any], bool]:
+    """
+    Convert a DecideResponse into a FlagsAndPayloads object which is a 
+    dict of feature flags and their payloads. This is needed by certain 
+    functions in the client.
+    Args:
+        resp: A DecideResponse containing feature flags and their payloads.
+
+    Returns:
+        A tuple containing:
+            - A dictionary mapping flag keys to their values (bool or str)
+            - A dictionary mapping flag keys to their payloads
+    """
+    return {
+        "featureFlags": to_values(resp),
+        "featureFlagPayloads": to_payloads(resp)
+    }
+
+def to_values(response: DecideResponse) -> dict[str, bool | str] | None:
+    if "flags" not in response:
+        return None
+
+    return {key: value.get_value() for key, value in response.get("flags", {}).items()}
+
+def to_payloads(response: DecideResponse) -> dict[str, str] | None:
+    if "flags" not in response:
+        return None
+
+    return {key: value.metadata.payload for key, value in response.get("flags", {}).items() if value.enabled}

--- a/posthog/types.py
+++ b/posthog/types.py
@@ -1,0 +1,54 @@
+from dataclasses import dataclass
+from typing import Dict, List, TypedDict, Any
+
+
+@dataclass(frozen=True)
+class FlagReason(TypedDict):
+    code: str
+    condition_index: int
+    description: str
+
+
+@dataclass(frozen=True)
+class FlagMetadata:
+    id: int
+    payload: Any
+    version: int
+    description: str
+
+
+@dataclass(frozen=True)
+class LegacyFlagMetadata:
+    payload: Any
+
+
+@dataclass(frozen=True)
+class FeatureFlag:
+    key: str
+    enabled: bool
+    variant: str | None
+    reason: FlagReason | None
+    metadata: FlagMetadata | LegacyFlagMetadata
+
+    def get_value(self):
+        assert self.variant is None or self.enabled
+        return self.variant or self.enabled
+
+    @classmethod
+    def from_value_and_payload(cls, key: str, value: any, payload: any) -> "FeatureFlag":
+        return cls(
+            key=key,
+            enabled=True if isinstance(value, str) else value,
+            variant=value if isinstance(value, str) else None,
+            reason=None,
+            metadata=LegacyFlagMetadata(
+                payload=payload,
+            ),
+        )
+
+
+class DecideResponse(TypedDict, total=False):
+    flags: Dict[str, FeatureFlag]
+    errorsWhileComputingFlags: bool
+    requestId: str
+    quotaLimit: List[str] | None

--- a/posthog/types.py
+++ b/posthog/types.py
@@ -84,7 +84,7 @@ def normalize_decide_response(resp: Any) -> DecideResponse:
         resp["flags"] = flags
     return cast(DecideResponse, resp)
 
-def to_flags_and_payloads(resp: DecideResponse) -> tuple[dict[str, FlagValue], dict[str, Any], bool]:
+def to_flags_and_payloads(resp: DecideResponse) -> FlagsAndPayloads:
     """
     Convert a DecideResponse into a FlagsAndPayloads object which is a 
     dict of feature flags and their payloads. This is needed by certain 
@@ -102,7 +102,7 @@ def to_flags_and_payloads(resp: DecideResponse) -> tuple[dict[str, FlagValue], d
         "featureFlagPayloads": to_payloads(resp)
     }
 
-def to_values(response: DecideResponse) -> dict[str, bool | str] | None:
+def to_values(response: DecideResponse) -> dict[str, FlagValue] | None:
     if "flags" not in response:
         return None
 

--- a/posthog/version.py
+++ b/posthog/version.py
@@ -1,4 +1,4 @@
-VERSION = "3.21.0"
+VERSION = "3.22.0"
 
 if __name__ == "__main__":
     print(VERSION, end="")  # noqa: T201


### PR DESCRIPTION
Add support for `/decide?v=4` (see https://github.com/PostHog/posthog/pull/29751). Similar to how it's done in https://github.com/PostHog/posthog-js-lite/pull/427.

## Updates to the `$feature_flag_called` event

When capturing the `$feature_flag_called` event, additional information are now captured:

The end result is `$feature_flag_called` events will have additional properties:

| Property Name                |  Descirption
| ------------------------ | -------------
| `$feature_flag_version` | The version of the feature flag. This is visible in the diffs of the feature flag activity log.
| `$feature_flag_reason` | The reason the feature flag matched or didn't match.
| `$feature_flag_id`          | The database id of the feature flag (Just in case a flag was deleted and then recreated with the same key, we can determine the difference.

## Backwards compatibility:

The changes are all backwards compatible with `/decide?v=3`.

## Testing

Unit tests and some manual testing