### PR TITLE
fix changelog to match pypi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
-## 4.4.1 and 4.4.2- 2025-06-07
+## 4.4.2- 2025-06-09
 
-- empty point release to fix the posthog_analytics release
+- empty point release to fix release automation
+
+## 4.4.1 2025-06-09
+
+- empty point release to fix release automation
 
 ## 4.4.0 - 2025-06-09
 
@@ -8,19 +12,16 @@
 
 ## 4.3.2 - 2025-06-06
 
-Add context management:
+1. Add context management:
  - New context manager with `posthog.new_context()`
  - Tag functions: `posthog.tag()`, `posthog.get_tags()`, `posthog.clear_tags()`
  - Function decorator:
    - `@posthog.scoped` - Creates context and captures exceptions thrown within the function
  - Automatic deduplication of exceptions to ensure each exception is only captured once
-
-## 4.2.1 - 2025-6-05
-
-1. fix: feature flag request use geoip_disable (#235)
-2. chore: pin actions versions (#210)
-3. fix: opinionated setup and clean fn fix (#240)
-4. fix: release action failed (#241)
+2. fix: feature flag request use geoip_disable (#235)
+3. chore: pin actions versions (#210)
+4. fix: opinionated setup and clean fn fix (#240)
+5. fix: release action failed (#241)
 
 ## 4.2.0 - 2025-05-22
 


### PR DESCRIPTION
now that the release process is fixed we can update the changelog so that it matches pypi

https://pypi.org/project/posthog/#history