### PR TITLE
chore: remove unsupported setup-uv input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,6 @@ jobs:
               uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
               with:
                   enable-cache: true
-                  pyproject-file: 'pyproject.toml'
 
             - name: Install dev dependencies
               shell: bash
@@ -65,7 +64,6 @@ jobs:
               uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
               with:
                   enable-cache: true
-                  pyproject-file: 'pyproject.toml'
 
             - name: Install test dependencies
               shell: bash
@@ -117,7 +115,6 @@ jobs:
               uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
               with:
                   enable-cache: true
-                  pyproject-file: 'integration_tests/django5/pyproject.toml'
 
             - name: Install Django 5 test project dependencies
               shell: bash

--- a/.github/workflows/generate-references.yml
+++ b/.github/workflows/generate-references.yml
@@ -24,7 +24,6 @@ jobs:
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
             enable-cache: true
-            pyproject-file: 'pyproject.toml'
 
       - name: Generate references
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,6 @@ jobs:
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
           enable-cache: true
-          pyproject-file: "pyproject.toml"
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@0b1efabc08b657293548b77fb76cc02d26091c7e


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`astral-sh/setup-uv@v8` no longer supports the `pyproject-file` input, which causes GitHub Actions to warn about an unexpected input in CI, reference generation, and release workflows.

This removes the unsupported input from all `setup-uv` steps. Root `pyproject.toml` discovery and default cache dependency handling are already covered by `setup-uv` itself.

## :green_heart: How did you test it?

- Verified no workflow references to `pyproject-file` remain with `rg -n "pyproject-file" .github/workflows`.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file
- [ ] Added the `release` label to the PR

<!-- For more details check RELEASING.md -->
