### PR TITLE
fix: avoid overwriting consumer list when using more than one consumer

### DIFF
--- a/posthog/client.py
+++ b/posthog/client.py
@@ -295,8 +295,9 @@ class Client(object):
             # to call flush().
             if send:
                 atexit.register(self.join)
-            for n in range(thread):
-                self.consumers = []
+
+            self.consumers = []
+            for _ in range(thread):
                 consumer = Consumer(
                     self.queue,
                     self.api_key,


### PR DESCRIPTION
When using more than one thread, the SDK would erroneously overwrite the list of consumers while starting them.