### PR TITLE
feat: further optimize code variables regex search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 7.8.3 - 2026-02-09
+# 7.8.5 - 2026-02-09
+
+fix: further optimize code variables pattern matching
+
+# 7.8.4 - 2026-02-09
 
 fix: do not pattern match long values in code variables
 

--- a/posthog/exception_utils.py
+++ b/posthog/exception_utils.py
@@ -938,7 +938,7 @@ def _extract_plain_substring(pattern):
     inline_flags = re.match(r"^\(\?[aiLmsux]*i[aiLmsux]*\)", pattern)
     if not inline_flags:
         return None
-    remainder = pattern[inline_flags.end():]
+    remainder = pattern[inline_flags.end() :]
     if not remainder or any(c in _REGEX_METACHARACTERS for c in remainder):
         return None
     return remainder.lower()

--- a/posthog/test/test_exception_capture.py
+++ b/posthog/test/test_exception_capture.py
@@ -617,12 +617,14 @@ def test_compile_patterns_fast_path_and_regex_fallback():
     assert _pattern_matches("normal_var", complex_only) is False
 
     # Mixed: simple substrings + complex regexes together
-    mixed = _compile_patterns([
-        r"(?i)secret",       # simple
-        r"(?i)api_key",      # simple
-        r"^__.*",            # regex
-        r"\btoken_\w+",     # regex
-    ])
+    mixed = _compile_patterns(
+        [
+            r"(?i)secret",  # simple
+            r"(?i)api_key",  # simple
+            r"^__.*",  # regex
+            r"\btoken_\w+",  # regex
+        ]
+    )
     substrings, regexes = mixed
     assert substrings == ["secret", "api_key"]
     assert len(regexes) == 2

--- a/posthog/version.py
+++ b/posthog/version.py
@@ -1,4 +1,4 @@
-VERSION = "7.8.4"
+VERSION = "7.8.5"
 
 if __name__ == "__main__":
     print(VERSION, end="")  # noqa: T201


### PR DESCRIPTION
Our python SDK does code variables capture in error tracking. We have 15 default regex case insensitive matches for redacting some variables like `password`, `api_key`, etc...

As it turns out, regex is extremely slow compared to `substring in string`.

This PR optimizes case insensitive regexes into simple substring matching which is substantially faster.