### PR TITLE
feat(ai): add OpenTelemetry integration for AI span export

### DIFF
--- a/posthog/ai/otel/__init__.py
+++ b/posthog/ai/otel/__init__.py
@@ -1,0 +1,33 @@
+"""PostHog OpenTelemetry integration for AI tracing.
+
+Provides components to route AI-related OpenTelemetry spans to PostHog's
+OTLP endpoint. Only spans matching known AI semantic convention prefixes
+(gen_ai, llm, ai, traceloop) are forwarded; all other spans are silently
+dropped.
+
+Two integration patterns are supported:
+
+1. **PostHogSpanProcessor** (recommended) - Self-contained processor that
+   handles batching and export internally::
+
+       provider = TracerProvider()
+       provider.add_span_processor(
+           PostHogSpanProcessor(api_key="phc_...")
+       )
+
+2. **PostHogTraceExporter** - Exporter for use with your own
+   BatchSpanProcessor or frameworks that only accept a SpanExporter::
+
+       provider = TracerProvider()
+       provider.add_span_processor(
+           BatchSpanProcessor(
+               PostHogTraceExporter(api_key="phc_...")
+           )
+       )
+"""
+
+from posthog.ai.otel.exporter import PostHogTraceExporter
+from posthog.ai.otel.processor import PostHogSpanProcessor
+from posthog.ai.otel.spans import is_ai_span
+
+__all__ = ["PostHogSpanProcessor", "PostHogTraceExporter", "is_ai_span"]

--- a/posthog/ai/otel/exporter.py
+++ b/posthog/ai/otel/exporter.py
@@ -11,9 +11,7 @@ from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 
-from .spans import is_ai_span
-
-DEFAULT_HOST = "https://us.i.posthog.com"
+from .spans import DEFAULT_HOST, is_ai_span
 
 
 class PostHogTraceExporter(SpanExporter):

--- a/posthog/ai/otel/exporter.py
+++ b/posthog/ai/otel/exporter.py
@@ -50,7 +50,7 @@ class PostHogTraceExporter(SpanExporter):
         self._host = host.rstrip("/")
 
         self._exporter = OTLPSpanExporter(
-            endpoint=f"{self._host}/v1/traces",
+            endpoint=f"{self._host}/i/v0/ai/otel",
             headers={"Authorization": f"Bearer {self._api_key}"},
         )
 

--- a/posthog/ai/otel/exporter.py
+++ b/posthog/ai/otel/exporter.py
@@ -1,0 +1,69 @@
+"""PostHog trace exporter for OpenTelemetry.
+
+Provides a SpanExporter that filters AI-related spans before forwarding them
+to PostHog's OTLP endpoint. Use this when your setup only accepts a
+SpanExporter (e.g. as an argument to BatchSpanProcessor).
+"""
+
+from typing import Optional, Sequence
+
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+
+from .spans import is_ai_span
+
+DEFAULT_HOST = "https://us.i.posthog.com"
+
+
+class PostHogTraceExporter(SpanExporter):
+    """Span exporter that filters AI spans and forwards them to PostHog.
+
+    Wraps an OTLPSpanExporter configured for PostHog's OTLP endpoint. Spans
+    that are not AI-related are silently dropped, returning SUCCESS immediately.
+
+    Usage::
+
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+        from posthog.ai.otel import PostHogTraceExporter
+
+        provider = TracerProvider()
+        provider.add_span_processor(
+            BatchSpanProcessor(
+                PostHogTraceExporter(api_key="phc_...")
+            )
+        )
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        host: str = DEFAULT_HOST,
+    ):
+        """
+        Args:
+            api_key: PostHog project API key.
+            host: PostHog host URL. Defaults to US cloud.
+        """
+        self._api_key = api_key
+        self._host = host.rstrip("/")
+
+        self._exporter = OTLPSpanExporter(
+            endpoint=f"{self._host}/v1/traces",
+            headers={"Authorization": f"Bearer {self._api_key}"},
+        )
+
+    def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
+        ai_spans = [span for span in spans if is_ai_span(span)]
+        if not ai_spans:
+            return SpanExportResult.SUCCESS
+        return self._exporter.export(ai_spans)
+
+    def shutdown(self) -> None:
+        self._exporter.shutdown()
+
+    def force_flush(self, timeout_millis: Optional[int] = None) -> bool:
+        if timeout_millis is not None:
+            return self._exporter.force_flush(timeout_millis)
+        return self._exporter.force_flush()

--- a/posthog/ai/otel/processor.py
+++ b/posthog/ai/otel/processor.py
@@ -12,9 +12,7 @@ from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 
-from .spans import is_ai_span
-
-DEFAULT_HOST = "https://us.i.posthog.com"
+from .spans import DEFAULT_HOST, is_ai_span
 
 
 class PostHogSpanProcessor(SpanProcessor):

--- a/posthog/ai/otel/processor.py
+++ b/posthog/ai/otel/processor.py
@@ -49,7 +49,7 @@ class PostHogSpanProcessor(SpanProcessor):
         self._host = host.rstrip("/")
 
         exporter = OTLPSpanExporter(
-            endpoint=f"{self._host}/v1/traces",
+            endpoint=f"{self._host}/i/v0/ai/otel",
             headers={"Authorization": f"Bearer {self._api_key}"},
         )
         self._processor = BatchSpanProcessor(exporter)

--- a/posthog/ai/otel/processor.py
+++ b/posthog/ai/otel/processor.py
@@ -1,0 +1,71 @@
+"""PostHog span processor for OpenTelemetry.
+
+Provides a self-contained SpanProcessor that filters AI-related spans and
+exports them to PostHog's OTLP endpoint. This is the recommended integration
+for setups using TracerProvider.add_span_processor().
+"""
+
+from typing import Optional
+
+from opentelemetry.context import Context
+from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+
+from .spans import is_ai_span
+
+DEFAULT_HOST = "https://us.i.posthog.com"
+
+
+class PostHogSpanProcessor(SpanProcessor):
+    """Span processor that filters AI spans and exports them to PostHog.
+
+    Wraps a BatchSpanProcessor and OTLPSpanExporter internally, configured
+    to send to PostHog's OTLP traces endpoint. Only spans identified as
+    AI-related (by name or attribute prefix) are forwarded for export.
+
+    Usage::
+
+        from opentelemetry.sdk.trace import TracerProvider
+        from posthog.ai.otel import PostHogSpanProcessor
+
+        provider = TracerProvider()
+        provider.add_span_processor(
+            PostHogSpanProcessor(api_key="phc_...")
+        )
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        host: str = DEFAULT_HOST,
+    ):
+        """
+        Args:
+            api_key: PostHog project API key.
+            host: PostHog host URL. Defaults to US cloud.
+        """
+        self._api_key = api_key
+        self._host = host.rstrip("/")
+
+        exporter = OTLPSpanExporter(
+            endpoint=f"{self._host}/v1/traces",
+            headers={"Authorization": f"Bearer {self._api_key}"},
+        )
+        self._processor = BatchSpanProcessor(exporter)
+
+    def on_start(self, span: Span, parent_context: Optional[Context] = None) -> None:
+        pass
+
+    def on_end(self, span: ReadableSpan) -> None:
+        if not is_ai_span(span):
+            return
+        self._processor.on_end(span)
+
+    def shutdown(self) -> None:
+        self._processor.shutdown()
+
+    def force_flush(self, timeout_millis: Optional[int] = None) -> bool:
+        if timeout_millis is not None:
+            return self._processor.force_flush(timeout_millis)
+        return self._processor.force_flush()

