### PR TITLE
chore: more fiddling to get release working

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ jobs:
         run: echo "REPO_VERSION=$(python3 posthog/version.py)" >> $GITHUB_ENV
 
       - name: Prepare for building release
-        run: uv sync --extra build
+        run: uv sync --extra dev
 
       - name: Push releases to PyPI
         run: uv run make release && uv run make release_analytics

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 4.4.1 - 2025-06-07
+## 4.4.1 and 4.4.2- 2025-06-07
 
 - empty point release to fix the posthog_analytics release
 

--- a/Makefile
+++ b/Makefile
@@ -16,14 +16,16 @@ release_analytics:
 	rm -rf posthoganalytics
 	mkdir posthoganalytics
 	cp -r posthog/* posthoganalytics/
-	find ./posthoganalytics -type f -not -path "*/__pycache__/*" -exec sed -i '' -e 's/from posthog /from posthoganalytics /g' {} \;
-	find ./posthoganalytics -type f -not -path "*/__pycache__/*" -exec sed -i '' -e 's/from posthog\./from posthoganalytics\./g' {} \;
+	find ./posthoganalytics -type f -name "*.py" -exec sed -i.bak -e 's/from posthog /from posthoganalytics /g' {} \;
+	find ./posthoganalytics -type f -name "*.py" -exec sed -i.bak -e 's/from posthog\./from posthoganalytics\./g' {} \;
+	find ./posthoganalytics -name "*.bak" -delete
 	rm -rf posthog
 	python setup_analytics.py sdist bdist_wheel
 	twine upload dist/*
 	mkdir posthog
-	find ./posthoganalytics -type f -not -path "*/__pycache__/*" -exec sed -i '' -e 's/from posthoganalytics /from posthog /g' {} \;
-	find ./posthoganalytics -type f  -not -path "*/__pycache__/*" -exec sed -i '' -e 's/from posthoganalytics\./from posthog\./g' {} \;
+	find ./posthoganalytics -type f -name "*.py" -exec sed -i.bak -e 's/from posthoganalytics /from posthog /g' {} \;
+	find ./posthoganalytics -type f -name "*.py" -exec sed -i.bak -e 's/from posthoganalytics\./from posthog\./g' {} \;
+	find ./posthoganalytics -name "*.bak" -delete
 	cp -r posthoganalytics/* posthog/
 	rm -rf posthoganalytics
 	rm -f pyproject.toml

--- a/posthog/version.py
+++ b/posthog/version.py
@@ -1,4 +1,4 @@
-VERSION = "4.4.1"
+VERSION = "4.4.2"
 
 if __name__ == "__main__":
     print(VERSION, end="")  # noqa: T201

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,10 @@ dev = [
     "pre-commit",
     "pydantic",
     "ruff",
+    "setuptools",
+    "packaging", 
+    "wheel",
+    "twine",
     "tomli",
     "tomli_w",
 ]
@@ -71,14 +75,6 @@ test = [
     "google-genai",
     "pydantic",
     "parameterized>=0.8.1",
-]
-build = [
-    "setuptools",
-    "packaging", 
-    "wheel",
-    "twine",
-    "tomli",
-    "tomli_w",
 ]
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,8 @@ build = [
     "packaging", 
     "wheel",
     "twine",
+    "tomli",
+    "tomli_w",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
ok, next error

```
sed: can't read : No such file or directory
sed: can't read : No such file or directory
sed: can't read : No such file or directory
sed: can't read : No such file or directory
sed: can't read : No such file or directory
sed: can't read : No such file or directory
rm -rf posthog
python setup_analytics.py sdist bdist_wheel
Traceback (most recent call last):
  File "/home/runner/work/posthog-python/posthog-python/setup_analytics.py", line 3, in <module>
    import tomli
ModuleNotFoundError: No module named 'tomli'
```

two things

an error we've not seen or ignored because we're using `sed` with a mac os flag that doesn't work on linux in CI

and then installing tomli in the wrong dependency group