### PR TITLE
feat(llma): add $ai_stop_reason extraction for all providers

### DIFF
--- a/.sampo/changesets/add-ai-stop-reason.md
+++ b/.sampo/changesets/add-ai-stop-reason.md
@@ -1,0 +1,5 @@
+---
+pypi/posthog: minor
+---
+
+feat(ai): add $ai_stop_reason extraction for all providers

--- a/posthog/ai/anthropic/anthropic.py
+++ b/posthog/ai/anthropic/anthropic.py
@@ -131,6 +131,7 @@ class WrappedMessages(Messages):
         content_blocks: List[StreamingContentBlock] = []
         tools_in_progress: Dict[str, ToolInProgress] = {}
         current_text_block: Optional[StreamingContentBlock] = None
+        stop_reason: Optional[str] = None
         response = super().create(**kwargs)
 
         def generator():
@@ -139,6 +140,7 @@ class WrappedMessages(Messages):
             nonlocal content_blocks
             nonlocal tools_in_progress
             nonlocal current_text_block
+            nonlocal stop_reason
 
             try:
                 for event in response:
@@ -181,6 +183,14 @@ class WrappedMessages(Messages):
                             event, content_blocks, tools_in_progress
                         )
 
+                    # Capture stop reason from message_delta events
+                    if hasattr(event, "type") and event.type == "message_delta":
+                        delta = getattr(event, "delta", None)
+                        if delta is not None:
+                            delta_stop_reason = getattr(delta, "stop_reason", None)
+                            if delta_stop_reason is not None:
+                                stop_reason = delta_stop_reason
+
                     yield event
 
             finally:
@@ -198,6 +208,7 @@ class WrappedMessages(Messages):
                     latency,
                     content_blocks,
                     accumulated_content,
+                    stop_reason=stop_reason,
                 )
 
         return generator()
@@ -214,6 +225,7 @@ class WrappedMessages(Messages):
         latency: float,
         content_blocks: List[StreamingContentBlock],
         accumulated_content: str,
+        stop_reason: Optional[str] = None,
     ):
         from posthog.ai.types import StreamingEventData
         from posthog.ai.anthropic.anthropic_converter import (
@@ -242,6 +254,7 @@ class WrappedMessages(Messages):
             properties=posthog_properties,
             privacy_mode=posthog_privacy_mode,
             groups=posthog_groups,
+            stop_reason=stop_reason,
         )
 
         # Use the common capture function

--- a/posthog/ai/anthropic/anthropic_async.py
+++ b/posthog/ai/anthropic/anthropic_async.py
@@ -131,6 +131,7 @@ class AsyncWrappedMessages(AsyncMessages):
         content_blocks: List[StreamingContentBlock] = []
         tools_in_progress: Dict[str, ToolInProgress] = {}
         current_text_block: Optional[StreamingContentBlock] = None
+        stop_reason: Optional[str] = None
         response = await super().create(**kwargs)
 
         async def generator():
@@ -139,6 +140,7 @@ class AsyncWrappedMessages(AsyncMessages):
             nonlocal content_blocks
             nonlocal tools_in_progress
             nonlocal current_text_block
+            nonlocal stop_reason
 
             try:
                 async for event in response:
@@ -181,6 +183,14 @@ class AsyncWrappedMessages(AsyncMessages):
                             event, content_blocks, tools_in_progress
                         )
 
+                    # Capture stop reason from message_delta events
+                    if hasattr(event, "type") and event.type == "message_delta":
+                        delta = getattr(event, "delta", None)
+                        if delta is not None:
+                            delta_stop_reason = getattr(delta, "stop_reason", None)
+                            if delta_stop_reason is not None:
+                                stop_reason = delta_stop_reason
+
                     yield event
 
             finally:
@@ -198,6 +208,7 @@ class AsyncWrappedMessages(AsyncMessages):
                     latency,
                     content_blocks,
                     accumulated_content,
+                    stop_reason=stop_reason,
                 )
 
         return generator()
@@ -214,6 +225,7 @@ class AsyncWrappedMessages(AsyncMessages):
         latency: float,
         content_blocks: List[StreamingContentBlock],
         accumulated_content: str,
+        stop_reason: Optional[str] = None,
     ):
         from posthog.ai.types import StreamingEventData
         from posthog.ai.anthropic.anthropic_converter import (
@@ -242,6 +254,7 @@ class AsyncWrappedMessages(AsyncMessages):
             properties=posthog_properties,
             privacy_mode=posthog_privacy_mode,
             groups=posthog_groups,
+            stop_reason=stop_reason,
         )
 
         # Use the common capture function

--- a/posthog/ai/anthropic/anthropic_converter.py
+++ b/posthog/ai/anthropic/anthropic_converter.py
@@ -190,6 +190,11 @@ def extract_anthropic_web_search_count(response: Any) -> int:
     return 0
 
 
