### PR TITLE
Run SDK generation after release job

### DIFF
--- a/.github/workflows/generate-references.yaml
+++ b/.github/workflows/generate-references.yaml
@@ -1,10 +1,6 @@
 name: "Generate References"
 
 on:
-  workflow_run:
-    workflows: ["Release"]
-    types:
-      - completed
   workflow_dispatch:
 
 jobs:
@@ -45,7 +41,7 @@ jobs:
             echo "No new references generated in references directory"
           fi
 
-      - uses: stefanzweifel/git-auto-commit-action@b3e3f72439fc3af08948f989a19a825463598a
+      - uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0
         if: steps.changes.outputs.changed == 'true'
         with:
           commit_message: "Update generated references"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,3 +49,9 @@ jobs:
         with:
           tag_name: v${{ env.REPO_VERSION }}
           release_name: ${{ env.REPO_VERSION }}
+      
+      - name: Dispatch generate-references for posthog-python
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run generate-references.yml --ref master


### PR DESCRIPTION
Helloooo!

The trigger for `published` doesn't work because of how we release. Instead we can just run following `workflows: ["Release"]`.

Similar approach in https://github.com/PostHog/posthog-js/actions/workflows/generate-references.yml