### PR TITLE
feat: Remove deprecated `monotonic` lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 4.0.1 – 2025-04-29
 
 1. Remove deprecated `monotonic` library. Use Python's core `time.monotonic` function instead
+2. Clarify Python 3.9+ is required
 
 ## 4.0.0 - 2025-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.1 – 2025-04-29
+
+1. Remove deprecated `monotonic` library. Use Python's core `time.monotonic` function instead
+
 ## 4.0.0 - 2025-04-24
 
 1. Added new method `get_feature_flag_result` which returns a `FeatureFlagResult` object. This object breaks down the result of a feature flag into its enabled state, variant, and payload. The benefit of this method is it allows you to retrieve the result of a feature flag and its payload in a single API call. You can call `get_value` on the result to get the value of the feature flag, which is the same value returned by `get_feature_flag` (aka the string `variant` if the flag is a multivariate flag or the `boolean` value if the flag is a boolean flag).

--- a/posthog/consumer.py
+++ b/posthog/consumer.py
@@ -1,9 +1,9 @@
 import json
 import logging
+import time
 from threading import Thread
 
 import backoff
-import monotonic
 
 from posthog.request import APIError, DatetimeSerializer, batch_post
 
@@ -96,11 +96,11 @@ class Consumer(Thread):
         queue = self.queue
         items = []
 
-        start_time = monotonic.monotonic()
+        start_time = time.monotonic()
         total_size = 0
 
         while len(items) < self.flush_at:
-            elapsed = monotonic.monotonic() - start_time
+            elapsed = time.monotonic() - start_time
             if elapsed >= self.flush_interval:
                 break
             try:

--- a/posthog/version.py
+++ b/posthog/version.py
@@ -1,4 +1,4 @@
-VERSION = "4.0.0"
+VERSION = "4.0.1"
 
 if __name__ == "__main__":
     print(VERSION, end="")  # noqa: T201

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,8 @@ from version import VERSION
 
 long_description = """
 PostHog is developer-friendly, self-hosted product analytics. posthog-python is the python package.
+
+This package requires Python 3.9 or higher.
 """
 
 install_requires = [

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,8 @@ PostHog is developer-friendly, self-hosted product analytics. posthog-python is 
 install_requires = [
     "requests>=2.7,<3.0",
     "six>=1.5",
-    "monotonic>=1.5",
+    "python-dateutil>=2.2",
     "backoff>=1.10.0",
-    "python-dateutil>2.1",
     "distro>=1.5.0",  # Required for Linux OS detection in Python 3.9+
 ]
 

--- a/setup_analytics.py
+++ b/setup_analytics.py
@@ -12,6 +12,8 @@ from version import VERSION
 
 long_description = """
 PostHog is developer-friendly, self-hosted product analytics. posthog-python is the python package.
+
+This package requires Python 3.9 or higher.
 """
 
 install_requires = [
@@ -57,19 +59,10 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.6",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.2",
-        "Programming Language :: Python :: 3.3",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ],
 )

--- a/setup_analytics.py
+++ b/setup_analytics.py
@@ -17,9 +17,8 @@ PostHog is developer-friendly, self-hosted product analytics. posthog-python is 
 install_requires = [
     "requests>=2.7,<3.0",
     "six>=1.5",
-    "monotonic>=1.5",
+    "python-dateutil>=2.2",
     "backoff>=1.10.0",
-    "python-dateutil>2.1",
     "distro>=1.5.0",  # Required for Linux OS detection in Python 3.9+
 ]
 


### PR DESCRIPTION
This library has been long-deprecated (2021). We can use `time.monotonic` instead which has been available since Python 3.3

Closes #230