### PR TITLE
update automatic retries to include read errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.23.0 – 2025-03-26
+
+1. Expand automatic retries to include read errors (e.g. RemoteDisconnected)
+
 ## 3.22.0 – 2025-03-26
 
 1. Add more information to `$feature_flag_called` events.

--- a/posthog/request.py
+++ b/posthog/request.py
@@ -7,11 +7,20 @@ from typing import Any, Optional, Union
 
 import requests
 from dateutil.tz import tzutc
+from urllib3.util.retry import Retry
 
 from posthog.utils import remove_trailing_slash
 from posthog.version import VERSION
 
-adapter = requests.adapters.HTTPAdapter(max_retries=2)
+# Retry on both connect and read errors
+# by default read errors will only retry idempotent HTTP methods (so not POST)
+adapter = requests.adapters.HTTPAdapter(
+    max_retries=Retry(
+        total=2,
+        connect=2,
+        read=2,
+    )
+)
 _session = requests.sessions.Session()
 _session.mount("https://", adapter)
 


### PR DESCRIPTION
in e.g. lambda environments the connection can time out between invocations, this comes through to the client as a "RemoteDisconnected" error, which it turns out urllib classifies as a "read" error not a connection error (as it's possible to get this error after data has been sent)

follow up to https://github.com/PostHog/posthog-python/pull/190