### PR TITLE
fix: acknowledge oversized dropped events

### DIFF
--- a/.sampo/changesets/oversized-event-flush-hang.md
+++ b/.sampo/changesets/oversized-event-flush-hang.md
@@ -1,0 +1,5 @@
+---
+pypi/posthog: patch
+---
+
+Prevent flush from hanging after dropping oversized queued events.

--- a/posthog/consumer.py
+++ b/posthog/consumer.py
@@ -112,6 +112,7 @@ class Consumer(Thread):
                     self.log.error(
                         "Item exceeds 900kib limit, dropping. (%s)", str(item)
                     )
+                    queue.task_done()
                     continue
                 items.append(item)
                 total_size += item_size

--- a/posthog/test/test_consumer.py
+++ b/posthog/test/test_consumer.py
@@ -45,6 +45,7 @@ class TestConsumer(unittest.TestCase):
         next = consumer.next()
         self.assertEqual(next, [])
         self.assertTrue(q.empty())
+        self.assertEqual(q.unfinished_tasks, 0)
 
     def test_upload(self) -> None:
         q = Queue()


### PR DESCRIPTION
## :bulb: Motivation and Context
Fixes #308.

When an oversized item was removed from the queue and dropped, it was never acknowledged with `task_done()`. That left `Queue.unfinished_tasks` non-zero, so `flush()` could block forever even though the queue was empty.

## :green_heart: How did you test it?
- `uv run pytest posthog/test/test_consumer.py::TestConsumer::test_dropping_oversize_msg -q`
- `uv run ruff format --check posthog/consumer.py posthog/test/test_consumer.py`
- `uv run ruff check posthog/consumer.py posthog/test/test_consumer.py`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file
- [x] Added the `release` label to the PR
