### PR TITLE
fix: Enrich captured events with locally evaluated flags

### DIFF
--- a/posthog/client.py
+++ b/posthog/client.py
@@ -479,16 +479,14 @@ class Client(object):
 
         extra_properties: dict[str, Any] = {}
         feature_variants: Optional[dict[str, Union[bool, str]]] = {}
-        if send_feature_flags:
-            try:
-                feature_variants = self.get_feature_variants(distinct_id, groups, disable_geoip=disable_geoip)
-            except Exception as e:
-                self.log.exception(f"[FEATURE FLAGS] Unable to get feature variants: {e}")
-
-        elif self.feature_flags and event != "$feature_flag_called":
+        if self.feature_flags and event != "$feature_flag_called":
             # Local evaluation is enabled, flags are loaded, so try and get all flags we can without going to the server
             feature_variants = self.get_all_flags(
                 distinct_id, groups=(groups or {}), disable_geoip=disable_geoip, only_evaluate_locally=True
+            )
+        elif send_feature_flags:
+            feature_variants = self.get_all_flags(
+                distinct_id, groups=(groups or {}), disable_geoip=disable_geoip, only_evaluate_locally=False
             )
 
         for feature, variant in (feature_variants or {}).items():


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/issues/31373

## Changes

When capturing an event and `send_feature_flags=True`, use locally evaluated feature flag data, before falling back to the /flags or /decide

- if `client.feature_flags` is set, the feature flags on the client is evaluated and sent with the event, regardless of the `send_feature_flags` setting
  - if the local evaluation fails, the capture event is sent without feature flags
- if `send_feature_flags=True`, feature flags data is retrieved from `/api/feature_flag/local_evaluation` and evaluated locally, and sent with the event
  - if the local evaluation fails, it falls back to the `/flags or /decide` endpoint
- if `personal_api_key` is not set, local evaluation is disabled and instead the `/flags or /decide` endpoint is called 