### PR TITLE
fix: change scoped export, add capturing param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.8.0 - 2025-06-10
+
+- fix: export scoped, rather than tracked, decorator
+- feat: allow use of contexts without error tracking
+
 ## 4.7.0 - 2025-06-10
 
 - feat: add support for parse endpoint in responses API (no longer beta)

--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -15,7 +15,7 @@ new_context = new_context
 tag = tag
 get_tags = get_tags
 clear_tags = clear_tags
-tracked = scoped
+scoped = scoped
 
 """Settings."""
 api_key = None  # type: Optional[str]

--- a/posthog/scopes.py
+++ b/posthog/scopes.py
@@ -12,31 +12,34 @@ def _get_current_context() -> Dict[str, Any]:
 
 
 @contextmanager
-def new_context(fresh=False):
+def new_context(fresh=False, capturing=True):
     """
-     Create a new context scope that will be active for the duration of the with block.
-     Any tags set within this scope will be isolated to this context. Any exceptions raised
+    Create a new context scope that will be active for the duration of the with block.
+    Any tags set within this scope will be isolated to this context. Any exceptions raised
     or events captured within the context will be tagged with the context tags.
 
-     Args:
-         fresh: Whether to start with a fresh context (default: False).
-                If False, inherits tags from parent context.
-                If True, starts with no tags.
+    Args:
+        fresh: Whether to start with a fresh context (default: False).
+               If False, inherits tags from parent context.
+               If True, starts with no tags.
+        capturing: Whether to capture exceptions raised within the context (default: True).
+               If True, captures exceptions and tags them with the context tags before propagating them.
+               If False, exceptions will propagate without being tagged or captured.
 
-     Examples:
-         # Inherit parent context tags
-         with posthog.new_context():
-             posthog.tag("request_id", "123")
-             # Both this event and the exception will be tagged with the context tags
-             posthog.capture("event_name", {"property": "value"})
-             raise ValueError("Something went wrong")
+    Examples:
+        # Inherit parent context tags
+        with posthog.new_context():
+            posthog.tag("request_id", "123")
+            # Both this event and the exception will be tagged with the context tags
+            posthog.capture("event_name", {"property": "value"})
+            raise ValueError("Something went wrong")
 
-         # Start with fresh context (no inherited tags)
-         with posthog.new_context(fresh=True):
-             posthog.tag("request_id", "123")
-             # Both this event and the exception will be tagged with the context tags
-             posthog.capture("event_name", {"property": "value"})
-             raise ValueError("Something went wrong")
+        # Start with fresh context (no inherited tags)
+        with posthog.new_context(fresh=True):
+            posthog.tag("request_id", "123")
+            # Both this event and the exception will be tagged with the context tags
+            posthog.capture("event_name", {"property": "value"})
+            raise ValueError("Something went wrong")
 
     """
     from posthog import capture_exception
@@ -49,7 +52,8 @@ def new_context(fresh=False):
     try:
         yield
     except Exception as e:
-        capture_exception(e)
+        if capturing:
+            capture_exception(e)
         raise
     finally:
         _context_stack.reset(token)
@@ -88,13 +92,14 @@ def clear_tags() -> None:
 F = TypeVar("F", bound=Callable[..., Any])
 
 
-def scoped(fresh=False):
+def scoped(fresh=False, capturing=True):
     """
     Decorator that creates a new context for the function. Simply wraps
     the function in a with posthog.new_context(): block.
 
     Args:
         fresh: Whether to start with a fresh context (default: False)
+        capturing: Whether to capture and track exceptions with posthog error tracking (default: True)
 
     Example:
         @posthog.scoped()
@@ -114,7 +119,7 @@ def scoped(fresh=False):
 
         @wraps(func)
         def wrapper(*args, **kwargs):
-            with new_context(fresh=fresh):
+            with new_context(fresh=fresh, capturing=capturing):
                 return func(*args, **kwargs)
 
         return cast(F, wrapper)

--- a/posthog/scopes.py
+++ b/posthog/scopes.py
@@ -12,7 +12,7 @@ def _get_current_context() -> Dict[str, Any]:
 
 
 @contextmanager
-def new_context(fresh=False, capturing=True):
+def new_context(fresh=False, capture_exceptions=True):
     """
     Create a new context scope that will be active for the duration of the with block.
     Any tags set within this scope will be isolated to this context. Any exceptions raised
@@ -22,7 +22,7 @@ def new_context(fresh=False, capturing=True):
         fresh: Whether to start with a fresh context (default: False).
                If False, inherits tags from parent context.
                If True, starts with no tags.
-        capturing: Whether to capture exceptions raised within the context (default: True).
+        capture_exceptions: Whether to capture exceptions raised within the context (default: True).
                If True, captures exceptions and tags them with the context tags before propagating them.
                If False, exceptions will propagate without being tagged or captured.
 
@@ -52,7 +52,7 @@ def new_context(fresh=False, capturing=True):
     try:
         yield
     except Exception as e:
-        if capturing:
+        if capture_exceptions:
             capture_exception(e)
         raise
     finally:
@@ -92,14 +92,14 @@ def clear_tags() -> None:
 F = TypeVar("F", bound=Callable[..., Any])
 
 
-def scoped(fresh=False, capturing=True):
+def scoped(fresh=False, capture_exceptions=True):
     """
     Decorator that creates a new context for the function. Simply wraps
     the function in a with posthog.new_context(): block.
 
     Args:
         fresh: Whether to start with a fresh context (default: False)
-        capturing: Whether to capture and track exceptions with posthog error tracking (default: True)
+        capture_exceptions: Whether to capture and track exceptions with posthog error tracking (default: True)
 
     Example:
         @posthog.scoped()
@@ -119,7 +119,7 @@ def scoped(fresh=False, capturing=True):
 
         @wraps(func)
         def wrapper(*args, **kwargs):
-            with new_context(fresh=fresh, capturing=capturing):
+            with new_context(fresh=fresh, capture_exceptions=capture_exceptions):
                 return func(*args, **kwargs)
 
         return cast(F, wrapper)

--- a/posthog/version.py
+++ b/posthog/version.py
@@ -1,4 +1,4 @@
-VERSION = "4.7.0"
+VERSION = "4.8.0"
 
 if __name__ == "__main__":
     print(VERSION, end="")  # noqa: T201


### PR DESCRIPTION
Figured while I was here we may as well let people use the tagging infrastructure without forcing them to use error tracking - it seems like a nice pattern for using posthog generally.

I do think we should default opt-in to error tracking tho - if we get complaints, we can expose a global config to disable it at the client level, but capturing exceptions in the most deeply nested context means getting the most tags on them, which is the ideal scenario.