### PR TITLE
Fix NoneType error when group_properties is None

### DIFF
--- a/posthog/client.py
+++ b/posthog/client.py
@@ -1997,7 +1997,7 @@ class Client(object):
             for group_name in groups:
                 all_group_properties[group_name] = {
                     "$group_key": groups[group_name],
-                    **(group_properties.get(group_name) or {}),
+                    **((group_properties or {}).get(group_name) or {}),
                 }
 
         return all_person_properties, all_group_properties


### PR DESCRIPTION
## Problem
The SDK crashes with `'NoneType' object has no attribute 'get'` when `group_properties` is `None`.

## Changes
Handle `None` group_properties by defaulting to an empty dict before calling `.get()`.

Related to #306. This fixes the immediate crash issue. The broader suggestion about wrapping all SDK calls in try/except to prevent crashes is worth considering separately.