### PR TITLE
chore: update branch references to main

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: 'CodeQL Advanced'
 
 on:
   push:
-    branches: ['master']
+    branches: ['main']
   pull_request:
-    branches: ['master']
+    branches: ['main']
   schedule:
     - cron: '32 13 * * 1'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: "Release"
 on:
   pull_request:
     types: [closed]
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -19,7 +19,7 @@ jobs:
   check-release-label:
     name: Check for release label
     runs-on: ubuntu-latest
-    # Run when PR with 'release' label is merged to master
+    # Run when PR with 'release' label is merged to main
     if: |
       github.event_name == 'workflow_dispatch' ||
        (github.event_name == 'pull_request' &&
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: master
+          ref: main
           fetch-depth: 0
 
       - name: Check release conditions
@@ -91,7 +91,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: master
+          ref: main
           fetch-depth: 0
           token: ${{ steps.releaser.outputs.token }}
 
@@ -147,7 +147,7 @@ jobs:
         with:
           commit_message: "chore: Release v${{ steps.sampo-release.outputs.new_version }}"
           repo: ${{ github.repository }}
-          branch: master
+          branch: main
         env:
           GITHUB_TOKEN: ${{ steps.releaser.outputs.token }}
 
@@ -199,7 +199,7 @@ jobs:
         if: steps.commit-release.outputs.commit-hash != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow run generate-references.yml --ref master
+        run: gh workflow run generate-references.yml --ref main
 
       # Notify in case of a failure
       - name: Send failure event to PostHog

--- a/.github/workflows/sdk-compliance.yml
+++ b/.github/workflows/sdk-compliance.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   compliance:

--- a/.sampo/config.toml
+++ b/.sampo/config.toml
@@ -2,7 +2,7 @@
 version = 1
 
 [git]
-default_branch = "master"
+default_branch = "main"
 short_tags = "posthog"    # Tag with v1.2.3 rather than posthog-v1.2.3
 
 [github]


### PR DESCRIPTION
## :bulb: Motivation and Context
This repo was still using `master` as the default branch. This updates the workflow, release references, and Sampo config that still pointed at `master` so the repository can use `main` consistently.

## :green_heart: How did you test it?
- Ran `git diff --check`
- Searched the repo for remaining branch-name references with `rg --hidden '\bmaster\b'`

## :pencil: Checklist
- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file
- [ ] Added the `release` label to the PR