+def extract_anthropic_stop_reason(response: Any) -> Optional[str]:
+    """Extract stop reason from Anthropic response."""
+    return getattr(response, "stop_reason", None)
+
+
 def extract_anthropic_usage_from_response(response: Any) -> TokenUsage:
     """
     Extract usage from a full Anthropic response (non-streaming).

--- a/posthog/ai/claude_agent_sdk/processor.py
+++ b/posthog/ai/claude_agent_sdk/processor.py
@@ -42,6 +42,7 @@ class _GenerationData:
     start_time: float = 0.0
     end_time: float = 0.0
     span_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    stop_reason: Optional[str] = None
 
 
 class _GenerationTracker:
@@ -81,6 +82,10 @@ class _GenerationTracker:
             # message_delta usage reports cumulative output tokens
             if usage.get("output_tokens"):
                 self._current.output_tokens = usage["output_tokens"]
+            # Extract stop reason from message_delta
+            delta_stop_reason = raw.get("delta", {}).get("stop_reason")
+            if delta_stop_reason is not None:
+                self._current.stop_reason = delta_stop_reason
 
         elif event_type == "message_stop" and self._current is not None:
             self._current.end_time = time.time()
@@ -434,6 +439,9 @@ class PostHogClaudeAgentProcessor:
             properties["$ai_cache_creation_input_tokens"] = (
                 gen.cache_creation_input_tokens
             )
+
+        if gen.stop_reason is not None:
+            properties["$ai_stop_reason"] = gen.stop_reason
 
         if resolved_id is None:
             properties["$process_person_profile"] = False

--- a/posthog/ai/gemini/gemini.py
+++ b/posthog/ai/gemini/gemini.py
@@ -22,6 +22,7 @@ from posthog.ai.utils import (
 from posthog.ai.gemini.gemini_converter import (
     extract_gemini_usage_from_chunk,
     extract_gemini_content_from_chunk,
+    extract_gemini_stop_reason_from_chunk,
     format_gemini_streaming_output,
 )
 from posthog.ai.sanitization import sanitize_gemini
@@ -298,6 +299,7 @@ class Models:
         start_time = time.time()
         usage_stats: TokenUsage = TokenUsage(input_tokens=0, output_tokens=0)
         accumulated_content = []
+        stop_reason: Optional[str] = None
 
         kwargs_without_stream = {"model": model, "contents": contents, **kwargs}
         response = self._client.models.generate_content_stream(**kwargs_without_stream)
@@ -305,6 +307,7 @@ class Models:
         def generator():
             nonlocal usage_stats
             nonlocal accumulated_content
+            nonlocal stop_reason
             try:
                 for chunk in response:
                     # Extract usage stats from chunk
@@ -319,6 +322,11 @@ class Models:
 
                     if content_block is not None:
                         accumulated_content.append(content_block)
+
+                    # Extract stop reason from chunk
+                    chunk_stop_reason = extract_gemini_stop_reason_from_chunk(chunk)
+                    if chunk_stop_reason is not None:
+                        stop_reason = chunk_stop_reason
 
                     yield chunk
 
@@ -338,6 +346,7 @@ class Models:
                     usage_stats,
                     latency,
                     accumulated_content,
+                    stop_reason=stop_reason,
                 )
 
         return generator()
@@ -355,6 +364,7 @@ class Models:
         usage_stats: TokenUsage,
         latency: float,
         output: Any,
+        stop_reason: Optional[str] = None,
     ):
         # Prepare standardized event data
         formatted_input = self._format_input(contents, **kwargs)
@@ -374,6 +384,7 @@ class Models:
             properties=properties,
             privacy_mode=privacy_mode,
             groups=groups,
+            stop_reason=stop_reason,
         )
 
         # Use the common capture function

--- a/posthog/ai/gemini/gemini_async.py
+++ b/posthog/ai/gemini/gemini_async.py
@@ -22,6 +22,7 @@ from posthog.ai.utils import (
 from posthog.ai.gemini.gemini_converter import (
     extract_gemini_usage_from_chunk,
     extract_gemini_content_from_chunk,
+    extract_gemini_stop_reason_from_chunk,
     format_gemini_streaming_output,
 )
 from posthog.ai.sanitization import sanitize_gemini
@@ -298,6 +299,7 @@ class AsyncModels:
         start_time = time.time()
         usage_stats: TokenUsage = TokenUsage(input_tokens=0, output_tokens=0)
         accumulated_content = []
+        stop_reason: Optional[str] = None
 
         kwargs_without_stream = {"model": model, "contents": contents, **kwargs}
         response = await self._client.aio.models.generate_content_stream(
@@ -307,6 +309,7 @@ class AsyncModels:
         async def async_generator():
             nonlocal usage_stats
             nonlocal accumulated_content
+            nonlocal stop_reason
 
             try:
                 async for chunk in response:
@@ -322,6 +325,11 @@ class AsyncModels:
 
                     if content_block is not None:
                         accumulated_content.append(content_block)
+
+                    # Extract stop reason from chunk
+                    chunk_stop_reason = extract_gemini_stop_reason_from_chunk(chunk)
+                    if chunk_stop_reason is not None:
+                        stop_reason = chunk_stop_reason
 
                     yield chunk
 
@@ -341,6 +349,7 @@ class AsyncModels:
                     usage_stats,
                     latency,
                     accumulated_content,
+                    stop_reason=stop_reason,
                 )
 
         return async_generator()
@@ -358,6 +367,7 @@ class AsyncModels:
         usage_stats: TokenUsage,
         latency: float,
         output: Any,
+        stop_reason: Optional[str] = None,
     ):
         # Prepare standardized event data
         formatted_input = self._format_input(contents, **kwargs)
@@ -377,6 +387,7 @@ class AsyncModels:
             properties=properties,
             privacy_mode=privacy_mode,
             groups=groups,
+            stop_reason=stop_reason,
         )
 
         # Use the common capture function

--- a/posthog/ai/gemini/gemini_converter.py
+++ b/posthog/ai/gemini/gemini_converter.py
@@ -287,6 +287,31 @@ def format_gemini_response(response: Any) -> List[FormattedMessage]:
     return output
 
 
+def extract_gemini_stop_reason(response: Any) -> Optional[str]:
+    """Extract stop reason from Gemini response."""
+    if response and hasattr(response, "candidates") and response.candidates:
+        candidate = response.candidates[0]
+        finish_reason = getattr(candidate, "finish_reason", None)
+        if finish_reason is not None:
+            # Gemini uses enum values — convert to string name
+            if hasattr(finish_reason, "name"):
+                return finish_reason.name
+            return str(finish_reason)
+    return None
+
+
+def extract_gemini_stop_reason_from_chunk(chunk: Any) -> Optional[str]:
+    """Extract stop reason from a Gemini streaming chunk."""
+    if chunk and hasattr(chunk, "candidates") and chunk.candidates:
+        candidate = chunk.candidates[0]
+        finish_reason = getattr(candidate, "finish_reason", None)
+        if finish_reason is not None:
+            if hasattr(finish_reason, "name"):
+                return finish_reason.name
+            return str(finish_reason)
+    return None
+
+
 def extract_gemini_system_instruction(config: Any) -> Optional[str]:
     """
     Extract system instruction from Gemini config parameter.

