### PR TITLE
feat: log captured exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.24.0 – 2025-04-10
+
+1. Add config option to `log_captured_exceptions`
+
 ## 3.23.0 – 2025-03-26
 
 1. Expand automatic retries to include read errors (e.g. RemoteDisconnected)
@@ -202,7 +206,6 @@
 ## 3.3.4 - 2024-01-30
 
 1. Update type hints for module variables to work with newer versions of mypy
-
 
 ## 3.3.3 - 2024-01-26
 

--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -314,6 +314,7 @@ def capture_exception(
     timestamp=None,  # type: Optional[datetime.datetime]
     uuid=None,  # type: Optional[str]
     groups=None,  # type: Optional[Dict]
+    **kwargs
 ):
     # type: (...) -> Tuple[bool, dict]
     """
@@ -327,6 +328,7 @@ def capture_exception(
     Optionally you can submit
     - `properties`, which can be a dict with any information you'd like to add
     - `groups`, which is a dict of group type -> group key mappings
+    - remaining `kwargs` will be logged if `log_captured_exceptions` is enabled
 
     For example:
     ```python
@@ -355,6 +357,7 @@ def capture_exception(
         timestamp=timestamp,
         uuid=uuid,
         groups=groups,
+        **kwargs
     )
 
 

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -126,6 +126,7 @@ class Client(object):
         feature_flags_request_timeout_seconds=3,
         super_properties=None,
         enable_exception_autocapture=False,
+        log_captured_exceptions=False,
         exception_autocapture_integrations=None,
         project_root=None,
         privacy_mode=False,
@@ -159,6 +160,7 @@ class Client(object):
         self.historical_migration = historical_migration
         self.super_properties = super_properties
         self.enable_exception_autocapture = enable_exception_autocapture
+        self.log_captured_exceptions = log_captured_exceptions
         self.exception_autocapture_integrations = exception_autocapture_integrations
         self.exception_capture = None
         self.privacy_mode = privacy_mode
@@ -513,6 +515,7 @@ class Client(object):
         timestamp=None,
         uuid=None,
         groups=None,
+        **kwargs
     ):
         if context is not None:
             warnings.warn(
@@ -565,6 +568,9 @@ class Client(object):
                 "$exception_personURL": f"{remove_trailing_slash(self.raw_host)}/project/{self.api_key}/person/{distinct_id}",
                 **properties,
             }
+
+            if self.log_captured_exceptions:
+                self.log.exception(exception, extra=kwargs)
 
             return self.capture(distinct_id, "$exception", properties, context, timestamp, uuid, groups)
         except Exception as e:

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -515,7 +515,7 @@ class Client(object):
         timestamp=None,
         uuid=None,
         groups=None,
-        **kwargs
+        **kwargs,
     ):
         if context is not None:
             warnings.warn(

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -263,6 +263,13 @@ class TestClient(unittest.TestCase):
                     "WARNING:posthog:No exception information available",
                 )
 
+    def test_capture_exception_logs_when_enabled(self):
+        client = Client(FAKE_TEST_API_KEY, log_captured_exceptions=True)
+        with self.assertLogs("posthog", level="ERROR") as logs:
+            client.capture_exception(Exception("test exception"), "distinct_id", path="one/two/three")
+            self.assertEqual(logs.output[0],"ERROR:posthog:test exception\nNoneType: None")
+            self.assertEqual(getattr(logs.records[0], "path"),"one/two/three")
+
     @mock.patch("posthog.client.decide")
     def test_basic_capture_with_feature_flags(self, patch_decide):
         patch_decide.return_value = {"featureFlags": {"beta-feature": "random-variant"}}

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -267,8 +267,8 @@ class TestClient(unittest.TestCase):
         client = Client(FAKE_TEST_API_KEY, log_captured_exceptions=True)
         with self.assertLogs("posthog", level="ERROR") as logs:
             client.capture_exception(Exception("test exception"), "distinct_id", path="one/two/three")
-            self.assertEqual(logs.output[0],"ERROR:posthog:test exception\nNoneType: None")
-            self.assertEqual(getattr(logs.records[0], "path"),"one/two/three")
+            self.assertEqual(logs.output[0], "ERROR:posthog:test exception\nNoneType: None")
+            self.assertEqual(getattr(logs.records[0], "path"), "one/two/three")
 
     @mock.patch("posthog.client.decide")
     def test_basic_capture_with_feature_flags(self, patch_decide):

--- a/posthog/version.py
+++ b/posthog/version.py
@@ -1,4 +1,4 @@
-VERSION = "3.23.0"
+VERSION = "3.24.0"
 
 if __name__ == "__main__":
     print(VERSION, end="")  # noqa: T201


### PR DESCRIPTION
Adds a `log_captured_exceptions` config option so that all `$exception` events can also be logged

This is useful internally to capture exceptions if our own product is unavailable.

We have a version of this already in https://github.com/PostHog/posthog/blob/c2c65827b31b13c8e2e84d4ddc33df34b5924487/posthog/exceptions.py#L58-L66 but that only applies to DFR views.

By doing this at the SDK level we can log _any_ exception that is being captured. One difference is that the logger in the SDK is not structured but I think that's ok