### PR TITLE
ubuntu 20.04 is EOL

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
     release:
         name: Publish release
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         env:
             TWINE_USERNAME: __token__
             TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
updating our release job for `posthog-python` since GH actions have officially discontinued 20.04.