--- a/posthog/ai/otel/spans.py
+++ b/posthog/ai/otel/spans.py
@@ -1,9 +1,11 @@
-"""Shared AI span filtering logic for OpenTelemetry integration."""
+"""Shared AI span filtering logic and constants for OpenTelemetry integration."""
 
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from opentelemetry.sdk.trace import ReadableSpan
+
+DEFAULT_HOST = "https://us.i.posthog.com"
 
 AI_SPAN_PREFIXES = ("gen_ai.", "llm.", "ai.", "traceloop.")
 

--- a/posthog/ai/otel/spans.py
+++ b/posthog/ai/otel/spans.py
@@ -1,0 +1,26 @@
+"""Shared AI span filtering logic for OpenTelemetry integration."""
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from opentelemetry.sdk.trace import ReadableSpan
+
+AI_SPAN_PREFIXES = ("gen_ai.", "llm.", "ai.", "traceloop.")
+
+
+def is_ai_span(span: "ReadableSpan") -> bool:
+    """Check if a span is AI-related by examining its name and attribute keys.
+
+    Matches spans whose name or any attribute key starts with one of the
+    known AI semantic convention prefixes (gen_ai, llm, ai, traceloop).
+    """
+    name = span.name
+    if any(name.startswith(prefix) for prefix in AI_SPAN_PREFIXES):
+        return True
+
+    attributes = span.attributes or {}
+    for key in attributes:
+        if any(key.startswith(prefix) for prefix in AI_SPAN_PREFIXES):
+            return True
+
+    return False

--- a/posthog/test/ai/otel/conftest.py
+++ b/posthog/test/ai/otel/conftest.py
@@ -1,0 +1,8 @@
+from unittest.mock import MagicMock
+
+
+def make_span(name: str = "test", attributes: dict | None = None) -> MagicMock:
+    span = MagicMock()
+    span.name = name
+    span.attributes = attributes or {}
+    return span

--- a/posthog/test/ai/otel/test_exporter.py
+++ b/posthog/test/ai/otel/test_exporter.py
@@ -18,7 +18,7 @@ class TestPostHogTraceExporter(unittest.TestCase):
     def test_configures_exporter_with_correct_endpoint(self, mock_otlp_cls):
         PostHogTraceExporter(api_key="phc_test123")
         mock_otlp_cls.assert_called_once_with(
-            endpoint="https://us.i.posthog.com/v1/traces",
+            endpoint="https://us.i.posthog.com/i/v0/ai/otel",
             headers={"Authorization": "Bearer phc_test123"},
         )
 
@@ -26,7 +26,7 @@ class TestPostHogTraceExporter(unittest.TestCase):
     def test_configures_custom_host(self, mock_otlp_cls):
         PostHogTraceExporter(api_key="phc_test", host="https://eu.i.posthog.com")
         mock_otlp_cls.assert_called_once_with(
-            endpoint="https://eu.i.posthog.com/v1/traces",
+            endpoint="https://eu.i.posthog.com/i/v0/ai/otel",
             headers={"Authorization": "Bearer phc_test"},
         )
 

--- a/posthog/test/ai/otel/test_exporter.py
+++ b/posthog/test/ai/otel/test_exporter.py
@@ -1,16 +1,10 @@
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from opentelemetry.sdk.trace.export import SpanExportResult
 
 from posthog.ai.otel.exporter import PostHogTraceExporter
-
-
-def _make_span(name: str = "test", attributes: dict | None = None) -> MagicMock:
-    span = MagicMock()
-    span.name = name
-    span.attributes = attributes or {}
-    return span
+from posthog.test.ai.otel.conftest import make_span
 
 
 class TestPostHogTraceExporter(unittest.TestCase):
