### PR TITLE
chore: reduce Dependabot PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,8 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
       time: "10:00"
       timezone: "UTC"
     groups:
@@ -12,19 +13,13 @@ updates:
           - "openai"
           - "anthropic"
           - "google-genai"
-          - "langchain-core"
-          - "langchain-community"
-          - "langchain-openai"
-          - "langchain-anthropic"
+          - "langchain*"
           - "langgraph"
     allow:
       - dependency-name: "openai"
       - dependency-name: "anthropic"
       - dependency-name: "google-genai"
-      - dependency-name: "langchain-core"
-      - dependency-name: "langchain-community"
-      - dependency-name: "langchain-openai"
-      - dependency-name: "langchain-anthropic"
+      - dependency-name: "langchain*"
       - dependency-name: "langgraph"
     open-pull-requests-limit: 1
     reviewers:


### PR DESCRIPTION
## :bulb: Motivation and Context
Dependabot was opening update PRs too frequently for the AI dependency set, which made it harder to keep up with the volume of maintenance PRs.


## :green_heart: How did you test it?
- Reviewed the `.github/dependabot.yml` changes
- Verified the config now runs weekly on Monday instead of daily
- Verified grouped matching now uses `langchain*` for both `groups` and `allow`


## :pencil: Checklist
- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file
- [ ] Added the `release` label to the PR

<!-- For more details check RELEASING.md -->
