### PR TITLE
Fix openai async missing await

### DIFF
--- a/posthog/ai/openai/openai_async.py
+++ b/posthog/ai/openai/openai_async.py
@@ -345,7 +345,7 @@ class WrappedCompletions:
         if "stream_options" not in kwargs:
             kwargs["stream_options"] = {}
         kwargs["stream_options"]["include_usage"] = True
-        response = self._original.create(**kwargs)
+        response = await self._original.create(**kwargs)
 
         async def async_generator():
             nonlocal usage_stats


### PR DESCRIPTION
Fix openai async missing await causing error: 
```
File "/usr/local/lib/python3.12/site-packages/posthog/ai/openai/openai_async.py", line 356, in async_generator
async for chunk in response:
                   ^^^^^^^^
TypeError: 'async for' requires an object with __aiter__ method, got coroutine
```