### PR TITLE
chore: ignore examples in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       day: "monday"
       time: "10:00"
       timezone: "UTC"
+    exclude-paths:
+      - "examples/**"
     groups:
       ai-providers:
         patterns:


### PR DESCRIPTION
## :bulb: Motivation and Context
Dependabot should not scan the `examples/` folder so example-only dependency files do not generate update PRs for the SDK package.

## :green_heart: How did you test it?
Verified `.github/dependabot.yml` parses as valid YAML with Ruby.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file

<!-- For more details check RELEASING.md -->
