### PR TITLE
Publish to PyPI using Trusted Publisher

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     steps:
       - name: Checkout the repository
         uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2
@@ -40,7 +41,6 @@ jobs:
       - name: Push releases to PyPI
         env:
           TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: uv run make release && uv run make release_analytics
 
       - name: Create GitHub release


### PR DESCRIPTION
Twine [supports Trusted Publisher](https://github.com/pypa/twine/pull/1194/), but their documentation is a bit sparse.

I'm still waiting on gaining access to PyPI so that I can configure Trusted Publisher.