### PR TITLE
fix: no-op clients without api key

### DIFF
--- a/.sampo/changesets/disabled-no-api-key.md
+++ b/.sampo/changesets/disabled-no-api-key.md
@@ -1,0 +1,5 @@
+---
+pypi/posthog: patch
+---
+
+Treat clients with an empty project API key as disabled no-ops.

--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -886,8 +886,9 @@ def setup() -> Client:
             in_app_modules=in_app_modules,
         )
 
-    # always set incase user changes it
-    default_client.disabled = disabled
+    # Always set in case user changes it. Preserve Client's auto-disabled state
+    # for API keys that become empty after trimming.
+    default_client.disabled = disabled or not default_client.api_key
     default_client.debug = debug
     default_client._set_before_send(before_send)
 

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -220,7 +220,7 @@ class Client(object):
         self.queue = queue.Queue(max_queue_size)
 
         # api_key: This should be the Team API Key (token), public
-        self.api_key = project_api_key.strip()
+        self.api_key = (project_api_key or "").strip()
 
         self.on_error = on_error
         self.debug = debug
@@ -245,7 +245,7 @@ class Client(object):
         self.flag_definition_version = 0
         self._flags_etag: Optional[str] = None
         self._flag_definition_cache_provider = flag_definition_cache_provider
-        self.disabled = disabled
+        self.disabled = disabled or not self.api_key
         self.disable_geoip = disable_geoip
         self.historical_migration = historical_migration
         self.super_properties = super_properties
@@ -538,6 +538,9 @@ class Client(object):
         Category:
             Feature flags
         """
+        if self.disabled:
+            return normalize_flags_response({})
+
         groups = groups or {}
         person_properties = person_properties or {}
         group_properties = group_properties or {}
@@ -1408,6 +1411,10 @@ class Client(object):
         Category:
             Feature flags
         """
+        if self.disabled:
+            self.feature_flags = []
+            return
+
         if not self.personal_api_key:
             self.log.warning(
                 "[FEATURE FLAGS] You have to specify a personal_api_key to use feature flags."

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -43,17 +43,19 @@ class TestClient(unittest.TestCase):
 
     @parameterized.expand(
         [
-            ("valid_key", " \nphc_validkey\t ", "phc_validkey", False),
-            ("whitespace_only", " \n\t ", "", True),
+            ("valid_key", " \nphc_validkey\t ", "phc_validkey", False, False),
+            ("whitespace_only", " \n\t ", "", True, True),
+            ("empty_string", "", "", True, True),
         ]
     )
     def test_trims_api_key_whitespace(
-        self, _, raw_api_key, expected_api_key, expect_error_log
+        self, _, raw_api_key, expected_api_key, expected_disabled, expect_error_log
     ):
         with mock.patch.object(Client.log, "error") as mock_error:
             client = Client(raw_api_key, send=False)
 
         self.assertEqual(client.api_key, expected_api_key)
+        self.assertEqual(client.disabled, expected_disabled)
         if expect_error_log:
             mock_error.assert_called_once_with(
                 "api_key is empty after trimming whitespace; check your project API key"
@@ -72,6 +74,37 @@ class TestClient(unittest.TestCase):
         self.assertEqual(client.raw_host, "https://eu.posthog.com/")
         self.assertEqual(client.host, "https://eu.i.posthog.com")
         self.assertIsNone(client.personal_api_key)
+
+    def test_client_with_empty_api_key_is_noop(self):
+        client = Client("", send=False)
+
+        self.assertIsNone(client.capture("event", distinct_id="distinct_id"))
+
+    @mock.patch("posthog.client.get")
+    def test_disabled_client_does_not_load_feature_flags(self, patch_get):
+        client = Client("", personal_api_key="test", send=False)
+
+        client.load_feature_flags()
+
+        patch_get.assert_not_called()
+        self.assertEqual(client.feature_flags, [])
+        self.assertIsNone(client.poller)
+
+    @mock.patch("posthog.client.flags")
+    def test_disabled_client_does_not_get_flags_decision(self, patch_flags):
+        client = Client("", send=False)
+
+        self.assertEqual(client.get_flags_decision("distinct_id")["flags"], {})
+        self.assertEqual(client.get_feature_variants("distinct_id"), {})
+        self.assertEqual(client.get_feature_payloads("distinct_id"), {})
+        self.assertEqual(
+            client.get_feature_flags_and_payloads("distinct_id"),
+            {"featureFlags": {}, "featureFlagPayloads": {}},
+        )
+        self.assertIsNone(
+            client.capture("event", distinct_id="distinct_id", send_feature_flags=True)
+        )
+        patch_flags.assert_not_called()
 
     def test_empty_flush(self):
         self.client.flush()

--- a/posthog/test/test_module.py
+++ b/posthog/test/test_module.py
@@ -36,6 +36,31 @@ class TestModule(unittest.TestCase):
         self.posthog.flush()
 
 
+class TestModuleLevelSetup(unittest.TestCase):
+    def setUp(self):
+        self._original_default_client = posthog.default_client
+        self._original_api_key = posthog.api_key
+        self._original_disabled = posthog.disabled
+        self._original_send = posthog.send
+        posthog.default_client = None
+        posthog.api_key = " \n\t "
+        posthog.disabled = False
+        posthog.send = False
+
+    def tearDown(self):
+        posthog.default_client = self._original_default_client
+        posthog.api_key = self._original_api_key
+        posthog.disabled = self._original_disabled
+        posthog.send = self._original_send
+
+    def test_setup_preserves_client_disabled_when_trimmed_api_key_is_empty(self):
+        posthog.setup()
+
+        self.assertIsNotNone(posthog.default_client)
+        self.assertEqual(posthog.default_client.api_key, "")
+        self.assertTrue(posthog.default_client.disabled)
+
+
 class TestModuleLevelWrappers(unittest.TestCase):
     """Test that module-level wrapper functions in posthog/__init__.py
     correctly propagate all parameters to the Client methods."""


### PR DESCRIPTION
## :bulb: Motivation and Context
Fixes #173.

When a direct client is created with a project API key that is missing or trims to an empty string, the SDK now logs the empty-key warning and marks that client as disabled so calls are no-ops. Feature flag loading and direct flag decision APIs also return early for disabled clients to avoid malformed requests with an empty token.

Module-level setup now preserves the client’s auto-disabled state after trimming a whitespace-only key.

## :green_heart: How did you test it?
- `uv run pytest posthog/test/test_client.py posthog/test/test_module.py -q`
- `uv run ruff format --check posthog/__init__.py posthog/client.py posthog/test/test_client.py posthog/test/test_module.py`
- `uv run ruff check posthog/__init__.py posthog/client.py posthog/test/test_client.py posthog/test/test_module.py`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file
- [x] Added the `release` label to the PR
