### PR TITLE
Run Python CI on main pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,10 @@
 name: CI
 
 on:
-    - pull_request
+    pull_request:
+    push:
+        branches:
+            - main
 
 permissions:
     contents: read


### PR DESCRIPTION
## :bulb: Motivation and Context
Ensure the Python SDK's CI workflow also runs after changes land on `main`, so regressions introduced by merges are caught on the default branch.

## :green_heart: How did you test it?
Validated the workflow YAML parses and now includes `push` for the `main` branch.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file
