### PR TITLE
feat: we should capture which properties were added as tags

### DIFF
--- a/posthog/client.py
+++ b/posthog/client.py
@@ -87,6 +87,7 @@ def add_context_tags(properties):
     current_context = _get_current_context()
     if current_context:
         context_tags = current_context.collect_tags()
+        properties["$context_tags"] = set(context_tags.keys())
         # We want explicitly passed properties to override context tags
         context_tags.update(properties)
         properties = context_tags

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -13,6 +13,7 @@ from posthog.request import APIError
 from posthog.test.test_utils import FAKE_TEST_API_KEY
 from posthog.types import FeatureFlag, LegacyFlagMetadata
 from posthog.version import VERSION
+from posthog.contexts import tag
 
 
 class TestClient(unittest.TestCase):
@@ -2282,9 +2283,7 @@ class TestClient(unittest.TestCase):
                             }
                         ]
                     },
-                    "payloads": {
-                        "empty-variant": ""  # Empty string payload
-                    },
+                    "payloads": {"empty-variant": ""},  # Empty string payload
                 },
             }
         ]
@@ -2355,3 +2354,15 @@ class TestClient(unittest.TestCase):
         self.assertEqual(
             result["featureFlagPayloads"]["normal-payload-flag"], "normal payload"
         )
+
+    def test_context_tags_added(self):
+        with mock.patch("posthog.client.batch_post") as mock_post:
+            client = Client(FAKE_TEST_API_KEY, on_error=self.set_fail, sync_mode=True)
+
+            with new_context():
+                tag("random_tag", 12345)
+                client.capture("python test event", distinct_id="distinct_id")
+
+            batch_data = mock_post.call_args[1]["batch"]
+            msg = batch_data[0]
+            self.assertEqual(msg["properties"]["$context_tags"], ["random_tag"])


### PR DESCRIPTION
From this thread: https://posthog.slack.com/archives/C07AA937K9A/p1754408603339899

Thought it would be interesting. Sure we can't let you query by tags (yet, although this could be materialized or stored like prop defs) but we can use the info on an individual event basis to highlight certain properties that we know were added as tags