### PR TITLE
docs: fix python release docs package registry

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,10 +1,10 @@
 # Releasing
 
-This repository uses [Sampo](https://github.com/bruits/sampo) for versioning, changelogs, and publishing to crates.io.
+This repository uses [Sampo](https://github.com/bruits/sampo) for versioning and changelog generation, with GitHub Actions publishing packages to PyPI.
 
 1. When making changes, include a changeset: `sampo add`
 2. Create a PR with your changes and the changeset file
 3. Add the `release` label and merge to `main`
-4. Approve the release in Slack when prompted — this triggers version bump, crates.io publish, git tag, and GitHub Release
+4. Approve the release in Slack when prompted — this triggers the version bump, publishes both `posthog` and the `posthoganalytics` mirror package to PyPI, creates a git tag, and creates a GitHub Release
 
 You can also trigger a release manually via the workflow's `workflow_dispatch` trigger (still requires pending changesets).


### PR DESCRIPTION
## :bulb: Motivation and Context
The Python SDK release docs currently say releases publish to crates.io, which is incorrect for this repository. That makes the release process confusing for anyone trying to ship a Python SDK change.

## :green_heart: How did you test it?
- Re-read `RELEASING.md` after the edit to confirm it now references PyPI
- Cross-checked the wording against `.github/workflows/release.yml`, which publishes `posthog` and `posthoganalytics` to PyPI

## :pencil: Checklist
- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file
- [ ] Added the `release` label to the PR

<!-- For more details check RELEASING.md -->
