### PR TITLE
fix: Fix get_feature_flag_payload return type annotation

### DIFF
--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -581,7 +581,7 @@ def get_feature_flag_payload(
     only_evaluate_locally=False,
     send_feature_flag_events=True,
     disable_geoip=None,  # type: Optional[bool]
-) -> Optional[str]:
+) -> Optional[FeatureFlagResult]:
     return _proxy(
         "get_feature_flag_payload",
         key=key,


### PR DESCRIPTION
PR #227 updated the return type of method `get_feature_flag_payload`, but it didn't update the `__init__.py` file.

## Changes

Update return type from Optional[str] to Optional[FeatureFlagResult] to match the actual return value from the underlying implementation.

