### PR TITLE
fix: trim whitespace from API keys and host config

### DIFF
--- a/.sampo/changesets/trim-whitespace-config-values.md
+++ b/.sampo/changesets/trim-whitespace-config-values.md
@@ -1,0 +1,5 @@
+---
+pypi/posthog: patch
+---
+
+Trim surrounding whitespace from API keys and host config before using them.

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -45,7 +45,6 @@ from posthog.flag_definition_cache import (
 )
 from posthog.poller import Poller
 from posthog.request import (
-    DEFAULT_HOST,
     APIError,
     QuotaLimitError,
     RequestsConnectionError,

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -280,7 +280,9 @@ class Client(object):
 
         # personal_api_key: This should be a generated Personal API Key, private
         self.personal_api_key = (
-            personal_api_key.strip() if isinstance(personal_api_key, str) else personal_api_key
+            personal_api_key.strip()
+            if isinstance(personal_api_key, str)
+            else personal_api_key
         ) or None
         if debug:
             # Ensures that debug level messages are logged when debug mode is on.

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -1297,12 +1297,19 @@ class Client(object):
 
     def _fetch_feature_flags_from_api(self):
         """Fetch feature flags from the PostHog API."""
+        personal_api_key = self.personal_api_key
+        if personal_api_key is None:
+            self.log.warning(
+                "[FEATURE FLAGS] You have to specify a personal_api_key to use feature flags."
+            )
+            return
+
         try:
             # Store old flags to detect changes
             old_flags_by_key: dict[str, dict] = self.feature_flags_by_key or {}
 
             response = get(
-                self.personal_api_key,
+                personal_api_key,
                 f"/flags/definitions?token={self.api_key}&send_cohorts",
                 self.host,
                 timeout=10,

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -54,6 +54,7 @@ from posthog.request import (
     determine_server_host,
     flags,
     get,
+    normalize_host,
     remote_config,
 )
 from posthog.types import (
@@ -221,14 +222,14 @@ class Client(object):
         self.queue = queue.Queue(max_queue_size)
 
         # api_key: This should be the Team API Key (token), public
-        self.api_key = project_api_key
+        self.api_key = project_api_key.strip()
 
         self.on_error = on_error
         self.debug = debug
         self.send = send
         self.sync_mode = sync_mode
         # Used for session replay URL generation - we don't want the server host here.
-        self.raw_host = host or DEFAULT_HOST
+        self.raw_host = normalize_host(host)
         self.host = determine_server_host(host)
         self.gzip = gzip
         self.timeout = timeout
@@ -278,7 +279,9 @@ class Client(object):
         self.project_root = project_root
 
         # personal_api_key: This should be a generated Personal API Key, private
-        self.personal_api_key = personal_api_key
+        self.personal_api_key = (
+            personal_api_key.strip() if isinstance(personal_api_key, str) else personal_api_key
+        ) or None
         if debug:
             # Ensures that debug level messages are logged when debug mode is on.
             # Otherwise, defaults to WARNING level. See https://docs.python.org/3/howto/logging.html#what-happens-if-no-configuration-is-provided
@@ -286,6 +289,11 @@ class Client(object):
             self.log.setLevel(logging.DEBUG)
         else:
             self.log.setLevel(logging.WARNING)
+
+        if not self.api_key:
+            self.log.error(
+                "api_key is empty after trimming whitespace; check your project API key"
+            )
 
         self._set_before_send(before_send)
 

--- a/posthog/request.py
+++ b/posthog/request.py
@@ -165,9 +165,17 @@ DEFAULT_HOST = US_INGESTION_ENDPOINT
 USER_AGENT = "posthog-python/" + VERSION
 
 
+def normalize_host(host: Optional[str]) -> str:
+    """Normalize a configured host, defaulting blank values to DEFAULT_HOST."""
+    normalized_host = (host or "").strip()
+    if not normalized_host:
+        return DEFAULT_HOST
+    return normalized_host
+
+
 def determine_server_host(host: Optional[str]) -> str:
     """Determines the server host to use."""
-    host_or_default = host or DEFAULT_HOST
+    host_or_default = normalize_host(host)
     trimmed_host = remove_trailing_slash(host_or_default)
     if trimmed_host in ("https://app.posthog.com", "https://us.posthog.com"):
         return US_INGESTION_ENDPOINT
@@ -190,7 +198,7 @@ def post(
     log = logging.getLogger("posthog")
     body = kwargs
     body["sentAt"] = datetime.now(tz=tzutc()).isoformat()
-    url = remove_trailing_slash(host or DEFAULT_HOST) + path
+    url = remove_trailing_slash(normalize_host(host)) + path
     body["api_key"] = api_key
     data = json.dumps(body, cls=DatetimeSerializer)
     log.debug("making request: %s to url: %s", data, url)
@@ -330,7 +338,7 @@ def get(
     - not_modified=False and data=response if server returns 200
     """
     log = logging.getLogger("posthog")
-    full_url = remove_trailing_slash(host or DEFAULT_HOST) + url
+    full_url = remove_trailing_slash(normalize_host(host)) + url
     headers = {"Authorization": "Bearer %s" % api_key, "User-Agent": USER_AGENT}
 
     if etag:

--- a/posthog/request.py
+++ b/posthog/request.py
@@ -198,7 +198,8 @@ def post(
     log = logging.getLogger("posthog")
     body = kwargs
     body["sentAt"] = datetime.now(tz=tzutc()).isoformat()
-    url = remove_trailing_slash(normalize_host(host)) + path
+    trimmed_host = remove_trailing_slash(normalize_host(host))
+    url = trimmed_host + path
     body["api_key"] = api_key
     data = json.dumps(body, cls=DatetimeSerializer)
     log.debug("making request: %s to url: %s", data, url)
@@ -338,7 +339,8 @@ def get(
     - not_modified=False and data=response if server returns 200
     """
     log = logging.getLogger("posthog")
-    full_url = remove_trailing_slash(normalize_host(host)) + url
+    trimmed_host = remove_trailing_slash(normalize_host(host))
+    full_url = trimmed_host + url
     headers = {"Authorization": "Bearer %s" % api_key, "User-Agent": USER_AGENT}
 
     if etag:

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -41,25 +41,37 @@ class TestClient(unittest.TestCase):
     def test_requires_api_key(self):
         self.assertRaises(TypeError, Client)
 
-    def test_trims_whitespace_sensitive_config(self):
-        with self.assertLogs("posthog", level="ERROR") as logs:
-            client = Client(
-                " \n\t ",
-                host=" \nhttps://eu.posthog.com/\t ",
-                personal_api_key=" \n\t ",
-                send=False,
-            )
+    @parameterized.expand(
+        [
+            ("valid_key", " \nphc_validkey\t ", "phc_validkey", False),
+            ("whitespace_only", " \n\t ", "", True),
+        ]
+    )
+    def test_trims_api_key_whitespace(
+        self, _, raw_api_key, expected_api_key, expect_error_log
+    ):
+        with mock.patch.object(Client.log, "error") as mock_error:
+            client = Client(raw_api_key, send=False)
 
-        self.assertEqual(client.api_key, "")
+        self.assertEqual(client.api_key, expected_api_key)
+        if expect_error_log:
+            mock_error.assert_called_once_with(
+                "api_key is empty after trimming whitespace; check your project API key"
+            )
+        else:
+            mock_error.assert_not_called()
+
+    def test_trims_host_and_personal_api_key_whitespace(self):
+        client = Client(
+            FAKE_TEST_API_KEY,
+            host=" \nhttps://eu.posthog.com/\t ",
+            personal_api_key=" \n\t ",
+            send=False,
+        )
+
         self.assertEqual(client.raw_host, "https://eu.posthog.com/")
         self.assertEqual(client.host, "https://eu.i.posthog.com")
         self.assertIsNone(client.personal_api_key)
-        self.assertTrue(
-            any(
-                "api_key is empty after trimming whitespace" in message
-                for message in logs.output
-            )
-        )
 
     def test_empty_flush(self):
         self.client.flush()

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -41,6 +41,26 @@ class TestClient(unittest.TestCase):
     def test_requires_api_key(self):
         self.assertRaises(TypeError, Client)
 
+    def test_trims_whitespace_sensitive_config(self):
+        with self.assertLogs("posthog", level="ERROR") as logs:
+            client = Client(
+                " \n\t ",
+                host=" \nhttps://eu.posthog.com/\t ",
+                personal_api_key=" \n\t ",
+                send=False,
+            )
+
+        self.assertEqual(client.api_key, "")
+        self.assertEqual(client.raw_host, "https://eu.posthog.com/")
+        self.assertEqual(client.host, "https://eu.i.posthog.com")
+        self.assertIsNone(client.personal_api_key)
+        self.assertTrue(
+            any(
+                "api_key is empty after trimming whitespace" in message
+                for message in logs.output
+            )
+        )
+
     def test_empty_flush(self):
         self.client.flush()
 

--- a/posthog/test/test_request.py
+++ b/posthog/test/test_request.py
@@ -348,6 +348,8 @@ class TestGet(unittest.TestCase):
         ("https://app.posthog.com/", "https://us.i.posthog.com"),
         ("https://eu.posthog.com/", "https://eu.i.posthog.com"),
         ("https://us.posthog.com/", "https://us.i.posthog.com"),
+        (" \nhttps://eu.posthog.com/\t ", "https://eu.i.posthog.com"),
+        (" \n\t ", "https://us.i.posthog.com"),
         (None, "https://us.i.posthog.com"),
     ],
 )


### PR DESCRIPTION
## :bulb: Motivation and Context
This ports the whitespace-trimming fix from `posthog-go` to `posthog-python`. It trims surrounding spaces and line breaks from the project API key, personal API key, and host before using them so the SDK does not silently send invalid tokens or build broken endpoints from whitespace-polluted configuration.


## :green_heart: How did you test it?
- `uv run --extra test pytest posthog/test/test_client.py -k "trims_api_key_whitespace or trims_host_and_personal_api_key_whitespace"`
- `uv run --extra test pytest posthog/test/test_request.py -k "routing_to_custom_host or defaults_blank_host_after_trimming_whitespace or trims_whitespace_sensitive_config"`
- `uv run ruff format --check .`


## :pencil: Checklist
- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file
- [x] Added the `release` label to the PR

<!-- For more details check RELEASING.md -->
