### PR TITLE
fix: support scoped async functions

### DIFF
--- a/.sampo/changesets/chivalrous-baron-tapio.md
+++ b/.sampo/changesets/chivalrous-baron-tapio.md
@@ -1,0 +1,5 @@
+---
+pypi/posthog: patch
+---
+
+Fix scoped context support for async functions

--- a/posthog/contexts.py
+++ b/posthog/contexts.py
@@ -391,12 +391,29 @@ def scoped(fresh: bool = False, capture_exceptions: bool = True):
             # and then re-raised
             some_risky_function()
 
+        # When stacking decorators, the posthog.scoped decorator must be
+        # closest to the function. For example, with FastAPI middleware:
+        @app.middleware("http")
+        @posthog.scoped()
+        async def middleware(request, call_next):
+            return await call_next(request)
+
     Category:
         Contexts
     """
 
     def decorator(func: F) -> F:
         from functools import wraps
+        from inspect import iscoroutinefunction
+
+        if iscoroutinefunction(func):
+
+            @wraps(func)
+            async def async_wrapper(*args, **kwargs):
+                with new_context(fresh=fresh, capture_exceptions=capture_exceptions):
+                    return await func(*args, **kwargs)
+
+            return cast(F, async_wrapper)
 
         @wraps(func)
         def wrapper(*args, **kwargs):

--- a/posthog/test/test_contexts.py
+++ b/posthog/test/test_contexts.py
@@ -88,8 +88,6 @@ class TestContexts(unittest.TestCase):
 
     @patch("posthog.capture_exception")
     def test_scoped_decorator_exception(self, mock_capture):
-        test_exception = ValueError("Test exception")
-
         def check_context_on_capture(exception, **kwargs):
             # Assert tags are available when capture_exception is called
             current_tags = get_tags()
@@ -97,20 +95,40 @@ class TestContexts(unittest.TestCase):
 
         mock_capture.side_effect = check_context_on_capture
 
-        @scoped()
-        def failing_function():
-            tag("important_context", "value")
-            raise test_exception
+        for name, is_async in [("sync", False), ("async", True)]:
+            with self.subTest(name=name):
+                test_exception = ValueError(f"Test {name} exception")
 
-        # Function should raise the exception
-        with self.assertRaises(ValueError):
-            failing_function()
+                if is_async:
 
-        # Verify capture_exception was called
-        mock_capture.assert_called_once_with(test_exception)
+                    @scoped()
+                    async def failing_function():
+                        tag("important_context", "value")
+                        raise test_exception
 
-        # Context should be cleared after function execution
-        assert get_tags() == {}
+                    def run():
+                        return asyncio.run(failing_function())
+
+                else:
+
+                    @scoped()
+                    def failing_function():
+                        tag("important_context", "value")
+                        raise test_exception
+
+                    run = failing_function
+
+                # Function should raise the exception
+                with self.assertRaises(ValueError):
+                    run()
+
+                # Verify capture_exception was called
+                mock_capture.assert_called_once_with(test_exception)
+
+                # Context should be cleared after function execution
+                assert get_tags() == {}
+
+                mock_capture.reset_mock()
 
     @patch("posthog.capture_exception")
     def test_new_context_exception_handling(self, mock_capture):
@@ -220,33 +238,31 @@ class TestContexts(unittest.TestCase):
 
     def test_scoped_decorator_with_context_ids(self):
         @scoped()
-        def function_with_context():
+        def sync_function_with_context():
             identify_context("user456")
             set_context_session("session789")
             return get_context_distinct_id(), get_context_session_id()
 
-        distinct_id, session_id = function_with_context()
-        assert distinct_id == "user456"
-        assert session_id == "session789"
-
-        # Context should be cleared after function execution
-        assert get_context_distinct_id() is None
-        assert get_context_session_id() is None
-
-    def test_scoped_decorator_async_function(self):
         @scoped()
         async def async_function_with_context():
-            identify_context("user_async")
-            set_context_session("session_async")
+            identify_context("user456")
+            set_context_session("session789")
             return get_context_distinct_id(), get_context_session_id()
 
-        distinct_id, session_id = asyncio.run(async_function_with_context())
-        assert distinct_id == "user_async"
-        assert session_id == "session_async"
+        cases = [
+            ("sync", sync_function_with_context, lambda func: func()),
+            ("async", async_function_with_context, lambda func: asyncio.run(func())),
+        ]
 
-        # Context should be cleared after function execution
-        assert get_context_distinct_id() is None
-        assert get_context_session_id() is None
+        for name, func, run in cases:
+            with self.subTest(name=name):
+                distinct_id, session_id = run(func)
+                assert distinct_id == "user456"
+                assert session_id == "session789"
+
+                # Context should be cleared after function execution
+                assert get_context_distinct_id() is None
+                assert get_context_session_id() is None
 
     def test_scoped_decorator_async_concurrent_context_isolation(self):
         first_ready = asyncio.Event()
@@ -274,29 +290,3 @@ class TestContexts(unittest.TestCase):
             return await asyncio.wait_for(asyncio.gather(first(), second()), timeout=1)
 
         assert asyncio.run(run()) == ["user_1", "user_2"]
-
-    @patch("posthog.capture_exception")
-    def test_scoped_decorator_async_exception(self, mock_capture):
-        test_exception = ValueError("Test async exception")
-
-        def check_context_on_capture(exception, **kwargs):
-            # Assert context IDs are available when capture_exception is called
-            assert get_context_distinct_id() == "user_async"
-            assert get_context_session_id() == "session_async"
-
-        mock_capture.side_effect = check_context_on_capture
-
-        @scoped()
-        async def failing_async_function():
-            identify_context("user_async")
-            set_context_session("session_async")
-            raise test_exception
-
-        with self.assertRaises(ValueError):
-            asyncio.run(failing_async_function())
-
-        mock_capture.assert_called_once_with(test_exception)
-
-        # Context should be cleared after function execution
-        assert get_context_distinct_id() is None
-        assert get_context_session_id() is None

--- a/posthog/test/test_contexts.py
+++ b/posthog/test/test_contexts.py
@@ -248,6 +248,33 @@ class TestContexts(unittest.TestCase):
         assert get_context_distinct_id() is None
         assert get_context_session_id() is None
 
+    def test_scoped_decorator_async_concurrent_context_isolation(self):
+        first_ready = asyncio.Event()
+        second_ready = asyncio.Event()
+        first_checked = asyncio.Event()
+
+        @scoped()
+        async def first():
+            identify_context("user_1")
+            first_ready.set()
+            await second_ready.wait()
+            distinct_id = get_context_distinct_id()
+            first_checked.set()
+            return distinct_id
+
+        @scoped()
+        async def second():
+            await first_ready.wait()
+            identify_context("user_2")
+            second_ready.set()
+            await first_checked.wait()
+            return get_context_distinct_id()
+
+        async def run():
+            return await asyncio.wait_for(asyncio.gather(first(), second()), timeout=1)
+
+        assert asyncio.run(run()) == ["user_1", "user_2"]
+
     @patch("posthog.capture_exception")
     def test_scoped_decorator_async_exception(self, mock_capture):
         test_exception = ValueError("Test async exception")

--- a/posthog/test/test_contexts.py
+++ b/posthog/test/test_contexts.py
@@ -1,3 +1,4 @@
+import asyncio
 import unittest
 from unittest.mock import patch
 
@@ -227,6 +228,47 @@ class TestContexts(unittest.TestCase):
         distinct_id, session_id = function_with_context()
         assert distinct_id == "user456"
         assert session_id == "session789"
+
+        # Context should be cleared after function execution
+        assert get_context_distinct_id() is None
+        assert get_context_session_id() is None
+
+    def test_scoped_decorator_async_function(self):
+        @scoped()
+        async def async_function_with_context():
+            identify_context("user_async")
+            set_context_session("session_async")
+            return get_context_distinct_id(), get_context_session_id()
+
+        distinct_id, session_id = asyncio.run(async_function_with_context())
+        assert distinct_id == "user_async"
+        assert session_id == "session_async"
+
+        # Context should be cleared after function execution
+        assert get_context_distinct_id() is None
+        assert get_context_session_id() is None
+
+    @patch("posthog.capture_exception")
+    def test_scoped_decorator_async_exception(self, mock_capture):
+        test_exception = ValueError("Test async exception")
+
+        def check_context_on_capture(exception, **kwargs):
+            # Assert context IDs are available when capture_exception is called
+            assert get_context_distinct_id() == "user_async"
+            assert get_context_session_id() == "session_async"
+
+        mock_capture.side_effect = check_context_on_capture
+
+        @scoped()
+        async def failing_async_function():
+            identify_context("user_async")
+            set_context_session("session_async")
+            raise test_exception
+
+        with self.assertRaises(ValueError):
+            asyncio.run(failing_async_function())
+
+        mock_capture.assert_called_once_with(test_exception)
 
         # Context should be cleared after function execution
         assert get_context_distinct_id() is None


### PR DESCRIPTION
## :bulb: Motivation and Context

Fixes #568.

`posthog.scoped()` previously wrapped async functions with a synchronous wrapper. That entered and exited the PostHog context before the returned coroutine was awaited, so context values such as `identify_context()` were unavailable inside async middleware/routes.

## :green_heart: How did you test it?

- `.venv/bin/python -m pytest posthog/test/test_contexts.py -q`
- `.venv/bin/python -m ruff check posthog/contexts.py posthog/test/test_contexts.py`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file
