### PR TITLE
Add categories to doc specs

### DIFF
--- a/bin/docs_scripts/doc_constant.py
+++ b/bin/docs_scripts/doc_constant.py
@@ -4,49 +4,9 @@ Constants for PostHog Python SDK documentation generation.
 
 from typing import Dict, Union
 
-# Types that are built-in to Python and don't need to be documented
-NO_DOCS_TYPES = [
-    "Client",
-    "any",
-    "int",
-    "float",
-    "bool",
-    "dict",
-    "list",
-    "str",
-    "tuple",
-    "set",
-    "frozenset",
-    "bytes",
-    "bytearray",
-    "memoryview",
-    "range",
-    "slice",
-    "complex",
-    "Union",
-    "Optional",
-    "Any",
-    "Callable",
-    "Type",
-    "TypeVar",
-    "Generic",
-    "Literal",
-    "ClassVar",
-    "Final",
-    "Annotated",
-    "NotRequired",
-    "Required",
-    "None",
-    "NoneType",
-    "object",
-    "Unpack",
-    "BaseException",
-    "Exception",
-]
-
 # Documentation generation metadata
 DOCUMENTATION_METADATA = {
-    "hogRef": "0.1",
+    "hogRef": "0.2",
     "slugPrefix": "posthog-python",
     "specUrl": "https://github.com/PostHog/posthog-python",
 }

--- a/bin/docs_scripts/doc_constant.py
+++ b/bin/docs_scripts/doc_constant.py
@@ -6,7 +6,7 @@ from typing import Dict, Union
 
 # Documentation generation metadata
 DOCUMENTATION_METADATA = {
-    "hogRef": "0.2",
+    "hogRef": "0.3",
     "slugPrefix": "posthog-python",
     "specUrl": "https://github.com/PostHog/posthog-python",
 }

--- a/bin/docs_scripts/generate_json_schemas.py
+++ b/bin/docs_scripts/generate_json_schemas.py
@@ -377,6 +377,16 @@ def generate_sdk_documentation():
             except Exception as e:
                 print(f"Error analyzing type {name}: {e}")
 
+    # Clean types of empty types
+
+    # Remove types that have no properties and no examples
+    for type_info in types_list[:]:
+        has_properties = len(type_info["properties"]) > 0
+        has_example = type_info["example"] != ""
+
+        if not (has_properties or has_example):
+            types_list.remove(type_info)
+
     # Collect classes
     classes_list = []
 
@@ -419,6 +429,19 @@ def generate_sdk_documentation():
             }
         )
 
+    # Collect categories from functions
+    categories = ["Initialization", "Identification", "Capture"]
+    for class_info in classes_list:
+        if "functions" in class_info:
+            for func in class_info["functions"]:
+                # I know this is O(n^2) but we're dealing with a script at known finite limits :)
+                if (
+                    "category" in func
+                    and func["category"] not in categories
+                    and func["category"]
+                ):
+                    categories.append(func["category"])
+
     # Create the final structure
     result = {
         "id": "posthog-python",
@@ -426,6 +449,7 @@ def generate_sdk_documentation():
         "info": sdk_info,
         "types": types_list,
         "classes": classes_list,
+        "categories": categories,
     }
 
     return result

--- a/bin/docs_scripts/generate_json_schemas.py
+++ b/bin/docs_scripts/generate_json_schemas.py
@@ -381,7 +381,9 @@ def generate_sdk_documentation():
 
     # Remove types that have no properties and no examples
     # Remove types that have no properties and no examples
-    types_list = [t for t in types_list if len(t['properties']) > 0 or t['example'] != '']
+    types_list = [
+        t for t in types_list if len(t["properties"]) > 0 or t["example"] != ""
+    ]
 
     # Collect classes
     classes_list = []
@@ -427,16 +429,17 @@ def generate_sdk_documentation():
 
     # Collect categories from functions
     categories = ["Initialization", "Identification", "Capture"]
+    seen_categories = set(categories)
     for class_info in classes_list:
         if "functions" in class_info:
             for func in class_info["functions"]:
-                # I know this is O(n^2) but we're dealing with a script at known finite limits :)
                 if (
                     "category" in func
-                    and func["category"] not in categories
+                    and func["category"] not in seen_categories
                     and func["category"]
                 ):
                     categories.append(func["category"])
