### PR TITLE
docs: Remove dead Slack link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,3 @@ Then navigate to `http://127.0.0.1:8080/sentry-debug/` and you should get an eve
 ### Releasing Versions
 
 Updated are released using GitHub Actions: after bumping `version.py` in `master` and adding to `CHANGELOG.md`, go to [our release workflow's page](https://github.com/PostHog/posthog-python/actions/workflows/release.yaml) and dispatch it manually, using workflow from `master`.
-
-## Questions?
-
-### [Join our Slack community.](https://join.slack.com/t/posthogusers/shared_invite/enQtOTY0MzU5NjAwMDY3LTc2MWQ0OTZlNjhkODk3ZDI3NDVjMDE1YjgxY2I4ZjI4MzJhZmVmNjJkN2NmMGJmMzc2N2U3Yjc3ZjI5NGFlZDQ)


### PR DESCRIPTION
I don't believe there's a maintained slack channel anymore