### PR TITLE
feat: add setup method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
+## 4.3.3 - 2025-06-06
+
+Add `setup()` function to initialise default client
+
 ## 4.3.2 - 2025-06-06
 
 Add context management:
- - New context manager with `posthog.new_context()`
- - Tag functions: `posthog.tag()`, `posthog.get_tags()`, `posthog.clear_tags()`
- - Function decorator:
-   - `@posthog.scoped` - Creates context and captures exceptions thrown within the function
- - Automatic deduplication of exceptions to ensure each exception is only captured once
+
+- New context manager with `posthog.new_context()`
+- Tag functions: `posthog.tag()`, `posthog.get_tags()`, `posthog.clear_tags()`
+- Function decorator:
+  - `@posthog.scoped` - Creates context and captures exceptions thrown within the function
+- Automatic deduplication of exceptions to ensure each exception is only captured once
 
 ## 4.2.1 - 2025-6-05
 

--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -572,8 +572,7 @@ def shutdown():
     _proxy("join")
 
 
-def _proxy(method, *args, **kwargs):
-    """Create an analytics client if one doesn't exist and send to it."""
+def setup():
     global default_client
     if not default_client:
         default_client = Client(
@@ -601,6 +600,11 @@ def _proxy(method, *args, **kwargs):
     # always set incase user changes it
     default_client.disabled = disabled
     default_client.debug = debug
+
+
+def _proxy(method, *args, **kwargs):
+    """Create an analytics client if one doesn't exist and send to it."""
+    setup()
 
     fn = getattr(default_client, method)
     return fn(*args, **kwargs)

--- a/posthog/version.py
+++ b/posthog/version.py
@@ -1,4 +1,4 @@
-VERSION = "4.3.2"
+VERSION = "4.3.3"
 
 if __name__ == "__main__":
     print(VERSION, end="")  # noqa: T201


### PR DESCRIPTION
We cannot guarantee that the default PostHog client is always created. This means things like exception autocapture handlers will not get set until some other function creates the client e.g. capture. Let's expose a function to setup the client for use in environments like Celery where we could potentially need to capture an exception event if no events are being captured