@@ -36,7 +30,7 @@ class TestPostHogTraceExporter(unittest.TestCase):
         inner = mock_otlp_cls.return_value
         inner.export.return_value = SpanExportResult.SUCCESS
 
-        spans = [_make_span("gen_ai.chat"), _make_span("llm.call")]
+        spans = [make_span("gen_ai.chat"), make_span("llm.call")]
         result = exporter.export(spans)
 
         self.assertEqual(result, SpanExportResult.SUCCESS)
@@ -48,8 +42,8 @@ class TestPostHogTraceExporter(unittest.TestCase):
         inner = mock_otlp_cls.return_value
         inner.export.return_value = SpanExportResult.SUCCESS
 
-        ai_span = _make_span("gen_ai.chat")
-        http_span = _make_span("http.request")
+        ai_span = make_span("gen_ai.chat")
+        http_span = make_span("http.request")
         result = exporter.export([ai_span, http_span])
 
         self.assertEqual(result, SpanExportResult.SUCCESS)
@@ -60,7 +54,7 @@ class TestPostHogTraceExporter(unittest.TestCase):
         exporter = PostHogTraceExporter(api_key="phc_test")
         inner = mock_otlp_cls.return_value
 
-        result = exporter.export([_make_span("http.request"), _make_span("db.query")])
+        result = exporter.export([make_span("http.request"), make_span("db.query")])
 
         self.assertEqual(result, SpanExportResult.SUCCESS)
         inner.export.assert_not_called()
@@ -81,7 +75,7 @@ class TestPostHogTraceExporter(unittest.TestCase):
         inner = mock_otlp_cls.return_value
         inner.export.return_value = SpanExportResult.SUCCESS
 
-        span = _make_span("http.request", {"gen_ai.system": "openai"})
+        span = make_span("http.request", {"gen_ai.system": "openai"})
         result = exporter.export([span])
 
         self.assertEqual(result, SpanExportResult.SUCCESS)

--- a/posthog/test/ai/otel/test_exporter.py
+++ b/posthog/test/ai/otel/test_exporter.py
@@ -1,0 +1,104 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from opentelemetry.sdk.trace.export import SpanExportResult
+
+from posthog.ai.otel.exporter import PostHogTraceExporter
+
+
+def _make_span(name: str = "test", attributes: dict | None = None) -> MagicMock:
+    span = MagicMock()
+    span.name = name
+    span.attributes = attributes or {}
+    return span
+
+
+class TestPostHogTraceExporter(unittest.TestCase):
+    @patch("posthog.ai.otel.exporter.OTLPSpanExporter")
+    def test_configures_exporter_with_correct_endpoint(self, mock_otlp_cls):
+        PostHogTraceExporter(api_key="phc_test123")
+        mock_otlp_cls.assert_called_once_with(
+            endpoint="https://us.i.posthog.com/v1/traces",
+            headers={"Authorization": "Bearer phc_test123"},
+        )
+
+    @patch("posthog.ai.otel.exporter.OTLPSpanExporter")
+    def test_configures_custom_host(self, mock_otlp_cls):
+        PostHogTraceExporter(api_key="phc_test", host="https://eu.i.posthog.com")
+        mock_otlp_cls.assert_called_once_with(
+            endpoint="https://eu.i.posthog.com/v1/traces",
+            headers={"Authorization": "Bearer phc_test"},
+        )
+
+    @patch("posthog.ai.otel.exporter.OTLPSpanExporter")
+    def test_exports_ai_spans(self, mock_otlp_cls):
+        exporter = PostHogTraceExporter(api_key="phc_test")
+        inner = mock_otlp_cls.return_value
+        inner.export.return_value = SpanExportResult.SUCCESS
+
+        spans = [_make_span("gen_ai.chat"), _make_span("llm.call")]
+        result = exporter.export(spans)
+
+        self.assertEqual(result, SpanExportResult.SUCCESS)
+        inner.export.assert_called_once_with(spans)
+
+    @patch("posthog.ai.otel.exporter.OTLPSpanExporter")
+    def test_filters_out_non_ai_spans(self, mock_otlp_cls):
+        exporter = PostHogTraceExporter(api_key="phc_test")
+        inner = mock_otlp_cls.return_value
+        inner.export.return_value = SpanExportResult.SUCCESS
+
+        ai_span = _make_span("gen_ai.chat")
+        http_span = _make_span("http.request")
+        result = exporter.export([ai_span, http_span])
+
+        self.assertEqual(result, SpanExportResult.SUCCESS)
+        inner.export.assert_called_once_with([ai_span])
+
+    @patch("posthog.ai.otel.exporter.OTLPSpanExporter")
+    def test_returns_success_when_no_ai_spans(self, mock_otlp_cls):
+        exporter = PostHogTraceExporter(api_key="phc_test")
+        inner = mock_otlp_cls.return_value
+
+        result = exporter.export([_make_span("http.request"), _make_span("db.query")])
+
+        self.assertEqual(result, SpanExportResult.SUCCESS)
+        inner.export.assert_not_called()
+
+    @patch("posthog.ai.otel.exporter.OTLPSpanExporter")
+    def test_returns_success_for_empty_batch(self, mock_otlp_cls):
+        exporter = PostHogTraceExporter(api_key="phc_test")
+        inner = mock_otlp_cls.return_value
+
+        result = exporter.export([])
+
+        self.assertEqual(result, SpanExportResult.SUCCESS)
+        inner.export.assert_not_called()
+
+    @patch("posthog.ai.otel.exporter.OTLPSpanExporter")
+    def test_exports_spans_with_ai_attributes(self, mock_otlp_cls):
+        exporter = PostHogTraceExporter(api_key="phc_test")
+        inner = mock_otlp_cls.return_value
+        inner.export.return_value = SpanExportResult.SUCCESS
+
+        span = _make_span("http.request", {"gen_ai.system": "openai"})
+        result = exporter.export([span])
+
+        self.assertEqual(result, SpanExportResult.SUCCESS)
+        inner.export.assert_called_once_with([span])
+
+    @patch("posthog.ai.otel.exporter.OTLPSpanExporter")
+    def test_shutdown_delegates(self, mock_otlp_cls):
+        exporter = PostHogTraceExporter(api_key="phc_test")
+        inner = mock_otlp_cls.return_value
+
+        exporter.shutdown()
+        inner.shutdown.assert_called_once()
+
+    @patch("posthog.ai.otel.exporter.OTLPSpanExporter")
+    def test_force_flush_delegates(self, mock_otlp_cls):
+        exporter = PostHogTraceExporter(api_key="phc_test")
+        inner = mock_otlp_cls.return_value
+
+        exporter.force_flush(timeout_millis=5000)
+        inner.force_flush.assert_called_once_with(5000)

