### PR TITLE
fix: Ignore new `flag` filter type in local evaluation

### DIFF
--- a/posthog/feature_flags.py
+++ b/posthog/feature_flags.py
@@ -109,6 +109,14 @@ def is_condition_match(
             property_type = prop.get("type")
             if property_type == "cohort":
                 matches = match_cohort(prop, properties, cohort_properties)
+            elif property_type == "flag":
+                log.warning(
+                    "Flag dependency filters are not supported in local evaluation. "
+                    "Skipping condition for flag '%s' with dependency on flag '%s'",
+                    feature_flag.get("key", "unknown"),
+                    prop.get("key", "unknown"),
+                )
+                continue
             else:
                 matches = match_property(prop, properties)
             if not matches:
@@ -317,6 +325,13 @@ def match_property_group(property_group, property_values, cohort_properties) -> 
             try:
                 if prop.get("type") == "cohort":
                     matches = match_cohort(prop, property_values, cohort_properties)
+                elif prop.get("type") == "flag":
+                    log.warning(
+                        "Flag dependency filters are not supported in local evaluation. "
+                        "Skipping condition with dependency on flag '%s'",
+                        prop.get("key", "unknown"),
+                    )
+                    continue
                 else:
                     matches = match_property(prop, property_values)
 


### PR DESCRIPTION
Add support for the new "flag" filter type to prevent serialization errors during local feature flag evaluation. Flag dependencies are not yet implemented in local evaluation, so these conditions are skipped to allow other conditions to be evaluated properly.