### PR TITLE
fix(err): permit disabling person processing

### DIFF
--- a/posthog/client.py
+++ b/posthog/client.py
@@ -351,7 +351,7 @@ class Client(object):
 
         (distinct_id, personless) = get_identity_state(distinct_id)
 
-        if personless:
+        if personless and "$process_person_profile" not in properties:
             properties["$process_person_profile"] = False
 
         msg = {


### PR DESCRIPTION
Recent changes left no good way to force disable person processing if you were in an identified context - this allows that again, by respecting the property if it's passed as set.