+                    seen_categories.add(func["category"])
 
     # Create the final structure
     result = {

--- a/bin/docs_scripts/generate_json_schemas.py
+++ b/bin/docs_scripts/generate_json_schemas.py
@@ -380,12 +380,8 @@ def generate_sdk_documentation():
     # Clean types of empty types
 
     # Remove types that have no properties and no examples
-    for type_info in types_list[:]:
-        has_properties = len(type_info["properties"]) > 0
-        has_example = type_info["example"] != ""
-
-        if not (has_properties or has_example):
-            types_list.remove(type_info)
+    # Remove types that have no properties and no examples
+    types_list = [t for t in types_list if len(t['properties']) > 0 or t['example'] != '']
 
     # Collect classes
     classes_list = []

--- a/bin/docs_scripts/generate_json_schemas.py
+++ b/bin/docs_scripts/generate_json_schemas.py
@@ -457,12 +457,6 @@ if __name__ == "__main__":
         print(f"   • {classes_count} classes documented")
         print(f"   • {total_functions} functions documented")
 
-        no_docs = documentation["noDocsTypes"]
-        if no_docs:
-            print(
-                f"   • {len(no_docs)} types without documentation: {', '.join(no_docs[:5])}{'...' if len(no_docs) > 5 else ''}"
-            )
-
     except Exception as e:
         print(f"❌ Error generating documentation: {e}")
         import traceback

--- a/bin/docs_scripts/generate_json_schemas.py
+++ b/bin/docs_scripts/generate_json_schemas.py
@@ -11,7 +11,6 @@ from dataclasses import is_dataclass, fields
 from typing import get_origin, get_args, Union
 from textwrap import dedent
 from doc_constant import (
-    NO_DOCS_TYPES,
     DOCUMENTATION_METADATA,
     DOCSTRING_PATTERNS,
     OUTPUT_CONFIG,
@@ -187,7 +186,7 @@ def analyze_parameter(param: inspect.Parameter, docstring: str = "") -> dict:
         param_type = get_type_name(type(param.default))
 
     # Extract parameter description from Args section
-    param_description = f"Parameter: {param.name}"
+    param_description = ""
     if docstring:
         # Look for Args section and extract description for this parameter
         args_section_match = re.search(
@@ -425,7 +424,6 @@ def generate_sdk_documentation():
         "id": "posthog-python",
         "hogRef": DOCUMENTATION_METADATA["hogRef"],
         "info": sdk_info,
-        "noDocsTypes": NO_DOCS_TYPES,
         "types": types_list,
         "classes": classes_list,
     }

--- a/posthog/ai/anthropic/anthropic.py
+++ b/posthog/ai/anthropic/anthropic.py
@@ -8,7 +8,7 @@ except ImportError:
 
 import time
 import uuid
-from typing import Any, Dict, Optional, cast
+from typing import Any, Dict, Optional
 
 from posthog.ai.utils import (
     call_llm_and_track_usage,

--- a/posthog/ai/openai/openai_async.py
+++ b/posthog/ai/openai/openai_async.py
@@ -1,6 +1,6 @@
 import time
 import uuid
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Dict, List, Optional
 
 try:
     import openai

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -329,7 +329,7 @@ class Client(object):
                 only these flags will be evaluated, improving performance.
 
         Category:
-            Feature Flags
+            Feature flags
         """
         resp_data = self.get_flags_decision(
             distinct_id,
@@ -368,7 +368,7 @@ class Client(object):
             ```
 
         Category:
-            Feature Flags
+            Feature flags
         """
         resp_data = self.get_flags_decision(
             distinct_id,
@@ -407,7 +407,7 @@ class Client(object):
             ```
 
         Category:
-            Feature Flags
+            Feature flags
         """
         resp = self.get_flags_decision(
             distinct_id,
@@ -446,7 +446,7 @@ class Client(object):
             ```
 
         Category:
-            Feature Flags
+            Feature flags
         """
         groups = groups or {}
         person_properties = person_properties or {}
@@ -1169,7 +1169,7 @@ class Client(object):
             ```
 
         Category:
-            Feature Flags
+            Feature flags
         """
         if not self.personal_api_key:
             self.log.warning(
@@ -1291,7 +1291,7 @@ class Client(object):
             ```
 
         Category:
-            Feature Flags
+            Feature flags
         """
         response = self.get_feature_flag(
             key,
@@ -1499,7 +1499,7 @@ class Client(object):
             ```
 
         Category:
-            Feature Flags
+            Feature flags
         """
         feature_flag_result = self.get_feature_flag_result(
             key,
@@ -1589,7 +1589,7 @@ class Client(object):
             ```
 
         Category:
-            Feature Flags
+            Feature flags
         """
         feature_flag_result = self._get_feature_flag_result(
             key,
@@ -1759,7 +1759,7 @@ class Client(object):
             ```
 
         Category:
-            Feature Flags
+            Feature flags
         """
         response = self.get_all_flags_and_payloads(
             distinct_id,
@@ -1803,7 +1803,7 @@ class Client(object):
             ```
 
         Category:
-            Feature Flags
+            Feature flags
         """
         if self.disabled:
             return {"featureFlags": None, "featureFlagPayloads": None}


### PR DESCRIPTION
To unlock category filters in reference docs. This lets us link to references per product. The UI here isn't final.

https://github.com/user-attachments/assets/422b02f7-cf6a-40fb-b205-60b2010fb27e

Also fixes a small bug where we're showing empty types