### PR TITLE
chore: update Dependabot exclusions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,33 @@
 version: 2
 updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "10:00"
+      timezone: "UTC"
+    exclude-paths:
+      - "examples/**"
+      - "integration_tests/**"
+    groups:
+      ai-providers:
+        patterns:
+          - "openai"
+          - "anthropic"
+          - "google-genai"
+          - "langchain*"
+          - "langgraph"
+    allow:
+      - dependency-name: "openai"
+      - dependency-name: "anthropic"
+      - dependency-name: "google-genai"
+      - dependency-name: "langchain*"
+      - dependency-name: "langgraph"
+    open-pull-requests-limit: 1
+    reviewers:
+      - "PostHog/team-llm-analytics"
+
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
@@ -9,6 +37,7 @@ updates:
       timezone: "UTC"
     exclude-paths:
       - "examples/**"
+      - "integration_tests/**"
     groups:
       ai-providers:
         patterns:


### PR DESCRIPTION
## :bulb: Motivation and Context
Dependabot was still opening PRs for uv-managed lockfiles under `examples/` and `integration_tests/`. The existing config only covered the `pip` ecosystem, so uv updates were not governed by the same exclusions.

## :green_heart: How did you test it?
Reviewed the Dependabot configuration against GitHub exclude-paths behavior.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file
