### PR TITLE
chore: release v7.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 7.9.0 - 2026-02-17
+
+feat: Support device_id as bucketing identifier for local evaluation
+
 # 7.8.6 - 2026-02-09
 
 fix: limit collections scanning in code variables

--- a/posthog/version.py
+++ b/posthog/version.py
@@ -1,4 +1,4 @@
-VERSION = "7.8.6"
+VERSION = "7.9.0"
 
 if __name__ == "__main__":
     print(VERSION, end="")  # noqa: T201


### PR DESCRIPTION
## Summary
- Bump version to 7.9.0
- Update CHANGELOG.md

### Changes in this release
- **feat:** Support device_id as bucketing identifier for local evaluation (#424)
- **test:** Make wrong-key load_feature_flags deterministic (#432)
