### PR TITLE
feat(llmo): support Vertex AI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+# 6.4.0 - 2025-08-05
+
+- feat: support Vertex AI for Gemini
+
 # 6.3.4 - 2025-08-04
 
-- fix: Set `$ai_tools` for all providers and `$ai_output_choices` for all non-streaming provider flows properly
+- fix: set `$ai_tools` for all providers and `$ai_output_choices` for all non-streaming provider flows properly
 
 # 6.3.3 - 2025-08-01
 

--- a/posthog/ai/gemini/gemini.py
+++ b/posthog/ai/gemini/gemini.py
@@ -42,6 +42,12 @@ class Client:
     def __init__(
         self,
         api_key: Optional[str] = None,
+        vertexai: Optional[bool] = None,
+        credentials: Optional[Any] = None,
+        project: Optional[str] = None,
+        location: Optional[str] = None,
+        debug_config: Optional[Any] = None,
+        http_options: Optional[Any] = None,
         posthog_client: Optional[PostHogClient] = None,
         posthog_distinct_id: Optional[str] = None,
         posthog_properties: Optional[Dict[str, Any]] = None,
@@ -51,7 +57,13 @@ class Client:
     ):
         """
         Args:
-            api_key: Google AI API key. If not provided, will use GOOGLE_API_KEY or API_KEY environment variable
+            api_key: Google AI API key. If not provided, will use GOOGLE_API_KEY or API_KEY environment variable (not required for Vertex AI)
+            vertexai: Whether to use Vertex AI authentication
+            credentials: Vertex AI credentials object
+            project: GCP project ID for Vertex AI
+            location: GCP location for Vertex AI
+            debug_config: Debug configuration for the client
+            http_options: HTTP options for the client
             posthog_client: PostHog client for tracking usage
             posthog_distinct_id: Default distinct ID for all calls (can be overridden per call)
             posthog_properties: Default properties for all calls (can be overridden per call)
@@ -66,6 +78,12 @@ class Client:
 
         self.models = Models(
             api_key=api_key,
+            vertexai=vertexai,
+            credentials=credentials,
+            project=project,
+            location=location,
+            debug_config=debug_config,
+            http_options=http_options,
             posthog_client=self._ph_client,
             posthog_distinct_id=posthog_distinct_id,
             posthog_properties=posthog_properties,
@@ -85,6 +103,12 @@ class Models:
     def __init__(
         self,
         api_key: Optional[str] = None,
+        vertexai: Optional[bool] = None,
+        credentials: Optional[Any] = None,
+        project: Optional[str] = None,
+        location: Optional[str] = None,
+        debug_config: Optional[Any] = None,
+        http_options: Optional[Any] = None,
         posthog_client: Optional[PostHogClient] = None,
         posthog_distinct_id: Optional[str] = None,
         posthog_properties: Optional[Dict[str, Any]] = None,
@@ -94,7 +118,13 @@ class Models:
     ):
         """
         Args:
-            api_key: Google AI API key. If not provided, will use GOOGLE_API_KEY or API_KEY environment variable
+            api_key: Google AI API key. If not provided, will use GOOGLE_API_KEY or API_KEY environment variable (not required for Vertex AI)
+            vertexai: Whether to use Vertex AI authentication
+            credentials: Vertex AI credentials object
+            project: GCP project ID for Vertex AI
+            location: GCP location for Vertex AI
+            debug_config: Debug configuration for the client
+            http_options: HTTP options for the client
             posthog_client: PostHog client for tracking usage
             posthog_distinct_id: Default distinct ID for all calls
             posthog_properties: Default properties for all calls
@@ -113,16 +143,40 @@ class Models:
         self._default_privacy_mode = posthog_privacy_mode
         self._default_groups = posthog_groups
 