--- a/posthog/ai/gemini/gemini_converter.py
+++ b/posthog/ai/gemini/gemini_converter.py
@@ -302,14 +302,7 @@ def extract_gemini_stop_reason(response: Any) -> Optional[str]:
 
 def extract_gemini_stop_reason_from_chunk(chunk: Any) -> Optional[str]:
     """Extract stop reason from a Gemini streaming chunk."""
-    if chunk and hasattr(chunk, "candidates") and chunk.candidates:
-        candidate = chunk.candidates[0]
-        finish_reason = getattr(candidate, "finish_reason", None)
-        if finish_reason is not None:
-            if hasattr(finish_reason, "name"):
-                return finish_reason.name
-            return str(finish_reason)
-    return None
+    return extract_gemini_stop_reason(chunk)
 
 
 def extract_gemini_system_instruction(config: Any) -> Optional[str]:

--- a/posthog/ai/langchain/callbacks.py
+++ b/posthog/ai/langchain/callbacks.py
@@ -629,6 +629,15 @@ class CallbackHandler(BaseCallbackHandler):
                 self._ph_client, self._privacy_mode, completions
             )
 
+            # Extract stop reason from generation info
+            if output.generations and output.generations[-1]:
+                last_gen = output.generations[-1][-1]
+                gen_info = getattr(last_gen, "generation_info", None)
+                if isinstance(gen_info, dict):
+                    finish_reason = gen_info.get("finish_reason")
+                    if finish_reason is not None:
+                        event_properties["$ai_stop_reason"] = finish_reason
+
         self._ph_client.capture(
             distinct_id=self._distinct_id or trace_id,
             event="$ai_generation",

--- a/posthog/ai/openai/openai.py
+++ b/posthog/ai/openai/openai.py
@@ -125,12 +125,14 @@ class WrappedResponses:
         usage_stats: TokenUsage = TokenUsage()
         final_content = []
         model_from_response: Optional[str] = None
+        stop_reason: Optional[str] = None
         response = self._original.create(**kwargs)
 
         def generator():
             nonlocal usage_stats
             nonlocal final_content  # noqa: F824
             nonlocal model_from_response
+            nonlocal stop_reason
 
             try:
                 for chunk in response:
@@ -153,6 +155,17 @@ class WrappedResponses:
                     if content is not None:
                         final_content.append(content)
 
+                    # Capture stop reason from response.completed event
+                    if (
+                        hasattr(chunk, "type")
+                        and chunk.type == "response.completed"
+                        and hasattr(chunk, "response")
+                        and chunk.response
+                    ):
+                        chunk_status = getattr(chunk.response, "status", None)
+                        if chunk_status is not None:
+                            stop_reason = chunk_status
+
                     yield chunk
 
             finally:
@@ -171,6 +184,7 @@ class WrappedResponses:
                     output,
                     None,  # Responses API doesn't have tools
                     model_from_response,
+                    stop_reason=stop_reason,
                 )
 
         return generator()
@@ -188,6 +202,7 @@ class WrappedResponses:
         output: Any,
         available_tool_calls: Optional[List[Dict[str, Any]]] = None,
         model_from_response: Optional[str] = None,
+        stop_reason: Optional[str] = None,
     ):
         from posthog.ai.types import StreamingEventData
         from posthog.ai.openai.openai_converter import (
@@ -217,6 +232,7 @@ class WrappedResponses:
             properties=posthog_properties,
             privacy_mode=posthog_privacy_mode,
             groups=posthog_groups,
+            stop_reason=stop_reason,
         )
 
         # Use the common capture function
@@ -335,6 +351,7 @@ class WrappedCompletions:
         accumulated_content = []
         accumulated_tool_calls: Dict[int, Dict[str, Any]] = {}
         model_from_response: Optional[str] = None
+        stop_reason: Optional[str] = None
         if "stream_options" not in kwargs:
             kwargs["stream_options"] = {}
         kwargs["stream_options"]["include_usage"] = True
