### PR TITLE
fix: type warning on `new_context`

### DIFF
--- a/.sampo/changesets/forthright-guardian-sampsa.md
+++ b/.sampo/changesets/forthright-guardian-sampsa.md
@@ -1,0 +1,5 @@
+---
+pypi/posthog: patch
+---
+
+fix: type warning on new_context

--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -73,7 +73,11 @@ __version__ = VERSION
 """Context management."""
 
 
-def new_context(fresh=False, capture_exceptions=True, client=None):
+def new_context(
+    fresh: bool = False,
+    capture_exceptions: bool = True,
+    client: Optional[Client] = None,
+):
     """
     Create a new context scope that will be active for the duration of the with block.
 


### PR DESCRIPTION
## :bulb: Motivation and Context
When using a strict Python typechecker, Posthog's `new_context` function raises a type warning:
```
Type of "new_context" is partially unknown
  Type of "new_context" is "(fresh: bool = False, capture_exceptions: bool = True, client: Unknown | None = None) -> _GeneratorContextManager[None, None, None]" (basedpyright reportUnknownVariableType)
```

This fixes that by assigning a type to `client`

## :green_heart: How did you test it?
Type fix only, ran typechecker

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file

<!-- For more details check RELEASING.md -->