-        # Handle API key - try parameter first, then environment variables
-        if api_key is None:
-            api_key = os.environ.get("GOOGLE_API_KEY") or os.environ.get("API_KEY")
+        # Build genai.Client arguments
+        client_args = {}
+        
+        # Add Vertex AI parameters if provided
+        if vertexai is not None:
+            client_args["vertexai"] = vertexai
+        if credentials is not None:
+            client_args["credentials"] = credentials
+        if project is not None:
+            client_args["project"] = project
+        if location is not None:
+            client_args["location"] = location
+        if debug_config is not None:
+            client_args["debug_config"] = debug_config
+        if http_options is not None:
+            client_args["http_options"] = http_options
 
-        if api_key is None:
-            raise ValueError(
-                "API key must be provided either as parameter or via GOOGLE_API_KEY/API_KEY environment variable"
-            )
+        # Handle API key authentication
+        if vertexai:
+            # For Vertex AI, api_key is optional
+            if api_key is not None:
+                client_args["api_key"] = api_key
+        else:
+            # For non-Vertex AI mode, api_key is required (backwards compatibility)
+            if api_key is None:
+                api_key = os.environ.get("GOOGLE_API_KEY") or os.environ.get("API_KEY")
 
-        self._client = genai.Client(api_key=api_key)
+            if api_key is None:
+                raise ValueError(
+                    "API key must be provided either as parameter or via GOOGLE_API_KEY/API_KEY environment variable"
+                )
+            client_args["api_key"] = api_key
+
+        self._client = genai.Client(**client_args)
         self._base_url = "https://generativelanguage.googleapis.com"
 
     def _merge_posthog_params(

--- a/posthog/ai/gemini/gemini.py
+++ b/posthog/ai/gemini/gemini.py
@@ -144,7 +144,7 @@ class Models:
         self._default_groups = posthog_groups
 
         # Build genai.Client arguments
-        client_args = {}
+        client_args: Dict[str, Any] = {}
 
         # Add Vertex AI parameters if provided
         if vertexai is not None:

--- a/posthog/ai/gemini/gemini.py
+++ b/posthog/ai/gemini/gemini.py
@@ -145,7 +145,7 @@ class Models:
 
         # Build genai.Client arguments
         client_args = {}
-        
+
         # Add Vertex AI parameters if provided
         if vertexai is not None:
             client_args["vertexai"] = vertexai

--- a/posthog/test/ai/gemini/test_gemini.py
+++ b/posthog/test/ai/gemini/test_gemini.py
@@ -472,6 +472,7 @@ def test_vertex_ai_mode_with_optional_api_key(
         project="test-project",
     )
 
+
 def test_tool_use_response(mock_client, mock_google_genai_client, mock_gemini_response):
     """Test that tools defined in config are captured in $ai_tools property"""
     mock_google_genai_client.models.generate_content.return_value = mock_gemini_response

--- a/posthog/test/ai/gemini/test_gemini.py
+++ b/posthog/test/ai/gemini/test_gemini.py
@@ -318,3 +318,71 @@ def test_new_client_override_defaults(
     assert props["team"] == "ai"  # from defaults
     assert props["feature"] == "chat"  # from call
     assert props["urgent"] is True  # from call
+
+
+def test_vertex_ai_parameters_passed_through(mock_client, mock_google_genai_client, mock_gemini_response):
+    """Test that Vertex AI parameters are properly passed to genai.Client"""
+    mock_google_genai_client.models.generate_content.return_value = mock_gemini_response
+    
+    # Mock credentials object
+    mock_credentials = MagicMock()
+    mock_debug_config = MagicMock()
+    mock_http_options = MagicMock()
+
+    # Create client with Vertex AI parameters
+    Client(
+        vertexai=True,
+        credentials=mock_credentials,
+        project="test-project",
+        location="us-central1",
+        debug_config=mock_debug_config,
+        http_options=mock_http_options,
+        posthog_client=mock_client,
+    )
+
+    # Verify genai.Client was called with correct parameters
+    google_genai.Client.assert_called_once_with(
+        vertexai=True,
+        credentials=mock_credentials,
+        project="test-project",
+        location="us-central1",
+        debug_config=mock_debug_config,
+        http_options=mock_http_options
+    )
+
+
+def test_api_key_mode(mock_client, mock_google_genai_client):
+    """Test API key authentication mode"""
+    
+    # Create client with just API key (traditional mode)
+    Client(
+        api_key="test-api-key",
+        posthog_client=mock_client,
+    )
+
+    # Verify genai.Client was called with only api_key
+    google_genai.Client.assert_called_once_with(api_key="test-api-key")
+
+
+def test_vertex_ai_mode_with_optional_api_key(mock_client, mock_google_genai_client, mock_gemini_response):
+    """Test Vertex AI mode with optional API key"""
+    mock_google_genai_client.models.generate_content.return_value = mock_gemini_response
+    
+    mock_credentials = MagicMock()
+
+    # Create client with Vertex AI + API key
+    Client(
+        vertexai=True,
+        api_key="test-api-key",
+        credentials=mock_credentials,
+        project="test-project",
+        posthog_client=mock_client,
+    )
+
+    # Verify genai.Client was called with both Vertex AI params and API key
+    google_genai.Client.assert_called_once_with(
+        vertexai=True,
+        api_key="test-api-key",
+        credentials=mock_credentials,
+        project="test-project"
+    )

--- a/posthog/test/ai/gemini/test_gemini.py
+++ b/posthog/test/ai/gemini/test_gemini.py
@@ -320,10 +320,12 @@ def test_new_client_override_defaults(
     assert props["urgent"] is True  # from call
 
 
-def test_vertex_ai_parameters_passed_through(mock_client, mock_google_genai_client, mock_gemini_response):
+def test_vertex_ai_parameters_passed_through(
+    mock_client, mock_google_genai_client, mock_gemini_response
+):
     """Test that Vertex AI parameters are properly passed to genai.Client"""
     mock_google_genai_client.models.generate_content.return_value = mock_gemini_response
-    
+
     # Mock credentials object
     mock_credentials = MagicMock()
     mock_debug_config = MagicMock()
@@ -347,13 +349,13 @@ def test_vertex_ai_parameters_passed_through(mock_client, mock_google_genai_clie
         project="test-project",
         location="us-central1",
         debug_config=mock_debug_config,
-        http_options=mock_http_options
+        http_options=mock_http_options,
     )
 
 
 def test_api_key_mode(mock_client, mock_google_genai_client):
     """Test API key authentication mode"""
-    
+
     # Create client with just API key (traditional mode)
     Client(
         api_key="test-api-key",
@@ -364,10 +366,12 @@ def test_api_key_mode(mock_client, mock_google_genai_client):
     google_genai.Client.assert_called_once_with(api_key="test-api-key")
 
 
-def test_vertex_ai_mode_with_optional_api_key(mock_client, mock_google_genai_client, mock_gemini_response):
+def test_vertex_ai_mode_with_optional_api_key(
+    mock_client, mock_google_genai_client, mock_gemini_response
+):
     """Test Vertex AI mode with optional API key"""
     mock_google_genai_client.models.generate_content.return_value = mock_gemini_response
-    
+
     mock_credentials = MagicMock()
 
     # Create client with Vertex AI + API key
@@ -384,5 +388,5 @@ def test_vertex_ai_mode_with_optional_api_key(mock_client, mock_google_genai_cli
         vertexai=True,
         api_key="test-api-key",
         credentials=mock_credentials,
-        project="test-project"
+        project="test-project",
     )

--- a/posthog/version.py
+++ b/posthog/version.py
@@ -1,4 +1,4 @@
-VERSION = "6.3.4"
+VERSION = "6.4.0"
 
 if __name__ == "__main__":
     print(VERSION, end="")  # noqa: T201


### PR DESCRIPTION
Some users requested the ability to use Vertex AI authentication instead of requiring API keys for the Gemini client wrapper. This adds Vertex AI authentication support to the Gemini client.

## Vertex AI mode (API key optional)
```
client = Client(vertexai=True, location="location", project="my-project")
```

## Traditional mode (unchanged)
```
client = Client(api_key="your-key")
```

### Note
- [x] I'm going to bump the version whenever this is ready to be merged because there might be other PRs being merged before this one).