### PR TITLE
remove 'import posthog'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.6.2 - 2025-06-09
+
+- fix: replace `import posthog` with direct method imports
+
 ## 4.6.1 - 2025-06-09
 
 - fix: replace `import posthog` in `posthoganalytics` package

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,6 @@ release_analytics:
 	cp -r posthog/* posthoganalytics/
 	find ./posthoganalytics -type f -name "*.py" -exec sed -i.bak -e 's/from posthog /from posthoganalytics /g' {} \;
 	find ./posthoganalytics -type f -name "*.py" -exec sed -i.bak -e 's/from posthog\./from posthoganalytics\./g' {} \;
-	find ./posthoganalytics -type f -name "*.py" -exec sed -i.bak -e 's/import posthog/import posthoganalytics/g' {} \;
 	find ./posthoganalytics -name "*.bak" -delete
 	rm -rf posthog
 	python setup_analytics.py sdist bdist_wheel
@@ -26,7 +25,6 @@ release_analytics:
 	mkdir posthog
 	find ./posthoganalytics -type f -name "*.py" -exec sed -i.bak -e 's/from posthoganalytics /from posthog /g' {} \;
 	find ./posthoganalytics -type f -name "*.py" -exec sed -i.bak -e 's/from posthoganalytics\./from posthog\./g' {} \;
-	find ./posthoganalytics -type f -name "*.py" -exec sed -i.bak -e 's/import posthoganalytics/import posthog/g' {} \;
 	find ./posthoganalytics -name "*.bak" -delete
 	cp -r posthoganalytics/* posthog/
 	rm -rf posthoganalytics

--- a/posthog/scopes.py
+++ b/posthog/scopes.py
@@ -1,7 +1,6 @@
 import contextvars
 from contextlib import contextmanager
 from typing import Any, Callable, Dict, TypeVar, cast
-from posthog import capture_exception
 
 _context_stack: contextvars.ContextVar[list] = contextvars.ContextVar(
     "posthog_context_stack", default=[{}]
@@ -40,6 +39,8 @@ def new_context(fresh=False):
              raise ValueError("Something went wrong")
 
     """
+    from posthog import capture_exception
+
     current_tags = _get_current_context().copy()
     current_stack = _context_stack.get()
     new_stack = current_stack + [{}] if fresh else current_stack + [current_tags]

--- a/posthog/scopes.py
+++ b/posthog/scopes.py
@@ -1,6 +1,7 @@
 import contextvars
 from contextlib import contextmanager
 from typing import Any, Callable, Dict, TypeVar, cast
+from posthog import capture_exception
 
 _context_stack: contextvars.ContextVar[list] = contextvars.ContextVar(
     "posthog_context_stack", default=[{}]
@@ -39,8 +40,6 @@ def new_context(fresh=False):
              raise ValueError("Something went wrong")
 
     """
-    import posthog
-
     current_tags = _get_current_context().copy()
     current_stack = _context_stack.get()
     new_stack = current_stack + [{}] if fresh else current_stack + [current_tags]
@@ -49,7 +48,7 @@ def new_context(fresh=False):
     try:
         yield
     except Exception as e:
-        posthog.capture_exception(e)
+        capture_exception(e)
         raise
     finally:
         _context_stack.reset(token)

--- a/posthog/sentry/posthog_integration.py
+++ b/posthog/sentry/posthog_integration.py
@@ -33,9 +33,9 @@ class PostHogIntegration(Integration):
 
                 if event.get("tags", {}).get(POSTHOG_ID_TAG):
                     posthog_distinct_id = event["tags"][POSTHOG_ID_TAG]
-                    event["tags"][
-                        "PostHog URL"
-                    ] = f"{host or DEFAULT_HOST}/person/{posthog_distinct_id}"
+                    event["tags"]["PostHog URL"] = (
+                        f"{host or DEFAULT_HOST}/person/{posthog_distinct_id}"
+                    )
 
                     properties = {
                         "$sentry_event_id": event["event_id"],

--- a/posthog/sentry/posthog_integration.py
+++ b/posthog/sentry/posthog_integration.py
@@ -4,7 +4,7 @@ from sentry_sdk.integrations import Integration
 from sentry_sdk.scope import add_global_event_processor
 from sentry_sdk.utils import Dsn
 
-import posthog
+from posthog import capture, host
 from posthog.request import DEFAULT_HOST
 from posthog.sentry import POSTHOG_ID_TAG
 
@@ -33,9 +33,9 @@ class PostHogIntegration(Integration):
 
                 if event.get("tags", {}).get(POSTHOG_ID_TAG):
                     posthog_distinct_id = event["tags"][POSTHOG_ID_TAG]
-                    event["tags"]["PostHog URL"] = (
-                        f"{posthog.host or DEFAULT_HOST}/person/{posthog_distinct_id}"
-                    )
+                    event["tags"][
+                        "PostHog URL"
+                    ] = f"{host or DEFAULT_HOST}/person/{posthog_distinct_id}"
 
                     properties = {
                         "$sentry_event_id": event["event_id"],
@@ -52,6 +52,6 @@ class PostHogIntegration(Integration):
                                 f"{PostHogIntegration.prefix}{PostHogIntegration.organization}/issues/?project={project_id}&query={event['event_id']}"
                             )
 
-                    posthog.capture(posthog_distinct_id, "$exception", properties)
+                    capture(posthog_distinct_id, "$exception", properties)
 
             return event

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -1,5 +1,5 @@
-import hashlib
 import time
+import hashlib
 import unittest
 from datetime import datetime
 from uuid import uuid4

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -1,5 +1,4 @@
 import time
-import hashlib
 import unittest
 from datetime import datetime
 from uuid import uuid4

--- a/posthog/version.py
+++ b/posthog/version.py
@@ -1,4 +1,4 @@
-VERSION = "4.6.1"
+VERSION = "4.6.2"
 
 if __name__ == "__main__":
     print(VERSION, end="")  # noqa: T201


### PR DESCRIPTION
Follow on from https://github.com/PostHog/posthog-python/pull/254

That PR had the intended effect of replacing `import posthog` with `import posthoganalytics`. I failed to realise that everywhere `posthog.{method_name}` was called also needed replacing. Going to try this simpler approach of never importing the entire package