--- a/posthog/test/ai/otel/test_processor.py
+++ b/posthog/test/ai/otel/test_processor.py
@@ -2,13 +2,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from posthog.ai.otel.processor import PostHogSpanProcessor
-
-
-def _make_span(name: str = "test", attributes: dict | None = None) -> MagicMock:
-    span = MagicMock()
-    span.name = name
-    span.attributes = attributes or {}
-    return span
+from posthog.test.ai.otel.conftest import make_span
 
 
 class TestPostHogSpanProcessor(unittest.TestCase):
@@ -48,7 +42,7 @@ class TestPostHogSpanProcessor(unittest.TestCase):
         processor = PostHogSpanProcessor(api_key="phc_test")
         inner = mock_batch_cls.return_value
 
-        ai_span = _make_span("gen_ai.chat")
+        ai_span = make_span("gen_ai.chat")
         processor.on_end(ai_span)
         inner.on_end.assert_called_once_with(ai_span)
 
@@ -58,7 +52,7 @@ class TestPostHogSpanProcessor(unittest.TestCase):
         processor = PostHogSpanProcessor(api_key="phc_test")
         inner = mock_batch_cls.return_value
 
-        processor.on_end(_make_span("http.request"))
+        processor.on_end(make_span("http.request"))
         inner.on_end.assert_not_called()
 
     @patch("posthog.ai.otel.processor.OTLPSpanExporter")
@@ -67,7 +61,7 @@ class TestPostHogSpanProcessor(unittest.TestCase):
         processor = PostHogSpanProcessor(api_key="phc_test")
         inner = mock_batch_cls.return_value
 
-        span = _make_span("http.request", {"gen_ai.system": "openai"})
+        span = make_span("http.request", {"gen_ai.system": "openai"})
         processor.on_end(span)
         inner.on_end.assert_called_once_with(span)
 

--- a/posthog/test/ai/otel/test_processor.py
+++ b/posthog/test/ai/otel/test_processor.py
@@ -1,0 +1,108 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from posthog.ai.otel.processor import PostHogSpanProcessor
+
+
+def _make_span(name: str = "test", attributes: dict | None = None) -> MagicMock:
+    span = MagicMock()
+    span.name = name
+    span.attributes = attributes or {}
+    return span
+
+
+class TestPostHogSpanProcessor(unittest.TestCase):
+    @patch("posthog.ai.otel.processor.OTLPSpanExporter")
+    @patch("posthog.ai.otel.processor.BatchSpanProcessor")
+    def test_configures_exporter_with_correct_endpoint(
+        self, mock_batch_cls, mock_otlp_cls
+    ):
+        PostHogSpanProcessor(api_key="phc_test123")
+        mock_otlp_cls.assert_called_once_with(
+            endpoint="https://us.i.posthog.com/v1/traces",
+            headers={"Authorization": "Bearer phc_test123"},
+        )
+        mock_batch_cls.assert_called_once_with(mock_otlp_cls.return_value)
+
+    @patch("posthog.ai.otel.processor.OTLPSpanExporter")
+    @patch("posthog.ai.otel.processor.BatchSpanProcessor")
+    def test_configures_custom_host(self, mock_batch_cls, mock_otlp_cls):
+        PostHogSpanProcessor(api_key="phc_test", host="https://eu.i.posthog.com")
+        mock_otlp_cls.assert_called_once_with(
+            endpoint="https://eu.i.posthog.com/v1/traces",
+            headers={"Authorization": "Bearer phc_test"},
+        )
+
+    @patch("posthog.ai.otel.processor.OTLPSpanExporter")
+    @patch("posthog.ai.otel.processor.BatchSpanProcessor")
+    def test_strips_trailing_slash_from_host(self, mock_batch_cls, mock_otlp_cls):
+        PostHogSpanProcessor(api_key="phc_test", host="https://us.i.posthog.com/")
+        mock_otlp_cls.assert_called_once_with(
+            endpoint="https://us.i.posthog.com/v1/traces",
+            headers={"Authorization": "Bearer phc_test"},
+        )
+
+    @patch("posthog.ai.otel.processor.OTLPSpanExporter")
+    @patch("posthog.ai.otel.processor.BatchSpanProcessor")
+    def test_forwards_ai_spans(self, mock_batch_cls, mock_otlp_cls):
+        processor = PostHogSpanProcessor(api_key="phc_test")
+        inner = mock_batch_cls.return_value
+
+        ai_span = _make_span("gen_ai.chat")
+        processor.on_end(ai_span)
+        inner.on_end.assert_called_once_with(ai_span)
+
+    @patch("posthog.ai.otel.processor.OTLPSpanExporter")
+    @patch("posthog.ai.otel.processor.BatchSpanProcessor")
+    def test_drops_non_ai_spans(self, mock_batch_cls, mock_otlp_cls):
+        processor = PostHogSpanProcessor(api_key="phc_test")
+        inner = mock_batch_cls.return_value
+
+        processor.on_end(_make_span("http.request"))
+        inner.on_end.assert_not_called()
+
+    @patch("posthog.ai.otel.processor.OTLPSpanExporter")
+    @patch("posthog.ai.otel.processor.BatchSpanProcessor")
+    def test_forwards_span_with_ai_attributes(self, mock_batch_cls, mock_otlp_cls):
+        processor = PostHogSpanProcessor(api_key="phc_test")
+        inner = mock_batch_cls.return_value
+
+        span = _make_span("http.request", {"gen_ai.system": "openai"})
+        processor.on_end(span)
+        inner.on_end.assert_called_once_with(span)
+
+    @patch("posthog.ai.otel.processor.OTLPSpanExporter")
+    @patch("posthog.ai.otel.processor.BatchSpanProcessor")
+    def test_on_start_is_noop(self, mock_batch_cls, mock_otlp_cls):
+        processor = PostHogSpanProcessor(api_key="phc_test")
+        inner = mock_batch_cls.return_value
+
+        processor.on_start(MagicMock())
+        inner.on_start.assert_not_called()
+
+    @patch("posthog.ai.otel.processor.OTLPSpanExporter")
+    @patch("posthog.ai.otel.processor.BatchSpanProcessor")
+    def test_shutdown_delegates(self, mock_batch_cls, mock_otlp_cls):
+        processor = PostHogSpanProcessor(api_key="phc_test")
+        inner = mock_batch_cls.return_value
+
+        processor.shutdown()
+        inner.shutdown.assert_called_once()
+
+    @patch("posthog.ai.otel.processor.OTLPSpanExporter")
+    @patch("posthog.ai.otel.processor.BatchSpanProcessor")
+    def test_force_flush_delegates(self, mock_batch_cls, mock_otlp_cls):
+        processor = PostHogSpanProcessor(api_key="phc_test")
+        inner = mock_batch_cls.return_value
+
+        processor.force_flush(timeout_millis=5000)
+        inner.force_flush.assert_called_once_with(5000)
+
+    @patch("posthog.ai.otel.processor.OTLPSpanExporter")
+    @patch("posthog.ai.otel.processor.BatchSpanProcessor")
+    def test_force_flush_without_timeout(self, mock_batch_cls, mock_otlp_cls):
+        processor = PostHogSpanProcessor(api_key="phc_test")
+        inner = mock_batch_cls.return_value
+
+        processor.force_flush()
+        inner.force_flush.assert_called_once_with()

