### PR TITLE
bug(llmo): fix anthropic tool call response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 6.3.2
+# 6.3.2 - 2025-07-31
 
 - fix: Anthropic's tool calls are now handled properly
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 6.3.2
+
+- fix: Anthropic's tool calls are now handled properly
+
 # 6.3.0 - 2025-07-22
 
 - feat: Enhanced `send_feature_flags` parameter to accept `SendFeatureFlagsOptions` object for declarative control over local/remote evaluation and custom properties

--- a/posthog/ai/utils.py
+++ b/posthog/ai/utils.py
@@ -118,7 +118,7 @@ def format_response(response, provider: str):
 def format_response_anthropic(response):
     output = []
     for choice in response.content:
-        if choice.text:
+        if hasattr(choice, "type") and choice.type == "text" and hasattr(choice, "text") and choice.text:
             output.append(
                 {
                     "role": "assistant",

--- a/posthog/ai/utils.py
+++ b/posthog/ai/utils.py
@@ -118,7 +118,12 @@ def format_response(response, provider: str):
 def format_response_anthropic(response):
     output = []
     for choice in response.content:
-        if hasattr(choice, "type") and choice.type == "text" and hasattr(choice, "text") and choice.text:
+        if (
+            hasattr(choice, "type")
+            and choice.type == "text"
+            and hasattr(choice, "text")
+            and choice.text
+        ):
             output.append(
                 {
                     "role": "assistant",
@@ -230,8 +235,14 @@ def format_tool_calls(response, provider: str):
 
             for content_item in response.content:
                 if hasattr(content_item, "type") and content_item.type == "tool_use":
-                    tool_call_dict = vars(content_item)
-                    tool_calls.append(tool_call_dict)
+                    tool_calls.append(
+                        {
+                            "type": content_item.type,
+                            "id": content_item.id,
+                            "name": content_item.name,
+                            "input": content_item.input,
+                        }
+                    )
 
             return tool_calls if tool_calls else None
     elif provider == "openai":

--- a/posthog/test/ai/anthropic/test_anthropic.py
+++ b/posthog/test/ai/anthropic/test_anthropic.py
@@ -96,7 +96,12 @@ def mock_anthropic_response_with_tool_use():
         role="assistant",
         content=[
             {"type": "text", "text": "I'll help you with that."},
-            {"type": "tool_use", "id": "tool_1", "name": "get_weather", "input": {"location": "New York"}}
+            {
+                "type": "tool_use",
+                "id": "tool_1",
+                "name": "get_weather",
+                "input": {"location": "New York"},
+            },
         ],
         model="claude-3-opus-20240229",
         usage=Usage(
@@ -479,7 +484,9 @@ def test_tool_use_response(mock_client, mock_anthropic_response_with_tool_use):
         assert call_args["event"] == "$ai_generation"
         assert props["$ai_provider"] == "anthropic"
         assert props["$ai_model"] == "claude-3-opus-20240229"
-        assert props["$ai_input"] == [{"role": "user", "content": "What's the weather like?"}]
+        assert props["$ai_input"] == [
+            {"role": "user", "content": "What's the weather like?"}
+        ]
         # Should only include text content, not tool_use content
         assert props["$ai_output_choices"] == [
             {"role": "assistant", "content": "I'll help you with that."}
@@ -490,4 +497,11 @@ def test_tool_use_response(mock_client, mock_anthropic_response_with_tool_use):
         assert props["foo"] == "bar"
         assert isinstance(props["$ai_latency"], float)
         # Verify that tools are captured separately
-        assert props["$ai_tools"] == [{"type": "tool_use", "id": "tool_1", "name": "get_weather", "input": {"location": "New York"}}]
+        assert props["$ai_tools"] == [
+            {
+                "type": "tool_use",
+                "id": "tool_1",
+                "name": "get_weather",
+                "input": {"location": "New York"},
+            }
+        ]

--- a/posthog/version.py
+++ b/posthog/version.py
@@ -1,4 +1,4 @@
-VERSION = "6.3.1"
+VERSION = "6.3.2"
 
 if __name__ == "__main__":
     print(VERSION, end="")  # noqa: T201


### PR DESCRIPTION
The anthropic response handler when there are tool calls is broken for two reasons:
1. It tries to access a field that doesn't exist when the response is a tool call (`text`).
2. It doesn't properly capture tool calls to send as `$ai_tools` to PostHog.

This fixes both problems. Here's a sample response with a tool call from Anthropic:

```json
{
  "message": {
    "id": "msg_h87n43hife...",
    "role": "assistant",
    "model": "claude-3-5-sonnet-20241022",
    "type": "message",
    "stop_reason": "tool_use",
    "stop_sequence": null,
    "content": [
      {
        "type": "tool_use",
        "id": "toolu_iudsn7es...",
        "name": "respond",
        "input": {
          "table": [
            {
              "name": "John Smith",
              "age": 30,
              "email": "john.smith@email.com"
            }
          ]
        }
      }
    ],
    "usage": {
      "input_tokens": 446,
      "output_tokens": 72,
      "cache_creation_input_tokens": 0,
      "cache_read_input_tokens": 0,
      "server_tool_use": null,
      "service_tier": "standard"
    }
  }
}
```