@@ -345,6 +362,7 @@ class WrappedCompletions:
             nonlocal accumulated_content  # noqa: F824
             nonlocal accumulated_tool_calls
             nonlocal model_from_response
+            nonlocal stop_reason
 
             try:
                 for chunk in response:
@@ -370,6 +388,14 @@ class WrappedCompletions:
                         accumulate_openai_tool_calls(
                             accumulated_tool_calls, chunk_tool_calls
                         )
+
+                    # Capture stop reason from chunk
+                    if (
+                        hasattr(chunk, "choices")
+                        and chunk.choices
+                        and getattr(chunk.choices[0], "finish_reason", None) is not None
+                    ):
+                        stop_reason = chunk.choices[0].finish_reason
 
                     yield chunk
 
@@ -397,6 +423,7 @@ class WrappedCompletions:
                     tool_calls_list,
                     extract_available_tool_calls("openai", kwargs),
                     model_from_response,
+                    stop_reason=stop_reason,
                 )
 
         return generator()
@@ -415,6 +442,7 @@ class WrappedCompletions:
         tool_calls: Optional[List[Dict[str, Any]]] = None,
         available_tool_calls: Optional[List[Dict[str, Any]]] = None,
         model_from_response: Optional[str] = None,
+        stop_reason: Optional[str] = None,
     ):
         from posthog.ai.types import StreamingEventData
         from posthog.ai.openai.openai_converter import (
@@ -444,6 +472,7 @@ class WrappedCompletions:
             properties=posthog_properties,
             privacy_mode=posthog_privacy_mode,
             groups=posthog_groups,
+            stop_reason=stop_reason,
         )
 
         # Use the common capture function

--- a/posthog/ai/openai/openai_async.py
+++ b/posthog/ai/openai/openai_async.py
@@ -129,12 +129,14 @@ class WrappedResponses:
         usage_stats: TokenUsage = TokenUsage()
         final_content = []
         model_from_response: Optional[str] = None
+        stop_reason: Optional[str] = None
         response = await self._original.create(**kwargs)
 
         async def async_generator():
             nonlocal usage_stats
             nonlocal final_content  # noqa: F824
             nonlocal model_from_response
+            nonlocal stop_reason
 
             try:
                 async for chunk in response:
@@ -157,6 +159,17 @@ class WrappedResponses:
                     if content is not None:
                         final_content.append(content)
 
+                    # Capture stop reason from response.completed event
+                    if (
+                        hasattr(chunk, "type")
+                        and chunk.type == "response.completed"
+                        and hasattr(chunk, "response")
+                        and chunk.response
+                    ):
+                        chunk_status = getattr(chunk.response, "status", None)
+                        if chunk_status is not None:
+                            stop_reason = chunk_status
+
                     yield chunk
 
             finally:
@@ -176,6 +189,7 @@ class WrappedResponses:
                     output,
                     extract_available_tool_calls("openai", kwargs),
                     model_from_response,
+                    stop_reason=stop_reason,
                 )
 
         return async_generator()
@@ -193,6 +207,7 @@ class WrappedResponses:
         output: Any,
         available_tool_calls: Optional[List[Dict[str, Any]]] = None,
         model_from_response: Optional[str] = None,
+        stop_reason: Optional[str] = None,
     ):
         if posthog_trace_id is None:
             posthog_trace_id = str(uuid.uuid4())
@@ -235,6 +250,9 @@ class WrappedResponses:
             and web_search_count > 0
         ):
             event_properties["$ai_web_search_count"] = web_search_count
+
+        if stop_reason is not None:
+            event_properties["$ai_stop_reason"] = stop_reason
 
         if available_tool_calls:
             event_properties["$ai_tools"] = available_tool_calls
@@ -365,6 +383,7 @@ class WrappedCompletions:
         accumulated_content = []
         accumulated_tool_calls: Dict[int, Dict[str, Any]] = {}
         model_from_response: Optional[str] = None
+        stop_reason: Optional[str] = None
 
         if "stream_options" not in kwargs:
             kwargs["stream_options"] = {}
@@ -376,6 +395,7 @@ class WrappedCompletions:
             nonlocal accumulated_content  # noqa: F824
             nonlocal accumulated_tool_calls
             nonlocal model_from_response
+            nonlocal stop_reason
 
             try:
                 async for chunk in response:
@@ -399,6 +419,14 @@ class WrappedCompletions:
                         accumulate_openai_tool_calls(
                             accumulated_tool_calls, chunk_tool_calls
                         )
+
+                    # Capture stop reason from chunk
+                    if (
+                        hasattr(chunk, "choices")
+                        and chunk.choices
+                        and getattr(chunk.choices[0], "finish_reason", None) is not None
+                    ):
+                        stop_reason = chunk.choices[0].finish_reason
 
                     yield chunk
 
@@ -426,6 +454,7 @@ class WrappedCompletions:
                     tool_calls_list,
                     extract_available_tool_calls("openai", kwargs),
                     model_from_response,
+                    stop_reason=stop_reason,
                 )
 
         return async_generator()
@@ -444,6 +473,7 @@ class WrappedCompletions:
         tool_calls: Optional[List[Dict[str, Any]]] = None,
         available_tool_calls: Optional[List[Dict[str, Any]]] = None,
         model_from_response: Optional[str] = None,
