### PR TITLE
chore(ci): use uv run when releasing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,7 +40,7 @@ jobs:
         run: uv sync --extra build
 
       - name: Push releases to PyPI
-        run: make release && make release_analytics
+        run: uv run make release && uv run make release_analytics
 
       - name: Create GitHub release
         uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1


### PR DESCRIPTION
hard to test this locally.

we got

```
rm -rf dist/*
python setup.py sdist bdist_wheel
/opt/hostedtoolcache/Python/3.11.11/x64/lib/python3.11/site-packages/setuptools/config/pyprojecttoml.py:108: _BetaConfiguration: Support for `[tool.setuptools]` in `pyproject.toml` is still *beta*.
  warnings.warn(msg, _BetaConfiguration)
usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
   or: setup.py --help [cmd1 cmd2 ...]
   or: setup.py --help-commands
   or: setup.py cmd --help

error: invalid command 'bdist_wheel'
```

but we're doing 

```
      - name: Prepare for building release
        run: uv sync --extra build
```

most likely gh isn't using the env so explicitly use uv run