### PR TITLE
fix: remove deprecated attribute  from exception events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 6.7.7 - 2025-10-14
+
+- fix: remove deprecated attribute $exception_personURL from exception events
+
 # 6.7.6 - 2025-09-16
 
 - fix: don't sort condition sets with variant overrides to the top

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -973,7 +973,6 @@ class Client(object):
                     "value"
                 ),
                 "$exception_list": all_exceptions_with_trace_and_in_app,
-                "$exception_personURL": f"{remove_trailing_slash(self.raw_host)}/project/{self.api_key}/person/{distinct_id}",
                 **properties,
             }
 

--- a/posthog/version.py
+++ b/posthog/version.py
@@ -1,4 +1,4 @@
-VERSION = "6.7.6"
+VERSION = "6.7.7"
 
 if __name__ == "__main__":
     print(VERSION, end="")  # noqa: T201


### PR DESCRIPTION
follow up https://github.com/PostHog/posthog-js/pull/2431