### PR TITLE
Langchain model token counting bug fix

### DIFF
--- a/posthog/ai/langchain/callbacks.py
+++ b/posthog/ai/langchain/callbacks.py
@@ -756,14 +756,23 @@ def _parse_usage(response: LLMResult) -> ModelUsage:
                 break
 
             for generation_chunk in generation:
-                usage_metadata = (
-                    (generation_chunk.generation_info or {}).get("usage_metadata") or
-                    (generation_chunk.message or {}).get("usage_metadata") or
-                    {}
-                )
-                if usage_metadata:
-                    llm_usage = _parse_usage_model(usage_metadata)
-                    break
+                if generation_chunk.generation_info and (
+                    "usage_metadata" in generation_chunk.generation_info
+                ):
+                    if generation_chunk.generation_info["usage_metadata"]:
+                        llm_usage = _parse_usage_model(
+                            generation_chunk.generation_info["usage_metadata"]
+                        )
+                        break
+                    
+                    elif generation_chunk.message and (
+                        "usage_metadata" in generation_chunk.message
+                    ):
+                        if generation_chunk.message["usage_metadata"]:
+                            llm_usage = _parse_usage_model(
+                                generation_chunk.message["usage_metadata"]
+                            )
+                            break
 
                 message_chunk = getattr(generation_chunk, "message", {})
                 response_metadata = getattr(message_chunk, "response_metadata", {})


### PR DESCRIPTION
For models with reasoning tokens, the `_parse_usage` function in the Langchain `CallbackHandler` does not successfully parse token usage metadata to PostHog.