### PR TITLE
feat(flags): decouple local evaluation from personal API keys; support decrypting remote config payloads without relying on the feature flags poller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 6.1.0 - 2025-01-07
+
+1. feat: decouple feature flag local evaluation from personal API keys; support decrypting remote config payloads without relying on the feature flags poller
+
 # 6.0.4 - 2025-07-09
 
 - fix: add POSTHOG_MW_CLIENT setting to django middleware, to support custom clients for exception capture.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# 6.1.0 - 2025-01-07
+# 6.1.0 - 2025-07-10
 
-1. feat: decouple feature flag local evaluation from personal API keys; support decrypting remote config payloads without relying on the feature flags poller
+- feat: decouple feature flag local evaluation from personal API keys; support decrypting remote config payloads without relying on the feature flags poller
 
 # 6.0.4 - 2025-07-09
 

--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -60,6 +60,9 @@ log_captured_exceptions = False  # type: bool
 project_root = None  # type: Optional[str]
 # Used for our AI observability feature to not capture any prompt or output just usage + metadata
 privacy_mode = False  # type: bool
+# Whether to enable feature flag polling for local evaluation by default. Defaults to True.
+# We recommend setting this to False if you are only using the personalApiKey for evaluating remote config payloads via `get_remote_config_payload` and not using local evaluation.
+enable_local_evaluation = True  # type: bool
 
 default_client = None  # type: Optional[Client]
 
@@ -465,6 +468,7 @@ def setup():
             # or deprecate this proxy option fully (it's already in the process of deprecation, no new clients should be using this method since like 5-6 months)
             enable_exception_autocapture=enable_exception_autocapture,
             log_captured_exceptions=log_captured_exceptions,
+            enable_local_evaluation=enable_local_evaluation,
         )
 
     # always set incase user changes it

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -152,6 +152,7 @@ class Client(object):
         privacy_mode=False,
         before_send=None,
         flag_fallback_cache_url=None,
+        enable_local_evaluation=True,
     ):
         self.queue = queue.Queue(max_queue_size)
 
@@ -187,6 +188,7 @@ class Client(object):
         self.log_captured_exceptions = log_captured_exceptions
         self.exception_capture = None
         self.privacy_mode = privacy_mode
+        self.enable_local_evaluation = enable_local_evaluation
 
         if project_root is None:
             try:
@@ -807,7 +809,11 @@ class Client(object):
             return
 
         self._load_feature_flags()
-        if not (self.poller and self.poller.is_alive()):
+
+        # Only start the poller if local evaluation is enabled
+        if self.enable_local_evaluation and not (
+            self.poller and self.poller.is_alive()
+        ):
             self.poller = Poller(
                 interval=timedelta(seconds=self.poll_interval),
                 execute=self._load_feature_flags,

--- a/posthog/version.py
+++ b/posthog/version.py
@@ -1,4 +1,4 @@
-VERSION = "6.0.4"
+VERSION = "6.1.0"
 
 if __name__ == "__main__":
     print(VERSION, end="")  # noqa: T201


### PR DESCRIPTION
Parity with the Node SDK changes I made [here](https://github.com/PostHog/posthog-js-lite/pull/559/)