### PR TITLE
chore: use engineering@posthog.com in package metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ build-backend = "setuptools.build_meta"
 name = "posthog"
 version = "7.11.2"
 description = "Integrate PostHog into any python application."
-authors = [{ name = "PostHog", email = "hey@posthog.com" }]
-maintainers = [{ name = "PostHog", email = "hey@posthog.com" }]
+authors = [{ name = "PostHog", email = "engineering@posthog.com" }]
+maintainers = [{ name = "PostHog", email = "engineering@posthog.com" }]
 license = { text = "MIT" }
 readme = "README.md"
 requires-python = ">=3.10"

--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,9 @@ setup(
     # Basic fields for backward compatibility
     url="https://github.com/posthog/posthog-python",
     author="Posthog",
-    author_email="hey@posthog.com",
+    author_email="engineering@posthog.com",
     maintainer="PostHog",
-    maintainer_email="hey@posthog.com",
+    maintainer_email="engineering@posthog.com",
     license="MIT License",
     description="Integrate PostHog into any python application.",
     long_description=long_description,


### PR DESCRIPTION
## :bulb: Motivation and Context

Python package metadata still uses `hey@posthog.com` for author and maintainer fields. This updates the published package metadata to use the shared `engineering@posthog.com` address instead.

## :green_heart: How did you test it?

- Verified `pyproject.toml` and `setup.py` now use `engineering@posthog.com`
- Confirmed there are no other non-`engineering@posthog.com` `@posthog.com` addresses in package metadata files in this repo

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file
- [ ] Added the `release` label to the PR
