### PR TITLE
fix: clarify feature flag auth errors

### DIFF
--- a/.sampo/changesets/feature-flag-auth-errors.md
+++ b/.sampo/changesets/feature-flag-auth-errors.md
@@ -1,0 +1,5 @@
+---
+pypi/posthog: patch
+---
+
+Improve local feature flag authentication error messages.

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -1353,9 +1353,12 @@ class Client(object):
 
         except APIError as e:
             if e.status == 401:
-                self.log.error(
-                    "[FEATURE FLAGS] Error loading feature flags: To use feature flags, please set a valid personal_api_key. More information: https://posthog.com/docs/api/overview"
+                detail = (
+                    f"Error loading feature flags: {e.message}. "
+                    "Please verify both your project_api_key and personal_api_key. "
+                    "More information: https://posthog.com/docs/api/overview"
                 )
+                self.log.error("[FEATURE FLAGS] %s", detail)
                 self.feature_flags = []
                 self.group_type_mapping = {}
                 self.cohorts = {}
@@ -1364,12 +1367,7 @@ class Client(object):
                     self.flag_cache.clear()
 
                 if self.debug:
-                    raise APIError(
-                        status=401,
-                        message="You are using a write-only key with feature flags. "
-                        "To use feature flags, please set a personal_api_key "
-                        "More information: https://posthog.com/docs/api/overview",
-                    )
+                    raise APIError(status=401, message=detail)
             elif e.status == 402:
                 self.log.warning(
                     "[FEATURE FLAGS] PostHog feature flags quota limited, resetting feature flag data.  Learn more about billing limits at https://posthog.com/docs/billing/limits-alerts"

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -555,7 +555,9 @@ class TestClient(unittest.TestCase):
             self.assertEqual(client.feature_flags_by_key, {})
             self.assertEqual(client.group_type_mapping, {})
             self.assertEqual(client.cohorts, {})
-            self.assertIn("please set a valid personal_api_key", logs.output[0])
+            self.assertIn("Unauthorized", logs.output[0])
+            self.assertIn("project_api_key", logs.output[0])
+            self.assertIn("personal_api_key", logs.output[0])
 
     @mock.patch("posthog.client.flags")
     def test_dont_override_capture_with_local_flags(self, patch_flags):

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -2546,12 +2546,12 @@ class TestLocalEvaluation(unittest.TestCase):
 
         with self.assertLogs("posthog", level="ERROR") as logs:
             client.load_feature_flags()
-            self.assertEqual(
-                logs.output[0],
-                "ERROR:posthog:[FEATURE FLAGS] Error loading feature flags: To use feature flags, please set a valid personal_api_key. More information: https://posthog.com/docs/api/overview",
-            )
+            self.assertIn("Unauthorized", logs.output[0])
+            self.assertIn("project_api_key", logs.output[0])
+            self.assertIn("personal_api_key", logs.output[0])
         client.debug = True
-        self.assertRaises(APIError, client.load_feature_flags)
+        with self.assertRaisesRegex(APIError, "Unauthorized"):
+            client.load_feature_flags()
 
     @mock.patch("posthog.client.flags")
     @mock.patch("posthog.client.get")


### PR DESCRIPTION
## :bulb: Motivation and Context
Relates to #526.

Local feature flag loading uses both the project API key and the personal/feature-flags API key, but 401 errors always blamed only `personal_api_key`. This keeps the server-provided error detail and asks users to verify both credentials.

## :green_heart: How did you test it?
- `uv run pytest posthog/test/test_client.py::TestClient::test_load_feature_flags_unauthorized posthog/test/test_feature_flags.py::TestLocalEvaluation::test_load_feature_flags_wrong_key -q`
- `uv run ruff format --check posthog/client.py posthog/test/test_client.py posthog/test/test_feature_flags.py`
- `uv run ruff check posthog/client.py posthog/test/test_client.py posthog/test/test_feature_flags.py`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file
- [x] Added the `release` label to the PR
