### PR TITLE
fix: revert manual release and add sampo changeset for ai_tokens_source

### DIFF
--- a/.sampo/changesets/ai-tokens-source.md
+++ b/.sampo/changesets/ai-tokens-source.md
@@ -1,0 +1,5 @@
+---
+"posthog": patch
+---
+
+feat(llma): add `$ai_tokens_source` property ("sdk" or "passthrough") to all `$ai_generation` events to detect when token values are externally overridden via `posthog_properties`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # posthog
 
-## 7.9.4 — 2026-02-25
-
-feat(llma): add `$ai_tokens_source` property ("sdk" or "passthrough") to all `$ai_generation` events to detect when token values are externally overridden via `posthog_properties`
-
 ## 7.9.3 — 2026-02-18
 
 ### Patch changes

--- a/posthog/version.py
+++ b/posthog/version.py
@@ -1,1 +1,1 @@
-VERSION = "7.9.4"
+VERSION = "7.9.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "posthog"
-version = "7.9.4"
+version = "7.9.3"
 description = "Integrate PostHog into any python application."
 authors = [{ name = "PostHog", email = "hey@posthog.com" }]
 maintainers = [{ name = "PostHog", email = "hey@posthog.com" }]


### PR DESCRIPTION
PR #444 was merged using the old release process. This reverts the manual version bump and changelog entry, and adds a Sampo changeset so it can be released properly.