### PR TITLE
feat: add Gemini embed_content tracking

### DIFF
--- a/.sampo/changesets/gemini-embed-content.md
+++ b/.sampo/changesets/gemini-embed-content.md
@@ -1,0 +1,5 @@
+---
+pypi/posthog: minor
+---
+
+Add Gemini `embed_content` tracking support for both sync and async clients

--- a/posthog/ai/gemini/gemini.py
+++ b/posthog/ai/gemini/gemini.py
@@ -20,10 +20,12 @@ from posthog.ai.utils import (
     merge_usage_stats,
 )
 from posthog.ai.gemini.gemini_converter import (
+    extract_gemini_embedding_token_count,
     extract_gemini_usage_from_chunk,
     extract_gemini_content_from_chunk,
     format_gemini_streaming_output,
 )
+from posthog.ai.utils import with_privacy_mode
 from posthog.ai.sanitization import sanitize_gemini
 from posthog.client import Client as PostHogClient
 
@@ -418,3 +420,90 @@ class Models:
             groups,
             **kwargs,
         )
+
+    def embed_content(
+        self,
+        model: str,
+        contents,
+        posthog_distinct_id: Optional[str] = None,
+        posthog_trace_id: Optional[str] = None,
+        posthog_properties: Optional[Dict[str, Any]] = None,
+        posthog_privacy_mode: Optional[bool] = None,
+        posthog_groups: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ):
+        """
+        Create embeddings using Gemini's API while tracking usage in PostHog.
+
+        Args:
+            model: The model to use (e.g., 'gemini-embedding-001')
+            contents: The input content for embedding
+            posthog_distinct_id: ID to associate with the usage event (overrides client default)
+            posthog_trace_id: Trace UUID for linking events (auto-generated if not provided)
+            posthog_properties: Extra properties to include in the event (merged with client defaults)
+            posthog_privacy_mode: Whether to redact sensitive information (overrides client default)
+            posthog_groups: Group analytics properties (overrides client default)
+            **kwargs: Arguments passed to Gemini's embed_content (e.g., config)
+        """
+        distinct_id, trace_id, properties, privacy_mode, groups = (
+            self._merge_posthog_params(
+                posthog_distinct_id,
+                posthog_trace_id,
+                posthog_properties,
+                posthog_privacy_mode,
+                posthog_groups,
+            )
+        )
+
+        start_time = time.time()
+        response = None
+        error = None
+        http_status = 200
+
+        try:
+            response = self._client.models.embed_content(
+                model=model, contents=contents, **kwargs
+            )
+        except Exception as exc:
+            error = exc
+            http_status = getattr(exc, "status_code", 0)
+        finally:
+            end_time = time.time()
+            latency = end_time - start_time
+
+            input_tokens = (
+                extract_gemini_embedding_token_count(response) if response else 0
+            )
+
+            event_properties = {
+                "$ai_provider": "gemini",
+                "$ai_model": model,
+                "$ai_input": with_privacy_mode(
+                    self._ph_client, privacy_mode, contents
+                ),
+                "$ai_http_status": http_status,
+                "$ai_input_tokens": input_tokens,
+                "$ai_latency": latency,
+                "$ai_trace_id": trace_id,
+                "$ai_base_url": self._base_url,
+                **(properties or {}),
+            }
+
+            if error:
+                event_properties["$ai_is_error"] = True
+                event_properties["$ai_error"] = str(error)
+
+            if distinct_id is None:
+                event_properties["$process_person_profile"] = False
+
+            self._ph_client.capture(
+                distinct_id=distinct_id or trace_id,
+                event="$ai_embedding",
+                properties=event_properties,
+                groups=groups,
+            )
+
+        if error:
+            raise error
+
+        return response

--- a/posthog/ai/gemini/gemini.py
+++ b/posthog/ai/gemini/gemini.py
@@ -478,9 +478,7 @@ class Models:
             event_properties = {
                 "$ai_provider": "gemini",
                 "$ai_model": model,
-                "$ai_input": with_privacy_mode(
-                    self._ph_client, privacy_mode, contents
-                ),
+                "$ai_input": with_privacy_mode(self._ph_client, privacy_mode, contents),
                 "$ai_http_status": http_status,
                 "$ai_input_tokens": input_tokens,
                 "$ai_latency": latency,

--- a/posthog/ai/gemini/gemini_async.py
+++ b/posthog/ai/gemini/gemini_async.py
@@ -20,10 +20,12 @@ from posthog.ai.utils import (
     merge_usage_stats,
 )
 from posthog.ai.gemini.gemini_converter import (
+    extract_gemini_embedding_token_count,
     extract_gemini_usage_from_chunk,
     extract_gemini_content_from_chunk,
     format_gemini_streaming_output,
 )
+from posthog.ai.utils import with_privacy_mode
 from posthog.ai.sanitization import sanitize_gemini
 from posthog.client import Client as PostHogClient
 
@@ -421,3 +423,90 @@ class AsyncModels:
             groups,
             **kwargs,
         )
