### PR TITLE
chore: pin litellm to 1.81.13 in example

### DIFF
--- a/examples/example-ai-litellm/requirements.txt
+++ b/examples/example-ai-litellm/requirements.txt
@@ -1,2 +1,2 @@
 posthog>=6.6.1
-litellm
+litellm==1.81.13


### PR DESCRIPTION
## Problem

The litellm example had an unpinned `litellm` dependency which could pull in malicious versions. See https://github.com/BerriAI/litellm/issues/24512.

## Changes

Pin `litellm` to `1.81.13` in `examples/example-ai-litellm/requirements.txt` to avoid pulling in a broken release.