+        stop_reason: Optional[str] = None,
     ):
         if posthog_trace_id is None:
             posthog_trace_id = str(uuid.uuid4())
@@ -487,6 +517,9 @@ class WrappedCompletions:
             and web_search_count > 0
         ):
             event_properties["$ai_web_search_count"] = web_search_count
+
+        if stop_reason is not None:
+            event_properties["$ai_stop_reason"] = stop_reason
 
         if available_tool_calls:
             event_properties["$ai_tools"] = available_tool_calls

--- a/posthog/ai/openai/openai_converter.py
+++ b/posthog/ai/openai/openai_converter.py
@@ -369,6 +369,17 @@ def extract_openai_web_search_count(response: Any) -> int:
     return 0
 
 
+def extract_openai_stop_reason(response: Any) -> Optional[str]:
+    """Extract stop reason from OpenAI response."""
+    # Chat Completions API
+    if hasattr(response, "choices") and response.choices:
+        return getattr(response.choices[0], "finish_reason", None)
+    # Responses API
+    if hasattr(response, "status"):
+        return getattr(response, "status", None)
+    return None
+
+
 def extract_openai_usage_from_response(response: Any) -> TokenUsage:
     """
     Extract usage statistics from a full OpenAI response (non-streaming).

--- a/posthog/ai/openai_agents/processor.py
+++ b/posthog/ai/openai_agents/processor.py
@@ -549,6 +549,13 @@ class PostHogTracingProcessor(TracingProcessor):
                 "cache_creation_input_tokens"
             ]
 
+        # Extract stop reason from response if available
+        response = getattr(span_data, "response", None)
+        if response is not None:
+            finish_reason = getattr(response, "finish_reason", None)
+            if finish_reason is not None:
+                properties["$ai_stop_reason"] = finish_reason
+
         self._capture_event("$ai_generation", properties, distinct_id)
 
     def _handle_function_span(
@@ -703,6 +710,11 @@ class PostHogTracingProcessor(TracingProcessor):
                 properties["$ai_output_choices"] = self._with_privacy_mode(
                     _ensure_serializable(output_items)
                 )
+
+            # Extract stop reason (status) from response
+            status = getattr(response, "status", None)
+            if status is not None:
+                properties["$ai_stop_reason"] = status
 
         self._capture_event("$ai_generation", properties, distinct_id)
 

--- a/posthog/ai/types.py
+++ b/posthog/ai/types.py
@@ -124,3 +124,4 @@ class StreamingEventData(TypedDict):
     properties: Optional[Dict[str, Any]]
     privacy_mode: bool
     groups: Optional[Dict[str, Any]]
+    stop_reason: Optional[str]

--- a/posthog/ai/utils.py
+++ b/posthog/ai/utils.py
@@ -240,7 +240,9 @@ def extract_stop_reason(response: Any, provider: str) -> Optional[str]:
 
         return extract_openai_stop_reason(response)
     elif provider == "anthropic":
-        from posthog.ai.anthropic.anthropic_converter import extract_anthropic_stop_reason
+        from posthog.ai.anthropic.anthropic_converter import (
+            extract_anthropic_stop_reason,
+        )
 
         return extract_anthropic_stop_reason(response)
     elif provider == "gemini":

--- a/posthog/ai/utils.py
+++ b/posthog/ai/utils.py
@@ -233,6 +233,23 @@ def format_response(response, provider: str):
     return []
 
 
+def extract_stop_reason(response: Any, provider: str) -> Optional[str]:
+    """Extract stop reason from response based on provider."""
+    if provider == "openai":
+        from posthog.ai.openai.openai_converter import extract_openai_stop_reason
+
+        return extract_openai_stop_reason(response)
+    elif provider == "anthropic":
+        from posthog.ai.anthropic.anthropic_converter import extract_anthropic_stop_reason
+
+        return extract_anthropic_stop_reason(response)
+    elif provider == "gemini":
+        from posthog.ai.gemini.gemini_converter import extract_gemini_stop_reason
+
+        return extract_gemini_stop_reason(response)
+    return None
+
+
 def extract_available_tool_calls(provider: str, kwargs: Dict[str, Any]):
     """
     Extract available tool calls for the given provider.
