### PR TITLE
fix: Prevent core Client methods from raising exceptions

### DIFF
--- a/posthog/test/test_module.py
+++ b/posthog/test/test_module.py
@@ -18,14 +18,6 @@ class TestModule(unittest.TestCase):
             "testsecret", host="http://localhost:8000", on_error=self.failed
         )
 
-    def test_no_api_key(self):
-        self.posthog.api_key = None
-        self.assertRaises(Exception, self.posthog.capture)
-
-    def test_no_host(self):
-        self.posthog.host = None
-        self.assertRaises(Exception, self.posthog.capture)
-
     def test_track(self):
         res = self.posthog.capture("python module event", distinct_id="distinct_id")
         self._assert_enqueue_result(res)


### PR DESCRIPTION
The goal is to ensure that our client doesn't cause a panic in an end-user application. This change updates
capture/set/set_once/group_identify/alias to swallow and log any exceptions that occur. Note that this won't prevent errors from propagating via the `on_error` callback if an error occurs while processing the queue.

Other methods like feature flags are documented to raise exceptions:
https://posthog.com/docs/libraries/python#error-handling

Resolves [#36982](https://github.com/PostHog/posthog/issues/36982)