--- a/posthog/test/ai/otel/test_processor.py
+++ b/posthog/test/ai/otel/test_processor.py
@@ -19,7 +19,7 @@ class TestPostHogSpanProcessor(unittest.TestCase):
     ):
         PostHogSpanProcessor(api_key="phc_test123")
         mock_otlp_cls.assert_called_once_with(
-            endpoint="https://us.i.posthog.com/v1/traces",
+            endpoint="https://us.i.posthog.com/i/v0/ai/otel",
             headers={"Authorization": "Bearer phc_test123"},
         )
         mock_batch_cls.assert_called_once_with(mock_otlp_cls.return_value)
@@ -29,7 +29,7 @@ class TestPostHogSpanProcessor(unittest.TestCase):
     def test_configures_custom_host(self, mock_batch_cls, mock_otlp_cls):
         PostHogSpanProcessor(api_key="phc_test", host="https://eu.i.posthog.com")
         mock_otlp_cls.assert_called_once_with(
-            endpoint="https://eu.i.posthog.com/v1/traces",
+            endpoint="https://eu.i.posthog.com/i/v0/ai/otel",
             headers={"Authorization": "Bearer phc_test"},
         )
 
@@ -38,7 +38,7 @@ class TestPostHogSpanProcessor(unittest.TestCase):
     def test_strips_trailing_slash_from_host(self, mock_batch_cls, mock_otlp_cls):
         PostHogSpanProcessor(api_key="phc_test", host="https://us.i.posthog.com/")
         mock_otlp_cls.assert_called_once_with(
-            endpoint="https://us.i.posthog.com/v1/traces",
+            endpoint="https://us.i.posthog.com/i/v0/ai/otel",
             headers={"Authorization": "Bearer phc_test"},
         )
 

--- a/posthog/test/ai/otel/test_spans.py
+++ b/posthog/test/ai/otel/test_spans.py
@@ -1,58 +1,52 @@
 import unittest
-from unittest.mock import MagicMock
+
+from parameterized import parameterized
 
 from posthog.ai.otel.spans import is_ai_span
-
-
-def _make_span(name: str = "test", attributes: dict | None = None) -> MagicMock:
-    span = MagicMock()
-    span.name = name
-    span.attributes = attributes or {}
-    return span
+from posthog.test.ai.otel.conftest import make_span
 
 
 class TestIsAISpan(unittest.TestCase):
-    def test_matches_gen_ai_name_prefix(self):
-        self.assertTrue(is_ai_span(_make_span("gen_ai.chat")))
+    @parameterized.expand(
+        [
+            ("gen_ai", "gen_ai.chat"),
+            ("llm", "llm.call"),
+            ("ai", "ai.completion"),
+            ("traceloop", "traceloop.workflow"),
+        ]
+    )
+    def test_matches_ai_name_prefix(self, _name, span_name):
+        self.assertTrue(is_ai_span(make_span(span_name)))
 