+
+    async def embed_content(
+        self,
+        model: str,
+        contents,
+        posthog_distinct_id: Optional[str] = None,
+        posthog_trace_id: Optional[str] = None,
+        posthog_properties: Optional[Dict[str, Any]] = None,
+        posthog_privacy_mode: Optional[bool] = None,
+        posthog_groups: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ):
+        """
+        Create embeddings using Gemini's API while tracking usage in PostHog.
+
+        Args:
+            model: The model to use (e.g., 'gemini-embedding-001')
+            contents: The input content for embedding
+            posthog_distinct_id: ID to associate with the usage event (overrides client default)
+            posthog_trace_id: Trace UUID for linking events (auto-generated if not provided)
+            posthog_properties: Extra properties to include in the event (merged with client defaults)
+            posthog_privacy_mode: Whether to redact sensitive information (overrides client default)
+            posthog_groups: Group analytics properties (overrides client default)
+            **kwargs: Arguments passed to Gemini's embed_content (e.g., config)
+        """
+        distinct_id, trace_id, properties, privacy_mode, groups = (
+            self._merge_posthog_params(
+                posthog_distinct_id,
+                posthog_trace_id,
+                posthog_properties,
+                posthog_privacy_mode,
+                posthog_groups,
+            )
+        )
+
+        start_time = time.time()
+        response = None
+        error = None
+        http_status = 200
+
+        try:
+            response = await self._client.aio.models.embed_content(
+                model=model, contents=contents, **kwargs
+            )
+        except Exception as exc:
+            error = exc
+            http_status = getattr(exc, "status_code", 0)
+        finally:
+            end_time = time.time()
+            latency = end_time - start_time
+
+            input_tokens = (
+                extract_gemini_embedding_token_count(response) if response else 0
+            )
+
+            event_properties = {
+                "$ai_provider": "gemini",
+                "$ai_model": model,
+                "$ai_input": with_privacy_mode(
+                    self._ph_client, privacy_mode, contents
+                ),
+                "$ai_http_status": http_status,
+                "$ai_input_tokens": input_tokens,
+                "$ai_latency": latency,
+                "$ai_trace_id": trace_id,
+                "$ai_base_url": self._base_url,
+                **(properties or {}),
+            }
+
+            if error:
+                event_properties["$ai_is_error"] = True
+                event_properties["$ai_error"] = str(error)
+
+            if distinct_id is None:
+                event_properties["$process_person_profile"] = False
+
+            self._ph_client.capture(
+                distinct_id=distinct_id or trace_id,
+                event="$ai_embedding",
+                properties=event_properties,
+                groups=groups,
+            )
+
+        if error:
+            raise error
+
+        return response

