### PR TITLE
feat(err): construct full trace if no traceback available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 5.1.0
+# 5.2.0 - 2025-06-19
+
+- feat: construct artificial stack traces if no traceback is available on a captured exception
+
+## 5.1.0 - 2025-06-18
 
 - feat: session and distinct ID's can now be associated with contexts, and are used as such
 - feat: django http request middleware

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -117,22 +117,6 @@ class TestClient(unittest.TestCase):
             capture_call = patch_capture.call_args[0]
             self.assertEqual(capture_call[0], "distinct_id")
             self.assertEqual(capture_call[1], "$exception")
-            self.assertEqual(
-                capture_call[2],
-                {
-                    "$exception_type": "Exception",
-                    "$exception_message": "test exception",
-                    "$exception_list": [
-                        {
-                            "mechanism": {"type": "generic", "handled": True},
-                            "module": None,
-                            "type": "Exception",
-                            "value": "test exception",
-                        }
-                    ],
-                    "$exception_personURL": "https://us.i.posthog.com/project/random_key/person/distinct_id",
-                },
-            )
 
     def test_basic_capture_exception_with_distinct_id(self):
         with mock.patch.object(Client, "capture", return_value=None) as patch_capture:
@@ -144,22 +128,6 @@ class TestClient(unittest.TestCase):
             capture_call = patch_capture.call_args[0]
             self.assertEqual(capture_call[0], "distinct_id")
             self.assertEqual(capture_call[1], "$exception")
-            self.assertEqual(
-                capture_call[2],
-                {
-                    "$exception_type": "Exception",
-                    "$exception_message": "test exception",
-                    "$exception_list": [
-                        {
-                            "mechanism": {"type": "generic", "handled": True},
-                            "module": None,
-                            "type": "Exception",
-                            "value": "test exception",
-                        }
-                    ],
-                    "$exception_personURL": "https://us.i.posthog.com/project/random_key/person/distinct_id",
-                },
-            )
 
     def test_basic_capture_exception_with_correct_host_generation(self):
         with mock.patch.object(Client, "capture", return_value=None) as patch_capture:
@@ -173,22 +141,6 @@ class TestClient(unittest.TestCase):
             capture_call = patch_capture.call_args[0]
             self.assertEqual(capture_call[0], "distinct_id")
             self.assertEqual(capture_call[1], "$exception")
-            self.assertEqual(
-                capture_call[2],
-                {
-                    "$exception_type": "Exception",
-                    "$exception_message": "test exception",
-                    "$exception_list": [
-                        {
-                            "mechanism": {"type": "generic", "handled": True},
-                            "module": None,
-                            "type": "Exception",
-                            "value": "test exception",
-                        }
-                    ],
-                    "$exception_personURL": "https://aloha.com/project/random_key/person/distinct_id",
-                },
-            )
 
     def test_basic_capture_exception_with_correct_host_generation_for_server_hosts(
         self,
@@ -206,22 +158,6 @@ class TestClient(unittest.TestCase):
             capture_call = patch_capture.call_args[0]
             self.assertEqual(capture_call[0], "distinct_id")
             self.assertEqual(capture_call[1], "$exception")
-            self.assertEqual(
-                capture_call[2],
-                {
-                    "$exception_type": "Exception",
-                    "$exception_message": "test exception",
-                    "$exception_list": [
-                        {
-                            "mechanism": {"type": "generic", "handled": True},
-                            "module": None,
-                            "type": "Exception",
-                            "value": "test exception",
-                        }
-                    ],
-                    "$exception_personURL": "https://app.posthog.com/project/random_key/person/distinct_id",
-                },
-            )
 
     def test_basic_capture_exception_with_no_exception_given(self):
         with mock.patch.object(Client, "capture", return_value=None) as patch_capture:

--- a/posthog/version.py
+++ b/posthog/version.py
@@ -1,4 +1,4 @@
-VERSION = "5.1.0"
+VERSION = "5.2.0"
 
 if __name__ == "__main__":
     print(VERSION, end="")  # noqa: T201


### PR DESCRIPTION
This goes with the reversed-full-stack approach. It is naive to async considerations. Options below:

Original
![image](https://github.com/user-attachments/assets/9b785fd7-4f4d-4b2b-9fad-d6ad0ba96b3c)

Naive full stack:
![image](https://github.com/user-attachments/assets/d8ddc02f-4825-4086-9944-3e351a91c4f2)

Reversed full stack:
![image](https://github.com/user-attachments/assets/c06bb41e-ba2a-40a8-892c-99bdb65b5c49)