-    def test_matches_llm_name_prefix(self):
-        self.assertTrue(is_ai_span(_make_span("llm.call")))
+    @parameterized.expand(
+        [
+            ("gen_ai", {"gen_ai.system": "openai"}),
+            ("llm", {"llm.model": "gpt-4"}),
+            ("ai", {"ai.provider": "anthropic"}),
+            ("traceloop", {"traceloop.entity.name": "chain"}),
+        ]
+    )
+    def test_matches_ai_attribute_key(self, _name, attrs):
+        self.assertTrue(is_ai_span(make_span("http.request", attrs)))
 
-    def test_matches_ai_name_prefix(self):
-        self.assertTrue(is_ai_span(_make_span("ai.completion")))
-
-    def test_matches_traceloop_name_prefix(self):
-        self.assertTrue(is_ai_span(_make_span("traceloop.workflow")))
-
-    def test_rejects_non_ai_name(self):
-        self.assertFalse(is_ai_span(_make_span("http.request")))
-        self.assertFalse(is_ai_span(_make_span("db.query")))
-        self.assertFalse(is_ai_span(_make_span("my_function")))
-
-    def test_matches_gen_ai_attribute_key(self):
-        span = _make_span("http.request", {"gen_ai.system": "openai"})
-        self.assertTrue(is_ai_span(span))
-
-    def test_matches_llm_attribute_key(self):
-        span = _make_span("http.request", {"llm.model": "gpt-4"})
-        self.assertTrue(is_ai_span(span))
-
-    def test_matches_ai_attribute_key(self):
-        span = _make_span("http.request", {"ai.provider": "anthropic"})
-        self.assertTrue(is_ai_span(span))
-
-    def test_matches_traceloop_attribute_key(self):
-        span = _make_span("http.request", {"traceloop.entity.name": "chain"})
-        self.assertTrue(is_ai_span(span))
+    @parameterized.expand(
+        [
+            ("http", "http.request"),
+            ("db", "db.query"),
+            ("custom", "my_function"),
+        ]
+    )
+    def test_rejects_non_ai_name(self, _name, span_name):
+        self.assertFalse(is_ai_span(make_span(span_name)))
 
     def test_rejects_non_ai_attributes(self):
-        span = _make_span("http.request", {"http.method": "GET", "http.url": "/"})
+        span = make_span("http.request", {"http.method": "GET", "http.url": "/"})
         self.assertFalse(is_ai_span(span))
 
     def test_empty_span(self):
-        self.assertFalse(is_ai_span(_make_span("test", {})))
+        self.assertFalse(is_ai_span(make_span("test", {})))
 
     def test_none_attributes(self):
-        span = _make_span("test")
+        span = make_span("test")
         span.attributes = None
         self.assertFalse(is_ai_span(span))

--- a/posthog/test/ai/otel/test_spans.py
+++ b/posthog/test/ai/otel/test_spans.py
@@ -1,0 +1,58 @@
+import unittest
+from unittest.mock import MagicMock
+
+from posthog.ai.otel.spans import is_ai_span
+
+
+def _make_span(name: str = "test", attributes: dict | None = None) -> MagicMock:
+    span = MagicMock()
+    span.name = name
+    span.attributes = attributes or {}
+    return span
+
+
+class TestIsAISpan(unittest.TestCase):
+    def test_matches_gen_ai_name_prefix(self):
+        self.assertTrue(is_ai_span(_make_span("gen_ai.chat")))
+
+    def test_matches_llm_name_prefix(self):
+        self.assertTrue(is_ai_span(_make_span("llm.call")))
+
+    def test_matches_ai_name_prefix(self):
+        self.assertTrue(is_ai_span(_make_span("ai.completion")))
+
+    def test_matches_traceloop_name_prefix(self):
+        self.assertTrue(is_ai_span(_make_span("traceloop.workflow")))
+
+    def test_rejects_non_ai_name(self):
+        self.assertFalse(is_ai_span(_make_span("http.request")))
+        self.assertFalse(is_ai_span(_make_span("db.query")))
+        self.assertFalse(is_ai_span(_make_span("my_function")))
+
+    def test_matches_gen_ai_attribute_key(self):
+        span = _make_span("http.request", {"gen_ai.system": "openai"})
+        self.assertTrue(is_ai_span(span))
+
+    def test_matches_llm_attribute_key(self):
+        span = _make_span("http.request", {"llm.model": "gpt-4"})
+        self.assertTrue(is_ai_span(span))
+
+    def test_matches_ai_attribute_key(self):
+        span = _make_span("http.request", {"ai.provider": "anthropic"})
+        self.assertTrue(is_ai_span(span))
+
+    def test_matches_traceloop_attribute_key(self):
+        span = _make_span("http.request", {"traceloop.entity.name": "chain"})
+        self.assertTrue(is_ai_span(span))
+
+    def test_rejects_non_ai_attributes(self):
+        span = _make_span("http.request", {"http.method": "GET", "http.url": "/"})
+        self.assertFalse(is_ai_span(span))
+
+    def test_empty_span(self):
+        self.assertFalse(is_ai_span(_make_span("test", {})))
+
+    def test_none_attributes(self):
+        span = _make_span("test")
+        span.attributes = None
+        self.assertFalse(is_ai_span(span))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,10 @@ Repository = "https://github.com/posthog/posthog-python"
 
 [project.optional-dependencies]
 langchain = ["langchain>=0.2.0"]
