### PR TITLE
chore: add SDK version support table to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Please see the [Python integration docs](https://posthog.com/docs/integrations/p
 
 | SDK Version | Python Versions Supported | Notes |
 |-------------|---------------------------|-------|
-| 7.4.3+      | 3.10, 3.11, 3.12, 3.13, 3.14 | Added Python 3.14 support |
-| 7.0.0 - 7.4.2 | 3.10, 3.11, 3.12, 3.13  | Dropped Python 3.9 support |
+| 7.3.1+      | 3.10, 3.11, 3.12, 3.13, 3.14 | Added Python 3.14 support |
+| 7.0.0 - 7.0.1 | 3.10, 3.11, 3.12, 3.13  | Dropped Python 3.9 support |
 | 4.0.1 - 6.x | 3.9, 3.10, 3.11, 3.12, 3.13 | Python 3.9+ required |
 
 ## Development


### PR DESCRIPTION
in https://github.com/PostHog/posthog-python/pull/361 the user is testing 3.14 support with version 6.x of the library 
but 3.14 support was introduced later

let's clarify support in the readme