### PR TITLE
fix(compliance): declare capabilities in health endpoint

### DIFF
--- a/sdk_compliance_adapter/adapter.py
+++ b/sdk_compliance_adapter/adapter.py
@@ -196,6 +196,7 @@ def health():
             "sdk_name": "posthog-python",
             "sdk_version": VERSION,
             "adapter_version": "1.0.0",
+            "capabilities": ["capture_v0", "encoding_gzip"],
         }
     )
 


### PR DESCRIPTION
## Problem
The SDK compliance test harness reads a `capabilities` array from the adapter's `/health` endpoint to determine which test suites to run. Without this field, all suites are skipped, resulting in 0/0 tests passing on every PR.

## Changes
Added `capabilities: ["capture_v0", "encoding_gzip"]` to the `/health` response, unlocking the capture and gzip compression test suites.

## Testing
- Verified on #500 that the compliance tests now discover and run tests after this change