### PR TITLE
fix: makefile for posthog_analytics release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.4.1 - 2025-06-07
+
+- empty point release to fix the posthog_analytics release
+
 ## 4.4.0 - 2025-06-09
 
 - Use the new `/flags` endpoint for all feature flag evaluations (don't fall back to `/decide` at all)

--- a/Makefile
+++ b/Makefile
@@ -16,16 +16,18 @@ release_analytics:
 	rm -rf posthoganalytics
 	mkdir posthoganalytics
 	cp -r posthog/* posthoganalytics/
-	find ./posthoganalytics -type f -exec sed -i '' -e 's/from posthog /from posthoganalytics /g' {} \;
-	find ./posthoganalytics -type f -exec sed -i '' -e 's/from posthog\./from posthoganalytics\./g' {} \;
+	find ./posthoganalytics -type f -not -path "*/__pycache__/*" -exec sed -i '' -e 's/from posthog /from posthoganalytics /g' {} \;
+	find ./posthoganalytics -type f -not -path "*/__pycache__/*" -exec sed -i '' -e 's/from posthog\./from posthoganalytics\./g' {} \;
 	rm -rf posthog
 	python setup_analytics.py sdist bdist_wheel
 	twine upload dist/*
 	mkdir posthog
-	find ./posthoganalytics -type f -exec sed -i '' -e 's/from posthoganalytics /from posthog /g' {} \;
-	find ./posthoganalytics -type f -exec sed -i '' -e 's/from posthoganalytics\./from posthog\./g' {} \;
+	find ./posthoganalytics -type f -not -path "*/__pycache__/*" -exec sed -i '' -e 's/from posthoganalytics /from posthog /g' {} \;
+	find ./posthoganalytics -type f  -not -path "*/__pycache__/*" -exec sed -i '' -e 's/from posthoganalytics\./from posthog\./g' {} \;
 	cp -r posthoganalytics/* posthog/
 	rm -rf posthoganalytics
+	rm -f pyproject.toml
+	cp pyproject.toml.backup pyproject.toml
 
 e2e_test:
 	.buildscripts/e2e.sh

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ release_analytics:
 	rm -rf posthoganalytics
 	rm -f pyproject.toml
 	cp pyproject.toml.backup pyproject.toml
+	rm -f pyproject.toml.backup
 
 e2e_test:
 	.buildscripts/e2e.sh

--- a/posthog/version.py
+++ b/posthog/version.py
@@ -1,4 +1,4 @@
-VERSION = "4.4.0"
+VERSION = "4.4.1"
 
 if __name__ == "__main__":
     print(VERSION, end="")  # noqa: T201

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,8 @@ dev = [
     "pre-commit",
     "pydantic",
     "ruff",
+    "tomli",
+    "tomli_w",
 ]
 test = [
     "mock>=2.0.0",

--- a/setup_analytics.py
+++ b/setup_analytics.py
@@ -1,5 +1,8 @@
 import os
 import sys
+import tomllib
+import tomli_w
+import shutil
 
 try:
     from setuptools import setup
@@ -7,8 +10,40 @@ except ImportError:
     from distutils.core import setup
 
 # Don't import analytics-python module here, since deps may not be installed
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "posthog"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "posthoganalytics"))
 from version import VERSION  # noqa: E402
+
+
+# Copy the original pyproject.toml as backup
+shutil.copy("pyproject.toml", "pyproject.toml.backup")
+
+# Read the original pyproject.toml
+with open("pyproject.toml", "rb") as f:
+    config = tomllib.load(f)
+
+print(config)
+
+# Override specific values
+config["project"]["name"] = "posthoganalytics"
+config["tool"]["setuptools"]["dynamic"]["version"] = {
+    "attr": "posthoganalytics.version.VERSION"
+}
+
+# Rename packages from posthog.* to posthoganalytics.*
+if "packages" in config["tool"]["setuptools"]:
+    new_packages = []
+    for package in config["tool"]["setuptools"]["packages"]:
+        if package == "posthog":
+            new_packages.append("posthoganalytics")
+        elif package.startswith("posthog."):
+            new_packages.append(package.replace("posthog.", "posthoganalytics.", 1))
+        else:
+            new_packages.append(package)
+    config["tool"]["setuptools"]["packages"] = new_packages
+
+# Overwrite the original pyproject.toml
+with open("pyproject.toml", "wb") as f:
+    tomli_w.dump(config, f)
 
 long_description = """
 PostHog is developer-friendly, self-hosted product analytics.

--- a/setup_analytics.py
+++ b/setup_analytics.py
@@ -1,6 +1,6 @@
 import os
 import sys
-import tomllib
+import tomli
 import tomli_w
 import shutil
 
@@ -19,9 +19,7 @@ shutil.copy("pyproject.toml", "pyproject.toml.backup")
 
 # Read the original pyproject.toml
 with open("pyproject.toml", "rb") as f:
-    config = tomllib.load(f)
-
-print(config)
+    config = tomli.load(f)
 
 # Override specific values
 config["project"]["name"] = "posthoganalytics"

--- a/uv.lock
+++ b/uv.lock
@@ -2059,6 +2059,8 @@ dev = [
     { name = "pre-commit" },
     { name = "pydantic" },
     { name = "ruff" },
+    { name = "tomli" },
+    { name = "tomli-w" },
     { name = "types-mock" },
     { name = "types-python-dateutil" },
     { name = "types-requests" },
@@ -2128,6 +2130,8 @@ requires-dist = [
     { name = "sentry-sdk", marker = "extra == 'sentry'" },
     { name = "setuptools", marker = "extra == 'build'" },
     { name = "six", specifier = ">=1.5" },
+    { name = "tomli", marker = "extra == 'dev'" },
+    { name = "tomli-w", marker = "extra == 'dev'" },
     { name = "twine", marker = "extra == 'build'" },
     { name = "types-mock", marker = "extra == 'dev'" },
     { name = "types-python-dateutil", marker = "extra == 'dev'" },
@@ -2951,6 +2955,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724 },
     { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383 },
     { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257 },
+]
+
+[[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675 },
 ]
 
 [[package]]


### PR DESCRIPTION
the posthog_analytics release was broken in the recent reorganisation of files

* update setup_analytics.py to change values in pyproject.toml instead of having the info duplicated in the 2 setup files
* update the makefile to tidy up a little more
* update the makefile so it can run if there's a pycache directory present