+otel = [
+    "opentelemetry-sdk>=1.20.0",
+    "opentelemetry-exporter-otlp-proto-http>=1.20.0",
+]
 dev = [
     "django-stubs",
     "lxml",
@@ -79,6 +83,8 @@ test = [
     "pydantic>=2.12.0",
     "parameterized>=0.8.1",
     "claude-agent-sdk",
+    "opentelemetry-sdk>=1.20.0",
+    "opentelemetry-exporter-otlp-proto-http>=1.20.0",
 ]
 
 [tool.setuptools]
@@ -91,10 +97,12 @@ packages = [
     "posthog.ai.anthropic",
     "posthog.ai.gemini",
     "posthog.ai.claude_agent_sdk",
+    "posthog.ai.otel",
     "posthog.test",
     "posthog.test.ai",
     "posthog.test.ai.openai_agents",
     "posthog.test.ai.claude_agent_sdk",
+    "posthog.test.ai.otel",
     "posthog.integrations",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-07T11:04:23.815357721Z"
+exclude-newer = "2026-04-07T11:21:48.780749Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -758,6 +758,18 @@ wheels = [
 ]
 
 [[package]]
+name = "googleapis-common-protos"
+version = "1.73.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/c0/4a54c386282c13449eca8bbe2ddb518181dc113e78d240458a68856b4d69/googleapis_common_protos-1.73.1.tar.gz", hash = "sha256:13114f0e9d2391756a0194c3a8131974ed7bffb06086569ba193364af59163b6", size = 147506, upload-time = "2026-03-26T22:17:38.451Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/82/fcb6520612bec0c39b973a6c0954b6a0d948aadfe8f7e9487f60ceb8bfa6/googleapis_common_protos-1.73.1-py3-none-any.whl", hash = "sha256:e51f09eb0a43a8602f5a915870972e6b4a394088415c79d79605a46d8e826ee8", size = 297556, upload-time = "2026-03-26T22:15:58.455Z" },
+]
+
+[[package]]
 name = "greenlet"
 version = "3.2.3"
 source = { registry = "https://pypi.org/simple" }
@@ -884,7 +896,7 @@ name = "importlib-metadata"
 version = "8.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.13'" },
+    { name = "zipp" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
 wheels = [
@@ -1769,6 +1781,88 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-api"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2c/1d/4049a9e8698361cc1a1aa03a6c59e4fa4c71e0c0f94a30f988a6876a2ae6/opentelemetry_api-1.40.0.tar.gz", hash = "sha256:159be641c0b04d11e9ecd576906462773eb97ae1b657730f0ecf64d32071569f", size = 70851, upload-time = "2026-03-04T14:17:21.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/bf/93795954016c522008da367da292adceed71cca6ee1717e1d64c83089099/opentelemetry_api-1.40.0-py3-none-any.whl", hash = "sha256:82dd69331ae74b06f6a874704be0cfaa49a1650e1537d4a813b86ecef7d0ecf9", size = 68676, upload-time = "2026-03-04T14:17:01.24Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/bc/1559d46557fe6eca0b46c88d4c2676285f1f3be2e8d06bb5d15fbffc814a/opentelemetry_exporter_otlp_proto_common-1.40.0.tar.gz", hash = "sha256:1cbee86a4064790b362a86601ee7934f368b81cd4cc2f2e163902a6e7818a0fa", size = 20416, upload-time = "2026-03-04T14:17:23.801Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/ca/8f122055c97a932311a3f640273f084e738008933503d0c2563cd5d591fc/opentelemetry_exporter_otlp_proto_common-1.40.0-py3-none-any.whl", hash = "sha256:7081ff453835a82417bf38dccf122c827c3cbc94f2079b03bba02a3165f25149", size = 18369, upload-time = "2026-03-04T14:17:04.796Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/fa/73d50e2c15c56be4d000c98e24221d494674b0cc95524e2a8cb3856d95a4/opentelemetry_exporter_otlp_proto_http-1.40.0.tar.gz", hash = "sha256:db48f5e0f33217588bbc00274a31517ba830da576e59503507c839b38fa0869c", size = 17772, upload-time = "2026-03-04T14:17:25.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/3a/8865d6754e61c9fb170cdd530a124a53769ee5f740236064816eb0ca7301/opentelemetry_exporter_otlp_proto_http-1.40.0-py3-none-any.whl", hash = "sha256:a8d1dab28f504c5d96577d6509f80a8150e44e8f45f82cdbe0e34c99ab040069", size = 19960, upload-time = "2026-03-04T14:17:07.153Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/77/dd38991db037fdfce45849491cb61de5ab000f49824a00230afb112a4392/opentelemetry_proto-1.40.0.tar.gz", hash = "sha256:03f639ca129ba513f5819810f5b1f42bcb371391405d99c168fe6937c62febcd", size = 45667, upload-time = "2026-03-04T14:17:31.194Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/b2/189b2577dde745b15625b3214302605b1353436219d42b7912e77fa8dc24/opentelemetry_proto-1.40.0-py3-none-any.whl", hash = "sha256:266c4385d88923a23d63e353e9761af0f47a6ed0d486979777fe4de59dc9b25f", size = 72073, upload-time = "2026-03-04T14:17:16.673Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/fd/3c3125b20ba18ce2155ba9ea74acb0ae5d25f8cd39cfd37455601b7955cc/opentelemetry_sdk-1.40.0.tar.gz", hash = "sha256:18e9f5ec20d859d268c7cb3c5198c8d105d073714db3de50b593b8c1345a48f2", size = 184252, upload-time = "2026-03-04T14:17:31.87Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/c5/6a852903d8bfac758c6dc6e9a68b015d3c33f2f1be5e9591e0f4b69c7e0a/opentelemetry_sdk-1.40.0-py3-none-any.whl", hash = "sha256:787d2154a71f4b3d81f20524a8ce061b7db667d24e46753f32a7bc48f1c1f3f1", size = 141951, upload-time = "2026-03-04T14:17:17.961Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.61b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/c0/4ae7973f3c2cfd2b6e321f1675626f0dab0a97027cc7a297474c9c8f3d04/opentelemetry_semantic_conventions-0.61b0.tar.gz", hash = "sha256:072f65473c5d7c6dc0355b27d6c9d1a679d63b6d4b4b16a9773062cb7e31192a", size = 145755, upload-time = "2026-03-04T14:17:32.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/37/cc6a55e448deaa9b27377d087da8615a3416d8ad523d5960b78dbeadd02a/opentelemetry_semantic_conventions-0.61b0-py3-none-any.whl", hash = "sha256:fa530a96be229795f8cef353739b618148b0fe2b4b3f005e60e262926c4d38e2", size = 231621, upload-time = "2026-03-04T14:17:19.33Z" },
+]
+
+[[package]]
 name = "orjson"
 version = "3.11.7"
 source = { registry = "https://pypi.org/simple" }
