### PR TITLE
fix: guard null token usage fields in OpenAI converter

### DIFF
--- a/.sampo/changesets/noble-thunderbearer-vellamo.md
+++ b/.sampo/changesets/noble-thunderbearer-vellamo.md
@@ -1,0 +1,5 @@
+---
+pypi/posthog: patch
+---
+
+Fix OpenAI usage parsing when token detail fields are null

--- a/posthog/ai/openai/openai_converter.py
+++ b/posthog/ai/openai/openai_converter.py
@@ -432,9 +432,9 @@ def extract_openai_usage_from_response(response: Any) -> TokenUsage:
         output_tokens=output_tokens,
     )
 
-    if cached_tokens > 0:
+    if cached_tokens is not None and cached_tokens > 0:
         result["cache_read_input_tokens"] = cached_tokens
-    if reasoning_tokens > 0:
+    if reasoning_tokens is not None and reasoning_tokens > 0:
         result["reasoning_tokens"] = reasoning_tokens
 
     web_search_count = extract_openai_web_search_count(response)
@@ -488,17 +488,17 @@ def extract_openai_usage_from_chunk(
         if hasattr(chunk.usage, "prompt_tokens_details") and hasattr(
             chunk.usage.prompt_tokens_details, "cached_tokens"
         ):
-            usage["cache_read_input_tokens"] = (
-                chunk.usage.prompt_tokens_details.cached_tokens
-            )
+            cached = chunk.usage.prompt_tokens_details.cached_tokens
+            if cached is not None:
+                usage["cache_read_input_tokens"] = cached
 
         # Handle reasoning tokens
         if hasattr(chunk.usage, "completion_tokens_details") and hasattr(
             chunk.usage.completion_tokens_details, "reasoning_tokens"
         ):
-            usage["reasoning_tokens"] = (
-                chunk.usage.completion_tokens_details.reasoning_tokens
-            )
+            reasoning = chunk.usage.completion_tokens_details.reasoning_tokens
+            if reasoning is not None:
+                usage["reasoning_tokens"] = reasoning
 
         # Capture raw usage metadata for backend processing
         # Serialize to dict here in the converter (not in utils)
@@ -522,17 +522,17 @@ def extract_openai_usage_from_chunk(
                 if hasattr(response_usage, "input_tokens_details") and hasattr(
                     response_usage.input_tokens_details, "cached_tokens"
                 ):
-                    usage["cache_read_input_tokens"] = (
-                        response_usage.input_tokens_details.cached_tokens
-                    )
+                    cached = response_usage.input_tokens_details.cached_tokens
+                    if cached is not None:
+                        usage["cache_read_input_tokens"] = cached
 
                 # Handle reasoning tokens
                 if hasattr(response_usage, "output_tokens_details") and hasattr(
                     response_usage.output_tokens_details, "reasoning_tokens"
                 ):
-                    usage["reasoning_tokens"] = (
-                        response_usage.output_tokens_details.reasoning_tokens
-                    )
+                    reasoning = response_usage.output_tokens_details.reasoning_tokens
+                    if reasoning is not None:
+                        usage["reasoning_tokens"] = reasoning
 
                 # Extract web search count from the complete response
                 if hasattr(chunk, "response"):

--- a/posthog/test/ai/openai/test_openai.py
+++ b/posthog/test/ai/openai/test_openai.py
@@ -222,6 +222,33 @@ def mock_openai_response_with_cached_tokens():
 
 
 @pytest.fixture
+def mock_openai_response_with_null_token_details():
+    return ChatCompletion(
+        id="test",
+        model="gpt-4",
+        object="chat.completion",
+        created=int(time.time()),
+        choices=[
+            Choice(
+                finish_reason="stop",
+                index=0,
+                message=ChatCompletionMessage(
+                    content="Test response",
+                    role="assistant",
+                ),
+            )
+        ],
+        usage=CompletionUsage(
+            completion_tokens=10,
+            prompt_tokens=20,
+            total_tokens=30,
+            prompt_tokens_details={"cached_tokens": None},
+            completion_tokens_details={"reasoning_tokens": None},
+        ),
+    )
+
+
+@pytest.fixture
 def streaming_tool_call_chunks():
     return [
         ChatCompletionChunk(
@@ -661,6 +688,32 @@ def test_cached_tokens(mock_client, mock_openai_response_with_cached_tokens):
         assert props["$ai_http_status"] == 200
         assert props["foo"] == "bar"
         assert isinstance(props["$ai_latency"], float)
+
+
+def test_null_token_details_do_not_crash(
+    mock_client, mock_openai_response_with_null_token_details
+):
+    with patch(
+        "openai.resources.chat.completions.Completions.create",
+        return_value=mock_openai_response_with_null_token_details,
+    ):
+        client = OpenAI(api_key="test-key", posthog_client=mock_client)
+        response = client.chat.completions.create(
+            model="gpt-4",
+            messages=[{"role": "user", "content": "Hello"}],
+            posthog_distinct_id="test-id",
+        )
+
+        assert response == mock_openai_response_with_null_token_details
+        assert mock_client.capture.call_count == 1
+
+        call_args = mock_client.capture.call_args[1]
+        props = call_args["properties"]
+
+        assert props["$ai_input_tokens"] == 20
+        assert props["$ai_output_tokens"] == 10
+        assert "$ai_cache_read_input_tokens" not in props
+        assert "$ai_reasoning_tokens" not in props
 
 
 def test_tool_calls(mock_client, mock_openai_response_with_tool_calls):


### PR DESCRIPTION
## Problem

`extract_openai_usage_from_response` crashes with:
```
TypeError: '>' not supported between instances of 'NoneType' and 'int'
```

when the OpenAI API response includes `prompt_tokens_details.cached_tokens = null` or `completion_tokens_details.reasoning_tokens = null`.

The `hasattr()` checks pass because the attributes exist on the response object — they're just `None`. The subsequent `> 0` comparisons then fail.

This is common with OpenAI-compatible proxies/gateways that include the token detail objects but set individual fields to null when not applicable (e.g. no caching, no reasoning tokens for a given model).

## Fix

- Add `is not None` guards before `> 0` comparisons in `extract_openai_usage_from_response`
- Add `is not None` guards before assigning to the usage dict in both streaming paths (chat completions and responses API)

## Impact

Without this fix, any `chat.completions.create()` or `.parse()` call that returns null token detail fields crashes the PostHog wrapper, which propagates up and kills the caller's request — even though the LLM response itself was valid.

Fixes #574