### PR TITLE
fix: add middleware setting for custom client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 6.0.4 - 2025-07-09
+
+- fix: add POSTHOG_MW_CLIENT setting to django middleware, to support custom clients for exception capture.
+
 # 6.0.3 - 2025-07-07
 
 - feat: add a feature flag evaluation cache (local storage or redis) to support returning flag evaluations when the service is down

--- a/posthog/integrations/django.py
+++ b/posthog/integrations/django.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING, cast
 from posthog import contexts
+from posthog.client import Client
 
 if TYPE_CHECKING:
     from django.http import HttpRequest, HttpResponse  # noqa: F401
@@ -16,7 +17,8 @@ class PosthogContextMiddleware:
     - Request Method as $request_method
 
     The context will also auto-capture exceptions and send them to PostHog, unless you disable it by setting
-    `POSTHOG_MW_CAPTURE_EXCEPTIONS` to `False` in your Django settings.
+    `POSTHOG_MW_CAPTURE_EXCEPTIONS` to `False` in your Django settings. The exceptions are captured using the
+    global client, unless the setting `POSTHOG_MW_CLIENT` is set to a custom client instant.
 
     The middleware behaviour is customisable through 3 additional functions:
     - `POSTHOG_MW_EXTRA_TAGS`, which is a Callable[[HttpRequest], Dict[str, Any]] expected to return a dictionary of additional tags to be added to the context.
@@ -73,6 +75,13 @@ class PosthogContextMiddleware:
             self.capture_exceptions = settings.POSTHOG_MW_CAPTURE_EXCEPTIONS
         else:
             self.capture_exceptions = True
+
+        if hasattr(settings, "POSTHOG_MW_CLIENT") and isinstance(
+            settings.POSTHOG_MW_CLIENT, Client
+        ):
+            self.client = settings.POSTHOG_MW_CLIENT
+        else:
+            self.client = None
 
     def extract_tags(self, request):
         # type: (HttpRequest) -> Dict[str, Any]
@@ -153,7 +162,7 @@ class PosthogContextMiddleware:
         if self.request_filter and not self.request_filter(request):
             return self.get_response(request)
 
-        with contexts.new_context(self.capture_exceptions):
+        with contexts.new_context(self.capture_exceptions, client=self.client):
             for k, v in self.extract_tags(request).items():
                 contexts.tag(k, v)
 

--- a/posthog/version.py
+++ b/posthog/version.py
@@ -1,4 +1,4 @@
-VERSION = "6.0.3"
+VERSION = "6.0.4"
 
 if __name__ == "__main__":
     print(VERSION, end="")  # noqa: T201


### PR DESCRIPTION
Many people construct a client instance, rather than using the module methods, and need a way to use that initialised client in the django middleware