### PR TITLE
Fix feature flag 401 errors causing HTTP request storm

### DIFF
--- a/posthog/client.py
+++ b/posthog/client.py
@@ -1336,6 +1336,12 @@ class Client(object):
                     "[FEATURE FLAGS] Error loading feature flags: To use feature flags, please set a valid personal_api_key. More information: https://posthog.com/docs/api/overview"
                 )
                 self.feature_flags = []
+                self.group_type_mapping = {}
+                self.cohorts = {}
+
+                if self.flag_cache:
+                    self.flag_cache.clear()
+
                 if self.debug:
                     raise APIError(
                         status=401,

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -489,6 +489,8 @@ class TestClient(unittest.TestCase):
 
             self.assertEqual(client.feature_flags, [])
             self.assertEqual(client.feature_flags_by_key, {})
+            self.assertEqual(client.group_type_mapping, {})
+            self.assertEqual(client.cohorts, {})
             self.assertIn("please set a valid personal_api_key", logs.output[0])
 
     @mock.patch("posthog.client.flags")


### PR DESCRIPTION
## Summary
- Set `feature_flags = []` on 401 error to prevent repeated HTTP requests
- Matches existing behavior for 402 errors

Fixes #421