### PR TITLE
fix(flags): don't cast `""` to `None` when returning feature flag payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 6.3.3 - 2025-08-01
+
+- fix: `get_feature_flag_result` now correctly returns FeatureFlagResult when payload is empty string instead of None
+
 # 6.3.2 - 2025-07-31
 
 - fix: Anthropic's tool calls are now handled properly

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -1285,7 +1285,7 @@ class Client(object):
             lookup_match_value = override_match_value or flag_value
             payload = (
                 self._compute_payload_locally(key, lookup_match_value)
-                if lookup_match_value
+                if lookup_match_value is not None
                 else None
             )
             flag_result = FeatureFlagResult.from_value_and_payload(
@@ -1586,7 +1586,7 @@ class Client(object):
                 f"$feature/{key}": response,
             }
 
-            if payload:
+            if payload is not None:
                 # if payload is not a string, json serialize it to a string
                 properties["$feature_flag_payload"] = payload
 
@@ -1790,7 +1790,7 @@ class Client(object):
                     matched_payload = self._compute_payload_locally(
                         flag["key"], flags[flag["key"]]
                     )
-                    if matched_payload:
+                    if matched_payload is not None:
                         payloads[flag["key"]] = matched_payload
                 except InconclusiveMatchError:
                     # No need to log this, since it's just telling us to fall back to `/decide`

--- a/posthog/types.py
+++ b/posthog/types.py
@@ -110,7 +110,7 @@ class FeatureFlag:
             variant=variant,
             reason=None,
             metadata=LegacyFlagMetadata(
-                payload=payload if payload else None,
+                payload=payload,
             ),
         )
 
@@ -178,7 +178,9 @@ class FeatureFlagResult:
             key=key,
             enabled=enabled,
             variant=variant,
-            payload=json.loads(payload) if isinstance(payload, str) else payload,
+            payload=json.loads(payload)
+            if isinstance(payload, str) and payload
+            else payload,
             reason=None,
         )
 
@@ -219,6 +221,7 @@ class FeatureFlagResult:
             payload=(
                 json.loads(details.metadata.payload)
                 if isinstance(details.metadata.payload, str)
+                and details.metadata.payload
                 else details.metadata.payload
             ),
             reason=details.reason.description if details.reason else None,
@@ -296,5 +299,7 @@ def to_payloads(response: FlagsResponse) -> Optional[dict[str, str]]:
     return {
         key: value.metadata.payload
         for key, value in response.get("flags", {}).items()
-        if isinstance(value, FeatureFlag) and value.enabled and value.metadata.payload
+        if isinstance(value, FeatureFlag)
+        and value.enabled
+        and value.metadata.payload is not None
     }

--- a/posthog/version.py
+++ b/posthog/version.py
@@ -1,4 +1,4 @@
-VERSION = "6.3.2"
+VERSION = "6.3.3"
 
 if __name__ == "__main__":
     print(VERSION, end="")  # noqa: T201


### PR DESCRIPTION


 ## Fix: Return FeatureFlagResult for empty string payloads

  ### Problem
  When a feature flag variant has an empty string (`""`) as its payload, `get_feature_flag_result()` returns `None` instead of a `FeatureFlagResult` object with the empty string payload.

  ### Solution
  Updated falsy checks throughout the codebase to use explicit `is not None` checks instead of relying on Python's truthiness. This ensures empty strings are properly handled as valid payloads.

  ### Changes
  - Fixed payload handling in `client.py` to check `is not None` instead of truthiness
  - Updated `types.py` to avoid JSON parsing empty strings
  - Added comprehensive tests for empty string payload scenarios

  ### Testing
  Added tests to verify:
  - `get_feature_flag_result()` returns a proper `FeatureFlagResult` with empty string payload
  - `get_all_flags_and_payloads()` includes flags with empty string payloads

Closes https://github.com/PostHog/posthog-python/issues/296