--- a/posthog/ai/gemini/gemini_async.py
+++ b/posthog/ai/gemini/gemini_async.py
@@ -481,9 +481,7 @@ class AsyncModels:
             event_properties = {
                 "$ai_provider": "gemini",
                 "$ai_model": model,
-                "$ai_input": with_privacy_mode(
-                    self._ph_client, privacy_mode, contents
-                ),
+                "$ai_input": with_privacy_mode(self._ph_client, privacy_mode, contents),
                 "$ai_http_status": http_status,
                 "$ai_input_tokens": input_tokens,
                 "$ai_latency": latency,

--- a/posthog/ai/gemini/gemini_converter.py
+++ b/posthog/ai/gemini/gemini_converter.py
@@ -657,3 +657,19 @@ def format_gemini_streaming_output(
 
     # Fallback for empty or unexpected input
     return [{"role": "assistant", "content": [{"type": "text", "text": ""}]}]
+
+
+def extract_gemini_embedding_token_count(response) -> int:
+    """
+    Extract total token count from a Gemini embed_content response.
+    Token counts are only available per-embedding via Vertex AI's statistics.token_count.
+    Returns 0 if no token counts are available.
+    """
+    total = 0
+    if hasattr(response, "embeddings") and response.embeddings:
+        for embedding in response.embeddings:
+            if hasattr(embedding, "statistics") and embedding.statistics:
+                token_count = getattr(embedding.statistics, "token_count", None)
+                if token_count is not None:
+                    total += int(token_count)
+    return total

--- a/posthog/test/ai/gemini/test_gemini.py
+++ b/posthog/test/ai/gemini/test_gemini.py
@@ -1193,8 +1193,12 @@ def mock_embed_content_response_with_stats():
     return mock_response
 
 
-def test_embed_content_basic(mock_client, mock_google_genai_client, mock_embed_content_response):
-    mock_google_genai_client.models.embed_content.return_value = mock_embed_content_response
+def test_embed_content_basic(
+    mock_client, mock_google_genai_client, mock_embed_content_response
+):
+    mock_google_genai_client.models.embed_content.return_value = (
+        mock_embed_content_response
+    )
 
     client = Client(api_key="test-key", posthog_client=mock_client)
     response = client.models.embed_content(
@@ -1227,8 +1231,12 @@ def test_embed_content_basic(mock_client, mock_google_genai_client, mock_embed_c
     )
 
 
-def test_embed_content_with_token_counts(mock_client, mock_google_genai_client, mock_embed_content_response_with_stats):
-    mock_google_genai_client.models.embed_content.return_value = mock_embed_content_response_with_stats
+def test_embed_content_with_token_counts(
+    mock_client, mock_google_genai_client, mock_embed_content_response_with_stats
+):
+    mock_google_genai_client.models.embed_content.return_value = (
+        mock_embed_content_response_with_stats
+    )
 
     client = Client(api_key="test-key", posthog_client=mock_client)
     client.models.embed_content(
@@ -1241,8 +1249,12 @@ def test_embed_content_with_token_counts(mock_client, mock_google_genai_client, 
     assert props["$ai_input_tokens"] == 13  # 5 + 8
 
 
-def test_embed_content_without_token_counts(mock_client, mock_google_genai_client, mock_embed_content_response):
-    mock_google_genai_client.models.embed_content.return_value = mock_embed_content_response
+def test_embed_content_without_token_counts(
+    mock_client, mock_google_genai_client, mock_embed_content_response
+):
+    mock_google_genai_client.models.embed_content.return_value = (
+        mock_embed_content_response
+    )
 
     client = Client(api_key="test-key", posthog_client=mock_client)
     client.models.embed_content(
@@ -1255,8 +1267,12 @@ def test_embed_content_without_token_counts(mock_client, mock_google_genai_clien
     assert props["$ai_input_tokens"] == 0
 
 
-def test_embed_content_privacy_mode(mock_client, mock_google_genai_client, mock_embed_content_response):
-    mock_google_genai_client.models.embed_content.return_value = mock_embed_content_response
+def test_embed_content_privacy_mode(
+    mock_client, mock_google_genai_client, mock_embed_content_response
+):
+    mock_google_genai_client.models.embed_content.return_value = (
+        mock_embed_content_response
+    )
 
     client = Client(api_key="test-key", posthog_client=mock_client)
     client.models.embed_content(
@@ -1270,8 +1286,12 @@ def test_embed_content_privacy_mode(mock_client, mock_google_genai_client, mock_
     assert props["$ai_input"] is None
 
 
-def test_embed_content_no_distinct_id(mock_client, mock_google_genai_client, mock_embed_content_response):
-    mock_google_genai_client.models.embed_content.return_value = mock_embed_content_response
+def test_embed_content_no_distinct_id(
+    mock_client, mock_google_genai_client, mock_embed_content_response
+):
+    mock_google_genai_client.models.embed_content.return_value = (
+        mock_embed_content_response
+    )
 
     client = Client(api_key="test-key", posthog_client=mock_client)
     client.models.embed_content(
@@ -1287,8 +1307,12 @@ def test_embed_content_no_distinct_id(mock_client, mock_google_genai_client, moc
     assert props["$process_person_profile"] is False
 
 
-def test_embed_content_default_params(mock_client, mock_google_genai_client, mock_embed_content_response):
-    mock_google_genai_client.models.embed_content.return_value = mock_embed_content_response
+def test_embed_content_default_params(
+    mock_client, mock_google_genai_client, mock_embed_content_response
+):
+    mock_google_genai_client.models.embed_content.return_value = (
+        mock_embed_content_response
+    )
 
     client = Client(
         api_key="test-key",
@@ -1332,8 +1356,12 @@ def test_embed_content_error_handling(mock_client, mock_google_genai_client):
     assert props["$ai_http_status"] == 0
 
 
-def test_embed_content_kwargs_passthrough(mock_client, mock_google_genai_client, mock_embed_content_response):
-    mock_google_genai_client.models.embed_content.return_value = mock_embed_content_response
+def test_embed_content_kwargs_passthrough(
+    mock_client, mock_google_genai_client, mock_embed_content_response
+):
+    mock_google_genai_client.models.embed_content.return_value = (
+        mock_embed_content_response
+    )
 
     client = Client(api_key="test-key", posthog_client=mock_client)
     client.models.embed_content(

--- a/posthog/test/ai/gemini/test_gemini.py
+++ b/posthog/test/ai/gemini/test_gemini.py
@@ -1,4 +1,5 @@
 import json
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -11,6 +12,8 @@ try:
     GEMINI_AVAILABLE = True
 except ImportError:
     GEMINI_AVAILABLE = False
+
+GOOGLE_API_KEY = os.getenv("GOOGLE_API_KEY")
 
 pytestmark = pytest.mark.skipif(
     not GEMINI_AVAILABLE, reason="Google Gemini package is not available"
@@ -1161,3 +1164,227 @@ def test_empty_array_grounding_metadata_no_web_search(
     assert "$ai_web_search_count" not in props
     assert props["$ai_input_tokens"] == 15
     assert props["$ai_output_tokens"] == 12
+
+
+@pytest.fixture
+def mock_embed_content_response():
+    mock_response = MagicMock()
+    mock_embedding1 = MagicMock()
+    mock_embedding1.values = [0.1, 0.2, 0.3]
+    mock_embedding1.statistics = None
+    mock_response.embeddings = [mock_embedding1]
+    return mock_response
+
+
+@pytest.fixture
+def mock_embed_content_response_with_stats():
+    mock_response = MagicMock()
+    mock_embedding1 = MagicMock()
+    mock_embedding1.values = [0.1, 0.2, 0.3]
+    mock_stats1 = MagicMock()
+    mock_stats1.token_count = 5
+    mock_embedding1.statistics = mock_stats1
+    mock_embedding2 = MagicMock()
+    mock_embedding2.values = [0.4, 0.5, 0.6]
+    mock_stats2 = MagicMock()
+    mock_stats2.token_count = 8
+    mock_embedding2.statistics = mock_stats2
+    mock_response.embeddings = [mock_embedding1, mock_embedding2]
+    return mock_response
+
+
+def test_embed_content_basic(mock_client, mock_google_genai_client, mock_embed_content_response):
+    mock_google_genai_client.models.embed_content.return_value = mock_embed_content_response
+
+    client = Client(api_key="test-key", posthog_client=mock_client)
+    response = client.models.embed_content(
+        model="gemini-embedding-001",
+        contents="Hello world",
+        posthog_distinct_id="test-id",
+        posthog_properties={"foo": "bar"},
+    )
+
+    assert response == mock_embed_content_response
+    assert mock_client.capture.call_count == 1
+
+    call_args = mock_client.capture.call_args[1]
+    props = call_args["properties"]
+
+    assert call_args["distinct_id"] == "test-id"
+    assert call_args["event"] == "$ai_embedding"
+    assert props["$ai_provider"] == "gemini"
+    assert props["$ai_model"] == "gemini-embedding-001"
+    assert props["$ai_input"] == "Hello world"
+    assert props["$ai_http_status"] == 200
+    assert isinstance(props["$ai_latency"], float)
+    assert "$ai_trace_id" in props
+    assert props["$ai_base_url"] == "https://generativelanguage.googleapis.com"
+    assert props["foo"] == "bar"
+
+    # Verify the underlying call received the right args
+    mock_google_genai_client.models.embed_content.assert_called_once_with(
+        model="gemini-embedding-001", contents="Hello world"
+    )
+
+
+def test_embed_content_with_token_counts(mock_client, mock_google_genai_client, mock_embed_content_response_with_stats):
+    mock_google_genai_client.models.embed_content.return_value = mock_embed_content_response_with_stats
+
+    client = Client(api_key="test-key", posthog_client=mock_client)
+    client.models.embed_content(
+        model="gemini-embedding-001",
+        contents=["Hello", "World"],
+        posthog_distinct_id="test-id",
+    )
+
+    props = mock_client.capture.call_args[1]["properties"]
+    assert props["$ai_input_tokens"] == 13  # 5 + 8
+
+
+def test_embed_content_without_token_counts(mock_client, mock_google_genai_client, mock_embed_content_response):
+    mock_google_genai_client.models.embed_content.return_value = mock_embed_content_response
+
+    client = Client(api_key="test-key", posthog_client=mock_client)
+    client.models.embed_content(
+        model="gemini-embedding-001",
+        contents="Hello",
+        posthog_distinct_id="test-id",
+    )
+
+    props = mock_client.capture.call_args[1]["properties"]
+    assert props["$ai_input_tokens"] == 0
+
+
+def test_embed_content_privacy_mode(mock_client, mock_google_genai_client, mock_embed_content_response):
+    mock_google_genai_client.models.embed_content.return_value = mock_embed_content_response
+
+    client = Client(api_key="test-key", posthog_client=mock_client)
+    client.models.embed_content(
+        model="gemini-embedding-001",
+        contents="Secret text",
+        posthog_distinct_id="test-id",
+        posthog_privacy_mode=True,
+    )
+
+    props = mock_client.capture.call_args[1]["properties"]
+    assert props["$ai_input"] is None
+
+
+def test_embed_content_no_distinct_id(mock_client, mock_google_genai_client, mock_embed_content_response):
+    mock_google_genai_client.models.embed_content.return_value = mock_embed_content_response
+
+    client = Client(api_key="test-key", posthog_client=mock_client)
+    client.models.embed_content(
+        model="gemini-embedding-001",
+        contents="Hello",
+    )
+
+    call_args = mock_client.capture.call_args[1]
+    props = call_args["properties"]
+
+    # Should fall back to trace_id as distinct_id
+    assert call_args["distinct_id"] == props["$ai_trace_id"]
+    assert props["$process_person_profile"] is False
+
+
+def test_embed_content_default_params(mock_client, mock_google_genai_client, mock_embed_content_response):
+    mock_google_genai_client.models.embed_content.return_value = mock_embed_content_response
+
+    client = Client(
+        api_key="test-key",
+        posthog_client=mock_client,
+        posthog_distinct_id="default-id",
+        posthog_properties={"team": "ai"},
+        posthog_groups={"company": "test-co"},
+    )
+    client.models.embed_content(
+        model="gemini-embedding-001",
+        contents="Hello",
+        posthog_properties={"extra": "prop"},
+    )
+
+    call_args = mock_client.capture.call_args[1]
+    props = call_args["properties"]
+
+    assert call_args["distinct_id"] == "default-id"
+    assert props["team"] == "ai"
+    assert props["extra"] == "prop"
+    assert call_args["groups"] == {"company": "test-co"}
+
+
+def test_embed_content_error_handling(mock_client, mock_google_genai_client):
+    mock_google_genai_client.models.embed_content.side_effect = Exception("API error")
+
+    client = Client(api_key="test-key", posthog_client=mock_client)
+
+    with pytest.raises(Exception, match="API error"):
+        client.models.embed_content(
+            model="gemini-embedding-001",
+            contents="Hello",
+            posthog_distinct_id="test-id",
+        )
+
+    # Event should still be captured
+    assert mock_client.capture.call_count == 1
+    props = mock_client.capture.call_args[1]["properties"]
+    assert props["$ai_is_error"] is True
+    assert props["$ai_error"] == "API error"
+    assert props["$ai_http_status"] == 0
+
+
+def test_embed_content_kwargs_passthrough(mock_client, mock_google_genai_client, mock_embed_content_response):
+    mock_google_genai_client.models.embed_content.return_value = mock_embed_content_response
+
+    client = Client(api_key="test-key", posthog_client=mock_client)
+    client.models.embed_content(
+        model="gemini-embedding-001",
+        contents="Hello",
+        posthog_distinct_id="test-id",
+        config={"output_dimensionality": 64},
+    )
+
+    mock_google_genai_client.models.embed_content.assert_called_once_with(
+        model="gemini-embedding-001",
+        contents="Hello",
+        config={"output_dimensionality": 64},
+    )
+
+
+@pytest.mark.skipif(not GOOGLE_API_KEY, reason="GOOGLE_API_KEY is not set")
+def test_embed_content_integration(mock_client):
+    client = Client(api_key=GOOGLE_API_KEY, posthog_client=mock_client)
+    response = client.models.embed_content(
+        model="gemini-embedding-001",
+        contents="Hello world",
+        posthog_distinct_id="test-id",
+    )
+
+    # Verify real response
+    assert response.embeddings is not None
+    assert len(response.embeddings) > 0
+    assert isinstance(response.embeddings[0].values, list)
+    assert all(isinstance(v, float) for v in response.embeddings[0].values)
+
+    # Verify event captured
+    assert mock_client.capture.call_count == 1
+    call_args = mock_client.capture.call_args[1]
+    props = call_args["properties"]
+    assert call_args["event"] == "$ai_embedding"
+    assert props["$ai_provider"] == "gemini"
+    assert props["$ai_model"] == "gemini-embedding-001"
+    assert props["$ai_input"] == "Hello world"
+    assert props["$ai_latency"] > 0
+
+
+@pytest.mark.skipif(not GOOGLE_API_KEY, reason="GOOGLE_API_KEY is not set")
+def test_embed_content_integration_batch(mock_client):
+    client = Client(api_key=GOOGLE_API_KEY, posthog_client=mock_client)
+    inputs = ["Hello", "World", "Test"]
+    response = client.models.embed_content(
+        model="gemini-embedding-001",
+        contents=inputs,
+        posthog_distinct_id="test-id",
+    )
+
+    assert response.embeddings is not None
+    assert len(response.embeddings) == len(inputs)

--- a/posthog/test/ai/gemini/test_gemini_async.py
+++ b/posthog/test/ai/gemini/test_gemini_async.py
@@ -883,8 +883,12 @@ def mock_embed_content_response_with_stats():
     return mock_response
 
 
-async def test_async_embed_content_basic(mock_client, mock_google_genai_client, mock_embed_content_response):
-    mock_google_genai_client.aio.models.embed_content = AsyncMock(return_value=mock_embed_content_response)
+async def test_async_embed_content_basic(
+    mock_client, mock_google_genai_client, mock_embed_content_response
+):
+    mock_google_genai_client.aio.models.embed_content = AsyncMock(
+        return_value=mock_embed_content_response
+    )
 
     client = AsyncClient(api_key="test-key", posthog_client=mock_client)
     response = await client.models.embed_content(
@@ -917,8 +921,12 @@ async def test_async_embed_content_basic(mock_client, mock_google_genai_client, 
     )
 
 
-async def test_async_embed_content_with_token_counts(mock_client, mock_google_genai_client, mock_embed_content_response_with_stats):
-    mock_google_genai_client.aio.models.embed_content = AsyncMock(return_value=mock_embed_content_response_with_stats)
+async def test_async_embed_content_with_token_counts(
+    mock_client, mock_google_genai_client, mock_embed_content_response_with_stats
+):
+    mock_google_genai_client.aio.models.embed_content = AsyncMock(
+        return_value=mock_embed_content_response_with_stats
+    )
 
     client = AsyncClient(api_key="test-key", posthog_client=mock_client)
     await client.models.embed_content(
@@ -931,8 +939,12 @@ async def test_async_embed_content_with_token_counts(mock_client, mock_google_ge
     assert props["$ai_input_tokens"] == 13  # 5 + 8
 
 
-async def test_async_embed_content_without_token_counts(mock_client, mock_google_genai_client, mock_embed_content_response):
-    mock_google_genai_client.aio.models.embed_content = AsyncMock(return_value=mock_embed_content_response)
+async def test_async_embed_content_without_token_counts(
+    mock_client, mock_google_genai_client, mock_embed_content_response
+):
+    mock_google_genai_client.aio.models.embed_content = AsyncMock(
+        return_value=mock_embed_content_response
+    )
 
     client = AsyncClient(api_key="test-key", posthog_client=mock_client)
     await client.models.embed_content(
@@ -945,8 +957,12 @@ async def test_async_embed_content_without_token_counts(mock_client, mock_google
     assert props["$ai_input_tokens"] == 0
 
 
-async def test_async_embed_content_privacy_mode(mock_client, mock_google_genai_client, mock_embed_content_response):
-    mock_google_genai_client.aio.models.embed_content = AsyncMock(return_value=mock_embed_content_response)
+async def test_async_embed_content_privacy_mode(
+    mock_client, mock_google_genai_client, mock_embed_content_response
+):
+    mock_google_genai_client.aio.models.embed_content = AsyncMock(
+        return_value=mock_embed_content_response
+    )
 
     client = AsyncClient(api_key="test-key", posthog_client=mock_client)
     await client.models.embed_content(
@@ -960,8 +976,12 @@ async def test_async_embed_content_privacy_mode(mock_client, mock_google_genai_c
     assert props["$ai_input"] is None
 
 
-async def test_async_embed_content_no_distinct_id(mock_client, mock_google_genai_client, mock_embed_content_response):
-    mock_google_genai_client.aio.models.embed_content = AsyncMock(return_value=mock_embed_content_response)
+async def test_async_embed_content_no_distinct_id(
+    mock_client, mock_google_genai_client, mock_embed_content_response
+):
+    mock_google_genai_client.aio.models.embed_content = AsyncMock(
+        return_value=mock_embed_content_response
+    )
 
     client = AsyncClient(api_key="test-key", posthog_client=mock_client)
     await client.models.embed_content(
@@ -977,8 +997,12 @@ async def test_async_embed_content_no_distinct_id(mock_client, mock_google_genai
     assert props["$process_person_profile"] is False
 
 
-async def test_async_embed_content_default_params(mock_client, mock_google_genai_client, mock_embed_content_response):
-    mock_google_genai_client.aio.models.embed_content = AsyncMock(return_value=mock_embed_content_response)
+async def test_async_embed_content_default_params(
+    mock_client, mock_google_genai_client, mock_embed_content_response
+):
+    mock_google_genai_client.aio.models.embed_content = AsyncMock(
+        return_value=mock_embed_content_response
+    )
 
     client = AsyncClient(
         api_key="test-key",
@@ -1002,8 +1026,12 @@ async def test_async_embed_content_default_params(mock_client, mock_google_genai
     assert call_args["groups"] == {"company": "test-co"}
 
 
-async def test_async_embed_content_error_handling(mock_client, mock_google_genai_client):
-    mock_google_genai_client.aio.models.embed_content = AsyncMock(side_effect=Exception("API error"))
+async def test_async_embed_content_error_handling(
+    mock_client, mock_google_genai_client
+):
+    mock_google_genai_client.aio.models.embed_content = AsyncMock(
+        side_effect=Exception("API error")
+    )
 
     client = AsyncClient(api_key="test-key", posthog_client=mock_client)
 
@@ -1022,8 +1050,12 @@ async def test_async_embed_content_error_handling(mock_client, mock_google_genai
     assert props["$ai_http_status"] == 0
 
 
-async def test_async_embed_content_kwargs_passthrough(mock_client, mock_google_genai_client, mock_embed_content_response):
-    mock_google_genai_client.aio.models.embed_content = AsyncMock(return_value=mock_embed_content_response)
+async def test_async_embed_content_kwargs_passthrough(
+    mock_client, mock_google_genai_client, mock_embed_content_response
+):
+    mock_google_genai_client.aio.models.embed_content = AsyncMock(
+        return_value=mock_embed_content_response
+    )
 
     client = AsyncClient(api_key="test-key", posthog_client=mock_client)
     await client.models.embed_content(

--- a/posthog/test/ai/gemini/test_gemini_async.py
+++ b/posthog/test/ai/gemini/test_gemini_async.py
@@ -1,3 +1,4 @@
+import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -10,6 +11,8 @@ try:
     GEMINI_AVAILABLE = True
 except ImportError:
     GEMINI_AVAILABLE = False
+
+GOOGLE_API_KEY = os.getenv("GOOGLE_API_KEY")
 
 pytestmark = [
     pytest.mark.skipif(
@@ -851,3 +854,227 @@ async def test_async_streaming_with_web_search(mock_client, mock_google_genai_cl
     assert props["$ai_web_search_count"] == 1
     assert props["$ai_input_tokens"] == 30
     assert props["$ai_output_tokens"] == 15
+
+
+@pytest.fixture
+def mock_embed_content_response():
+    mock_response = MagicMock()
+    mock_embedding1 = MagicMock()
+    mock_embedding1.values = [0.1, 0.2, 0.3]
+    mock_embedding1.statistics = None
+    mock_response.embeddings = [mock_embedding1]
+    return mock_response
+
+
+@pytest.fixture
+def mock_embed_content_response_with_stats():
+    mock_response = MagicMock()
+    mock_embedding1 = MagicMock()
+    mock_embedding1.values = [0.1, 0.2, 0.3]
+    mock_stats1 = MagicMock()
+    mock_stats1.token_count = 5
+    mock_embedding1.statistics = mock_stats1
+    mock_embedding2 = MagicMock()
+    mock_embedding2.values = [0.4, 0.5, 0.6]
+    mock_stats2 = MagicMock()
+    mock_stats2.token_count = 8
+    mock_embedding2.statistics = mock_stats2
+    mock_response.embeddings = [mock_embedding1, mock_embedding2]
+    return mock_response
+
+
+async def test_async_embed_content_basic(mock_client, mock_google_genai_client, mock_embed_content_response):
+    mock_google_genai_client.aio.models.embed_content = AsyncMock(return_value=mock_embed_content_response)
+
+    client = AsyncClient(api_key="test-key", posthog_client=mock_client)
+    response = await client.models.embed_content(
+        model="gemini-embedding-001",
+        contents="Hello world",
+        posthog_distinct_id="test-id",
+        posthog_properties={"foo": "bar"},
+    )
+
+    assert response == mock_embed_content_response
+    assert mock_client.capture.call_count == 1
+
+    call_args = mock_client.capture.call_args[1]
+    props = call_args["properties"]
+
+    assert call_args["distinct_id"] == "test-id"
+    assert call_args["event"] == "$ai_embedding"
+    assert props["$ai_provider"] == "gemini"
+    assert props["$ai_model"] == "gemini-embedding-001"
+    assert props["$ai_input"] == "Hello world"
+    assert props["$ai_http_status"] == 200
+    assert isinstance(props["$ai_latency"], float)
+    assert "$ai_trace_id" in props
+    assert props["$ai_base_url"] == "https://generativelanguage.googleapis.com"
+    assert props["foo"] == "bar"
+
+    # Verify the underlying call received the right args
+    mock_google_genai_client.aio.models.embed_content.assert_called_once_with(
+        model="gemini-embedding-001", contents="Hello world"
+    )
+
+
+async def test_async_embed_content_with_token_counts(mock_client, mock_google_genai_client, mock_embed_content_response_with_stats):
+    mock_google_genai_client.aio.models.embed_content = AsyncMock(return_value=mock_embed_content_response_with_stats)
+
+    client = AsyncClient(api_key="test-key", posthog_client=mock_client)
+    await client.models.embed_content(
+        model="gemini-embedding-001",
+        contents=["Hello", "World"],
+        posthog_distinct_id="test-id",
+    )
+
+    props = mock_client.capture.call_args[1]["properties"]
+    assert props["$ai_input_tokens"] == 13  # 5 + 8
+
+
+async def test_async_embed_content_without_token_counts(mock_client, mock_google_genai_client, mock_embed_content_response):
+    mock_google_genai_client.aio.models.embed_content = AsyncMock(return_value=mock_embed_content_response)
+
+    client = AsyncClient(api_key="test-key", posthog_client=mock_client)
+    await client.models.embed_content(
+        model="gemini-embedding-001",
+        contents="Hello",
+        posthog_distinct_id="test-id",
+    )
+
+    props = mock_client.capture.call_args[1]["properties"]
+    assert props["$ai_input_tokens"] == 0
+
+
+async def test_async_embed_content_privacy_mode(mock_client, mock_google_genai_client, mock_embed_content_response):
+    mock_google_genai_client.aio.models.embed_content = AsyncMock(return_value=mock_embed_content_response)
+
+    client = AsyncClient(api_key="test-key", posthog_client=mock_client)
+    await client.models.embed_content(
+        model="gemini-embedding-001",
+        contents="Secret text",
+        posthog_distinct_id="test-id",
+        posthog_privacy_mode=True,
+    )
+
+    props = mock_client.capture.call_args[1]["properties"]
+    assert props["$ai_input"] is None
+
+
+async def test_async_embed_content_no_distinct_id(mock_client, mock_google_genai_client, mock_embed_content_response):
+    mock_google_genai_client.aio.models.embed_content = AsyncMock(return_value=mock_embed_content_response)
+
+    client = AsyncClient(api_key="test-key", posthog_client=mock_client)
+    await client.models.embed_content(
+        model="gemini-embedding-001",
+        contents="Hello",
+    )
+
+    call_args = mock_client.capture.call_args[1]
+    props = call_args["properties"]
+
+    # Should fall back to trace_id as distinct_id
+    assert call_args["distinct_id"] == props["$ai_trace_id"]
+    assert props["$process_person_profile"] is False
+
+
+async def test_async_embed_content_default_params(mock_client, mock_google_genai_client, mock_embed_content_response):
+    mock_google_genai_client.aio.models.embed_content = AsyncMock(return_value=mock_embed_content_response)
+
+    client = AsyncClient(
+        api_key="test-key",
+        posthog_client=mock_client,
+        posthog_distinct_id="default-id",
+        posthog_properties={"team": "ai"},
+        posthog_groups={"company": "test-co"},
+    )
+    await client.models.embed_content(
+        model="gemini-embedding-001",
+        contents="Hello",
+        posthog_properties={"extra": "prop"},
+    )
+
+    call_args = mock_client.capture.call_args[1]
+    props = call_args["properties"]
+
+    assert call_args["distinct_id"] == "default-id"
+    assert props["team"] == "ai"
+    assert props["extra"] == "prop"
+    assert call_args["groups"] == {"company": "test-co"}
+
+
+async def test_async_embed_content_error_handling(mock_client, mock_google_genai_client):
+    mock_google_genai_client.aio.models.embed_content = AsyncMock(side_effect=Exception("API error"))
+
+    client = AsyncClient(api_key="test-key", posthog_client=mock_client)
+
+    with pytest.raises(Exception, match="API error"):
+        await client.models.embed_content(
+            model="gemini-embedding-001",
+            contents="Hello",
+            posthog_distinct_id="test-id",
+        )
+
+    # Event should still be captured
+    assert mock_client.capture.call_count == 1
+    props = mock_client.capture.call_args[1]["properties"]
+    assert props["$ai_is_error"] is True
+    assert props["$ai_error"] == "API error"
+    assert props["$ai_http_status"] == 0
+
+
+async def test_async_embed_content_kwargs_passthrough(mock_client, mock_google_genai_client, mock_embed_content_response):
+    mock_google_genai_client.aio.models.embed_content = AsyncMock(return_value=mock_embed_content_response)
+
+    client = AsyncClient(api_key="test-key", posthog_client=mock_client)
+    await client.models.embed_content(
+        model="gemini-embedding-001",
+        contents="Hello",
+        posthog_distinct_id="test-id",
+        config={"output_dimensionality": 64},
+    )
+
+    mock_google_genai_client.aio.models.embed_content.assert_called_once_with(
+        model="gemini-embedding-001",
+        contents="Hello",
+        config={"output_dimensionality": 64},
+    )
+
+
+@pytest.mark.skipif(not GOOGLE_API_KEY, reason="GOOGLE_API_KEY is not set")
+async def test_async_embed_content_integration(mock_client):
+    client = AsyncClient(api_key=GOOGLE_API_KEY, posthog_client=mock_client)
+    response = await client.models.embed_content(
+        model="gemini-embedding-001",
+        contents="Hello world",
+        posthog_distinct_id="test-id",
+    )
+
+    # Verify real response
+    assert response.embeddings is not None
+    assert len(response.embeddings) > 0
+    assert isinstance(response.embeddings[0].values, list)
+    assert all(isinstance(v, float) for v in response.embeddings[0].values)
+
+    # Verify event captured
+    assert mock_client.capture.call_count == 1
+    call_args = mock_client.capture.call_args[1]
+    props = call_args["properties"]
+    assert call_args["event"] == "$ai_embedding"
+    assert props["$ai_provider"] == "gemini"
+    assert props["$ai_model"] == "gemini-embedding-001"
+    assert props["$ai_input"] == "Hello world"
+    assert props["$ai_latency"] > 0
+
+
+@pytest.mark.skipif(not GOOGLE_API_KEY, reason="GOOGLE_API_KEY is not set")
+async def test_async_embed_content_integration_batch(mock_client):
+    client = AsyncClient(api_key=GOOGLE_API_KEY, posthog_client=mock_client)
+    inputs = ["Hello", "World", "Test"]
+    response = await client.models.embed_content(
+        model="gemini-embedding-001",
+        contents=inputs,
+        posthog_distinct_id="test-id",
+    )
+
+    assert response.embeddings is not None
+    assert len(response.embeddings) == len(inputs)


### PR DESCRIPTION
## Changes

Adds `embed_content` wrapping to the Gemini client (both sync and async), capturing `$ai_embedding` events in PostHog. This addresses a [community request](https://posthog.com/questions/embeddings) for tracking Gemini embedding calls.

- Add `embed_content()` to `Models` and `AsyncModels` classes, matching the native `client.models.embed_content()` API
- Track `$ai_embedding` events with provider, model, input, latency, and token counts (Vertex AI)
- Support all PostHog params (distinct_id, trace_id, properties, privacy_mode, groups) with default merging
- Error handling: capture event with error properties before re-raising

## How to test

- [ ] `pytest posthog/test/ai/gemini/ -v` — 20 new tests (8 sync + 8 async mock-based, 2 sync + 2 async integration)
- [ ] Integration tests run with `GOOGLE_API_KEY=$GEMINI_API_KEY` and hit the real Gemini embedding API
- [ ] Existing Gemini tests still pass (55 passed, 4 skipped)