### PR TITLE
chore(ci): fix release attribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,20 +184,14 @@ jobs:
           NEW_VERSION: ${{ steps.sampo-release.outputs.new_version }}
           COMMIT_HASH: ${{ steps.commit-release.outputs.commit-hash }}
         run: |
-          TAG_SHA=$(gh api "repos/${{ github.repository }}/git/tags" \
-            -f "tag=v${NEW_VERSION}" \
-            -f "message=Release v${NEW_VERSION}" \
-            -f "object=${COMMIT_HASH}" \
-            -f "type=commit" \
-            -q '.sha')
           gh api "repos/${{ github.repository }}/git/refs" \
             -f "ref=refs/tags/v${NEW_VERSION}" \
-            -f "sha=${TAG_SHA}"
+            -f "sha=${COMMIT_HASH}"
 
       - name: Create GitHub Release
         if: steps.commit-release.outputs.commit-hash != ''
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.releaser.outputs.token }}
           NEW_VERSION: ${{ steps.sampo-release.outputs.new_version }}
         run: gh release create "v$NEW_VERSION" --generate-notes
 

--- a/.sampo/changesets/roguish-king-akka.md
+++ b/.sampo/changesets/roguish-king-akka.md
@@ -1,0 +1,5 @@
+---
+pypi/posthog: patch
+---
+
+chore(ci): fix release attribution


### PR DESCRIPTION
The release should now be attributed to the GitHub App that's used, rather than github-actions. But for real this time.