@@ -431,6 +448,10 @@ def call_llm_and_track_usage(
                 # Already serialized by converters
                 tag("$ai_usage", raw_usage)
 
+            stop_reason = extract_stop_reason(response, provider)
+            if stop_reason is not None:
+                tag("$ai_stop_reason", stop_reason)
+
             if not has_person_distinct_id:
                 tag("$process_person_profile", False)
 
@@ -575,6 +596,10 @@ async def call_llm_and_track_usage_async(
             if raw_usage is not None:
                 # Already serialized by converters
                 tag("$ai_usage", raw_usage)
+
+            stop_reason = extract_stop_reason(response, provider)
+            if stop_reason is not None:
+                tag("$ai_stop_reason", stop_reason)
 
             if not has_person_distinct_id:
                 tag("$process_person_profile", False)
@@ -732,6 +757,11 @@ def capture_streaming_event(
     if raw_usage is not None:
         # Already serialized by converters
         event_properties["$ai_usage"] = raw_usage
+
+    # Add stop reason if present
+    stop_reason = event_data.get("stop_reason")
+    if stop_reason is not None:
+        event_properties["$ai_stop_reason"] = stop_reason
 
     # Handle provider-specific fields
     if (

--- a/posthog/test/ai/anthropic/test_anthropic.py
+++ b/posthog/test/ai/anthropic/test_anthropic.py
@@ -1,4 +1,5 @@
 import json
+import os
 from unittest.mock import patch
 
 import pytest
@@ -1401,3 +1402,22 @@ def test_explicit_distinct_id_overrides_outer_context(
 
         call_args = mock_client.capture.call_args[1]
         assert call_args["distinct_id"] == "explicit-user-789"
+
+
+ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY")
+
+
+@pytest.mark.skipif(not ANTHROPIC_API_KEY, reason="ANTHROPIC_API_KEY is not set")
+def test_integration_stop_reason(mock_client):
+    client = Anthropic(api_key=ANTHROPIC_API_KEY, posthog_client=mock_client)
+    client.messages.create(
+        model="claude-sonnet-4-20250514",
+        messages=[{"role": "user", "content": "Say hi"}],
+        max_tokens=5,
+        posthog_distinct_id="test-id",
+    )
+
+    props = mock_client.capture.call_args[1]["properties"]
+    assert props["$ai_stop_reason"] in ("end_turn", "max_tokens")
+    assert props["$ai_provider"] == "anthropic"
+    assert props["$ai_input_tokens"] > 0

--- a/posthog/test/ai/anthropic/test_anthropic.py
+++ b/posthog/test/ai/anthropic/test_anthropic.py
@@ -308,6 +308,7 @@ def test_basic_completion(mock_client, mock_anthropic_response):
         assert props["$ai_output_tokens"] == 10
         assert props["$ai_http_status"] == 200
         assert props["foo"] == "bar"
+        assert props["$ai_stop_reason"] == "end_turn"
         assert props["$ai_tokens_source"] == "sdk"
         assert isinstance(props["$ai_latency"], float)
         # Verify raw usage metadata is passed for backend processing

--- a/posthog/test/ai/gemini/test_gemini.py
+++ b/posthog/test/ai/gemini/test_gemini.py
@@ -46,6 +46,9 @@ def mock_gemini_response():
 
     mock_candidate = MagicMock()
     mock_candidate.text = "Test response from Gemini"
+    mock_finish_reason = MagicMock()
+    mock_finish_reason.name = "STOP"
+    mock_candidate.finish_reason = mock_finish_reason
     mock_content = MagicMock()
     mock_part = MagicMock()
     mock_part.text = "Test response from Gemini"
@@ -196,6 +199,7 @@ def test_new_client_basic_generation(
     assert props["foo"] == "bar"
     assert "$ai_trace_id" in props
     assert props["$ai_latency"] > 0
+    assert props["$ai_stop_reason"] == "STOP"
     # Verify raw usage metadata is passed for backend processing
     assert "$ai_usage" in props
     assert props["$ai_usage"] is not None
@@ -1161,3 +1165,124 @@ def test_empty_array_grounding_metadata_no_web_search(
     assert "$ai_web_search_count" not in props
     assert props["$ai_input_tokens"] == 15
     assert props["$ai_output_tokens"] == 12
+
+
+def test_stop_reason_captured(mock_client, mock_google_genai_client):
+    mock_response = MagicMock()
+    mock_response.text = "Test"
+
+    mock_usage = MagicMock()
+    mock_usage.prompt_token_count = 10
+    mock_usage.candidates_token_count = 5
+    mock_usage.cached_content_token_count = 0
+    mock_usage.thoughts_token_count = 0
+    mock_usage.model_dump.return_value = {
+        "prompt_token_count": 10,
+        "candidates_token_count": 5,
+    }
+    mock_response.usage_metadata = mock_usage
+
+    mock_candidate = MagicMock()
+    mock_candidate.finish_reason = MagicMock()
+    mock_candidate.finish_reason.name = "STOP"
+    mock_candidate.content = MagicMock()
+    mock_candidate.content.parts = [MagicMock(text="Test")]
+    mock_response.candidates = [mock_candidate]
+
+    mock_google_genai_client.models.generate_content.return_value = mock_response
+
+    client = Client(api_key="test-key", posthog_client=mock_client)
+    client.models.generate_content(
+        model="gemini-2.0-flash",
+        contents=["Hello"],
+        posthog_distinct_id="test-id",
+    )
+
+    assert mock_client.capture.call_count == 1
+    props = mock_client.capture.call_args[1]["properties"]
+    assert props["$ai_stop_reason"] == "STOP"
+
+
+def test_stop_reason_max_tokens(mock_client, mock_google_genai_client):
+    mock_response = MagicMock()
+    mock_response.text = "Truncated"
+
+    mock_usage = MagicMock()
+    mock_usage.prompt_token_count = 10
+    mock_usage.candidates_token_count = 5
+    mock_usage.cached_content_token_count = 0
+    mock_usage.thoughts_token_count = 0
+    mock_usage.model_dump.return_value = {
+        "prompt_token_count": 10,
+        "candidates_token_count": 5,
+    }
+    mock_response.usage_metadata = mock_usage
+
+    mock_candidate = MagicMock()
+    mock_candidate.finish_reason = MagicMock()
+    mock_candidate.finish_reason.name = "MAX_TOKENS"
+    mock_candidate.content = MagicMock()
+    mock_candidate.content.parts = [MagicMock(text="Truncated")]
+    mock_response.candidates = [mock_candidate]
+
+    mock_google_genai_client.models.generate_content.return_value = mock_response
+
+    client = Client(api_key="test-key", posthog_client=mock_client)
+    client.models.generate_content(
+        model="gemini-2.0-flash",
+        contents=["Hello"],
+        posthog_distinct_id="test-id",
+    )
+
+    props = mock_client.capture.call_args[1]["properties"]
+    assert props["$ai_stop_reason"] == "MAX_TOKENS"
+
+
+def test_stop_reason_streaming(mock_client, mock_google_genai_client):
+    def mock_streaming_response():
+        mock_chunk1 = MagicMock()
+        mock_chunk1.text = "Hello "
+        mock_usage1 = MagicMock()
+        mock_usage1.prompt_token_count = 10
+        mock_usage1.candidates_token_count = 5
+        mock_usage1.cached_content_token_count = 0
+        mock_usage1.thoughts_token_count = 0
+        mock_chunk1.usage_metadata = mock_usage1
+        # No candidates with finish_reason on first chunk
+        mock_chunk1.candidates = []
+
+        mock_chunk2 = MagicMock()
+        mock_chunk2.text = "world!"
+        mock_usage2 = MagicMock()
+        mock_usage2.prompt_token_count = 10
+        mock_usage2.candidates_token_count = 10
+        mock_usage2.cached_content_token_count = 0
+        mock_usage2.thoughts_token_count = 0
+        mock_chunk2.usage_metadata = mock_usage2
+        # Final chunk has finish_reason
+        mock_candidate = MagicMock()
+        mock_candidate.finish_reason = MagicMock()
+        mock_candidate.finish_reason.name = "STOP"
+        mock_candidate.content = MagicMock()
+        mock_candidate.content.parts = [MagicMock(text="world!")]
+        mock_chunk2.candidates = [mock_candidate]
+
+        yield mock_chunk1
+        yield mock_chunk2
+
+    mock_google_genai_client.models.generate_content_stream.return_value = (
+        mock_streaming_response()
+    )
+
+    client = Client(api_key="test-key", posthog_client=mock_client)
+    response = client.models.generate_content_stream(
+        model="gemini-2.0-flash",
+        contents=["Hello"],
+        posthog_distinct_id="test-id",
+    )
+
+    list(response)
+
+    assert mock_client.capture.call_count == 1
+    props = mock_client.capture.call_args[1]["properties"]
+    assert props["$ai_stop_reason"] == "STOP"

--- a/posthog/test/ai/gemini/test_gemini.py
+++ b/posthog/test/ai/gemini/test_gemini.py
@@ -1,4 +1,5 @@
 import json
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -1286,3 +1287,22 @@ def test_stop_reason_streaming(mock_client, mock_google_genai_client):
     assert mock_client.capture.call_count == 1
     props = mock_client.capture.call_args[1]["properties"]
     assert props["$ai_stop_reason"] == "STOP"
+
+
+GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
+
+
+@pytest.mark.skipif(not GEMINI_API_KEY, reason="GEMINI_API_KEY is not set")
+def test_integration_stop_reason(mock_client):
+    client = Client(api_key=GEMINI_API_KEY, posthog_client=mock_client)
+    client.models.generate_content(
+        model="gemini-2.0-flash",
+        contents="Say hi",
+        posthog_distinct_id="test-id",
+    )
+
+    props = mock_client.capture.call_args[1]["properties"]
+    assert props["$ai_stop_reason"] is not None
+    assert isinstance(props["$ai_stop_reason"], str)
+    assert props["$ai_provider"] == "gemini"
+    assert props["$ai_input_tokens"] > 0

--- a/posthog/test/ai/gemini/test_gemini.py
+++ b/posthog/test/ai/gemini/test_gemini.py
@@ -1168,9 +1168,18 @@ def test_empty_array_grounding_metadata_no_web_search(
     assert props["$ai_output_tokens"] == 12
 
 
-def test_stop_reason_captured(mock_client, mock_google_genai_client):
+@pytest.mark.parametrize(
+    "finish_reason_name,response_text",
+    [
+        ("STOP", "Test"),
+        ("MAX_TOKENS", "Truncated"),
+    ],
+)
+def test_stop_reason_captured(
+    mock_client, mock_google_genai_client, finish_reason_name, response_text
+):
     mock_response = MagicMock()
-    mock_response.text = "Test"
+    mock_response.text = response_text
 
     mock_usage = MagicMock()
     mock_usage.prompt_token_count = 10
@@ -1185,45 +1194,9 @@ def test_stop_reason_captured(mock_client, mock_google_genai_client):
 
     mock_candidate = MagicMock()
     mock_candidate.finish_reason = MagicMock()
-    mock_candidate.finish_reason.name = "STOP"
+    mock_candidate.finish_reason.name = finish_reason_name
     mock_candidate.content = MagicMock()
-    mock_candidate.content.parts = [MagicMock(text="Test")]
-    mock_response.candidates = [mock_candidate]
-
-    mock_google_genai_client.models.generate_content.return_value = mock_response
-
-    client = Client(api_key="test-key", posthog_client=mock_client)
-    client.models.generate_content(
-        model="gemini-2.0-flash",
-        contents=["Hello"],
-        posthog_distinct_id="test-id",
-    )
-
-    assert mock_client.capture.call_count == 1
-    props = mock_client.capture.call_args[1]["properties"]
-    assert props["$ai_stop_reason"] == "STOP"
-
-
-def test_stop_reason_max_tokens(mock_client, mock_google_genai_client):
-    mock_response = MagicMock()
-    mock_response.text = "Truncated"
-
-    mock_usage = MagicMock()
-    mock_usage.prompt_token_count = 10
-    mock_usage.candidates_token_count = 5
-    mock_usage.cached_content_token_count = 0
-    mock_usage.thoughts_token_count = 0
-    mock_usage.model_dump.return_value = {
-        "prompt_token_count": 10,
-        "candidates_token_count": 5,
-    }
-    mock_response.usage_metadata = mock_usage
-
-    mock_candidate = MagicMock()
-    mock_candidate.finish_reason = MagicMock()
-    mock_candidate.finish_reason.name = "MAX_TOKENS"
-    mock_candidate.content = MagicMock()
-    mock_candidate.content.parts = [MagicMock(text="Truncated")]
+    mock_candidate.content.parts = [MagicMock(text=response_text)]
     mock_response.candidates = [mock_candidate]
 
     mock_google_genai_client.models.generate_content.return_value = mock_response
@@ -1236,7 +1209,7 @@ def test_stop_reason_max_tokens(mock_client, mock_google_genai_client):
     )
 
     props = mock_client.capture.call_args[1]["properties"]
-    assert props["$ai_stop_reason"] == "MAX_TOKENS"
+    assert props["$ai_stop_reason"] == finish_reason_name
 
 
 def test_stop_reason_streaming(mock_client, mock_google_genai_client):

--- a/posthog/test/ai/langchain/test_callbacks.py
+++ b/posthog/test/ai/langchain/test_callbacks.py
@@ -894,6 +894,7 @@ def test_openai_chain(mock_client):
     )
     assert gen_props["$ai_input_tokens"] == 20
     assert gen_props["$ai_output_tokens"] == 1
+    assert gen_props["$ai_stop_reason"] == "stop"
 
 
 @pytest.mark.skipif(not OPENAI_API_KEY, reason="OpenAI API key not set")
@@ -1172,6 +1173,7 @@ def test_anthropic_chain(mock_client):
     )
     assert gen_props["$ai_input_tokens"] == 17
     assert gen_props["$ai_output_tokens"] == 4
+    assert gen_props["$ai_stop_reason"] == "end_turn"
 
     assert trace_args["event"] == "$ai_trace"
     assert trace_props["$ai_input_state"] == {}

--- a/posthog/test/ai/openai/test_openai.py
+++ b/posthog/test/ai/openai/test_openai.py
@@ -496,6 +496,7 @@ def test_basic_completion(mock_client, mock_openai_response):
         assert props["$ai_output_tokens"] == 10
         assert props["$ai_http_status"] == 200
         assert props["foo"] == "bar"
+        assert props["$ai_stop_reason"] == "stop"
         assert isinstance(props["$ai_latency"], float)
         # Verify raw usage metadata is passed for backend processing
         assert "$ai_usage" in props
@@ -978,6 +979,7 @@ def test_responses_api(mock_client, mock_openai_response_with_responses_api):
         assert props["$ai_reasoning_tokens"] == 15
         assert props["$ai_http_status"] == 200
         assert props["foo"] == "bar"
+        assert props["$ai_stop_reason"] == "completed"
         assert isinstance(props["$ai_latency"], float)
 
 

--- a/posthog/test/ai/openai/test_openai.py
+++ b/posthog/test/ai/openai/test_openai.py
@@ -1,4 +1,5 @@
 import json
+import os
 import time
 from unittest.mock import AsyncMock, patch
 
@@ -2154,3 +2155,22 @@ async def test_async_streaming_responses_extracts_model_from_response(mock_clien
     props = call_args["properties"]
 
     assert props["$ai_model"] == "gpt-4o-mini-async-stored"
+
+
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+
+
+@pytest.mark.skipif(not OPENAI_API_KEY, reason="OPENAI_API_KEY is not set")
+def test_integration_stop_reason(mock_client):
+    client = OpenAI(api_key=OPENAI_API_KEY, posthog_client=mock_client)
+    client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "Say hi"}],
+        max_tokens=5,
+        posthog_distinct_id="test-id",
+    )
+
+    props = mock_client.capture.call_args[1]["properties"]
+    assert props["$ai_stop_reason"] in ("stop", "length")
+    assert props["$ai_provider"] == "openai"
+    assert props["$ai_input_tokens"] > 0


### PR DESCRIPTION
## Problem

LLM analytics users cannot filter or analyze why model responses ended. The finish/stop reason was never extracted from provider responses in the Python SDK.

## Changes

- New extractor functions for OpenAI (`choices[0].finish_reason` / `status`), Anthropic (`stop_reason`), and Gemini (`candidates[0].finish_reason`)
- Wired into both sync and async `call_llm_and_track_usage` and `capture_streaming_event`
- Streaming support for all three providers (captures from final chunk)
- LangChain, OpenAI Agents SDK, and Claude Agent SDK support
- Added `stop_reason` field to `StreamingEventData` TypedDict
- Tests for Gemini (non-streaming, max_tokens, streaming), OpenAI, and Anthropic
- Integration tests for all three providers (API-key gated)
