### PR TITLE
chore(flags): latest version of `posthog-python` now uses `/flags` by default, except for a few exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.25.0 – 2025-04-15
+
+1. Roll out new `/flags` endpoint to 100% of `/decide` traffic, excluding the top 10 customers.
+
 ## 3.24.3 – 2025-04-15
 
 1. Fix hash inclusion/exclusion for flag rollout

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -53,8 +53,8 @@ ID_TYPES = (numbers.Number, string_types, UUID)
 MAX_DICT_SIZE = 50_000
 
 # TODO: Get rid of these when you're done rolling out `/flags` to all customers
-ROLLOUT_PERCENTAGE = 0
-INCLUDED_HASHES = set()  # this is PostHog's API key
+ROLLOUT_PERCENTAGE = 1
+INCLUDED_HASHES = set({"bc94e67150c97dbcbf52549d50a7b80814841dbf"})  # this is PostHog's API key
 # Explicitly excluding all the API tokens associated with the top 10 customers; we'll get to them soon, but don't want to rollout to them just yet
 EXCLUDED_HASHES = set(
     {

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -53,7 +53,7 @@ ID_TYPES = (numbers.Number, string_types, UUID)
 MAX_DICT_SIZE = 50_000
 
 # TODO: Get rid of these when you're done rolling out `/flags` to all customers
-ROLLOUT_PERCENTAGE = 0.1
+ROLLOUT_PERCENTAGE = 1
 INCLUDED_HASHES = set({"bc94e67150c97dbcbf52549d50a7b80814841dbf"})  # this is PostHog's API key
 # Explicitly excluding all the API tokens associated with the top 10 customers; we'll get to them soon, but don't want to rollout to them just yet
 EXCLUDED_HASHES = set(

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -53,8 +53,8 @@ ID_TYPES = (numbers.Number, string_types, UUID)
 MAX_DICT_SIZE = 50_000
 
 # TODO: Get rid of these when you're done rolling out `/flags` to all customers
-ROLLOUT_PERCENTAGE = 1
-INCLUDED_HASHES = set({"bc94e67150c97dbcbf52549d50a7b80814841dbf"})  # this is PostHog's API key
+ROLLOUT_PERCENTAGE = 0
+INCLUDED_HASHES = set()  # this is PostHog's API key
 # Explicitly excluding all the API tokens associated with the top 10 customers; we'll get to them soon, but don't want to rollout to them just yet
 EXCLUDED_HASHES = set(
     {

--- a/posthog/version.py
+++ b/posthog/version.py
@@ -1,4 +1,4 @@
-VERSION = "3.24.3"
+VERSION = "3.25.0"
 
 if __name__ == "__main__":
     print(VERSION, end="")  # noqa: T201


### PR DESCRIPTION
rolled the percentage to 100%.  Let's get some real data. 