@@ -1987,6 +2081,10 @@ dev = [
 langchain = [
     { name = "langchain" },
 ]
+otel = [
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
+]
 test = [
     { name = "anthropic" },
     { name = "claude-agent-sdk" },
@@ -2002,6 +2100,8 @@ test = [
     { name = "langgraph-checkpoint" },
     { name = "mock" },
     { name = "openai" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
     { name = "parameterized" },
     { name = "pydantic" },
     { name = "pytest" },
@@ -2038,6 +2138,10 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "mypy-baseline", marker = "extra == 'dev'" },
     { name = "openai", marker = "extra == 'test'", specifier = ">=2.0" },
+    { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'otel'", specifier = ">=1.20.0" },
+    { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'test'", specifier = ">=1.20.0" },
+    { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.20.0" },
+    { name = "opentelemetry-sdk", marker = "extra == 'test'", specifier = ">=1.20.0" },
     { name = "packaging", marker = "extra == 'dev'" },
     { name = "parameterized", marker = "extra == 'test'", specifier = ">=0.8.1" },
     { name = "pre-commit", marker = "extra == 'dev'" },
@@ -2063,7 +2167,7 @@ requires-dist = [
     { name = "typing-extensions", specifier = ">=4.2.0" },
     { name = "wheel", marker = "extra == 'dev'" },
 ]
-provides-extras = ["langchain", "dev", "test"]
+provides-extras = ["langchain", "otel", "dev", "test"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "claude-agent-sdk", specifier = ">=0.1.50" }]
@@ -2171,6 +2275,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/4c/b0fe775a2bdd01e176b14b574be679d84fc83958335790f7c9a686c1f468/propcache-0.3.2-cp313-cp313t-win32.whl", hash = "sha256:f86e5d7cd03afb3a1db8e9f9f6eff15794e79e791350ac48a8c924e6f439f394", size = 41175, upload-time = "2025-06-09T22:55:38.436Z" },
     { url = "https://files.pythonhosted.org/packages/a4/ff/47f08595e3d9b5e149c150f88d9714574f1a7cbd89fe2817158a952674bf/propcache-0.3.2-cp313-cp313t-win_amd64.whl", hash = "sha256:9704bedf6e7cbe3c65eca4379a9b53ee6a83749f047808cbb5044d40d7d72198", size = 44857, upload-time = "2025-06-09T22:55:39.687Z" },
     { url = "https://files.pythonhosted.org/packages/cc/35/cc0aaecf278bb4575b8555f2b137de5ab821595ddae9da9d3cd1da4072c7/propcache-0.3.2-py3-none-any.whl", hash = "sha256:98f1ec44fb675f5052cccc8e609c46ed23a35a1cfd18545ad4e29002d858a43f", size = 12663, upload-time = "2025-06-09T22:56:04.484Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.33.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

Users instrumenting their AI/LLM applications with OpenTelemetry have no way to route AI spans to PostHog without writing custom glue code. This is the Python equivalent of https://github.com/PostHog/posthog-js/pull/3358.

## Changes

Adds a `posthog.ai.otel` module with two integration patterns:

- **`PostHogSpanProcessor`** (recommended) — self-contained `SpanProcessor` that wraps `BatchSpanProcessor` + `OTLPSpanExporter`, filtering to only forward AI spans to PostHog's OTLP endpoint at `/i/v0/ai/otel`
- **`PostHogTraceExporter`** — `SpanExporter` that filters AI spans before forwarding, for setups that only accept an exporter (e.g. passed to `SimpleSpanProcessor`)
- **`is_ai_span()`** — shared predicate matching `gen_ai.*`, `llm.*`, `ai.*`, `traceloop.*` prefixes on span names and attribute keys

Also adds `posthog[otel]` optional dependency group for `opentelemetry-sdk` and `opentelemetry-exporter-otlp-proto-http`.

### Usage

```python
from opentelemetry import trace
from opentelemetry.sdk.trace import TracerProvider
from opentelemetry.sdk.resources import Resource, SERVICE_NAME
from posthog.ai.otel import PostHogSpanProcessor

resource = Resource(
    attributes={
        SERVICE_NAME: "my-app",
        "posthog.distinct_id": "user-123",
    }
)
provider = TracerProvider(resource=resource)
provider.add_span_processor(
    PostHogSpanProcessor(api_key="phc_...")
)
trace.set_tracer_provider(provider)
```

### Consistency with #482

Uses the same OTLP endpoint (`/i/v0/ai/otel`) and auth header format (`Authorization: Bearer {api_key}`) as the migrated examples in #482.

## How did you test this code?

31 unit tests covering span filtering, processor forwarding/dropping, exporter filtering, endpoint configuration, and lifecycle delegation.