### PR TITLE
Remove exception autocapture alpha marker

### DIFF
--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -315,7 +315,6 @@ poll_interval = 30  # type: int
 disable_geoip = True  # type: bool
 feature_flags_request_timeout_seconds = 3  # type: int
 super_properties = None  # type: Optional[Dict]
-# Currently alpha, use at your own risk
 enable_exception_autocapture = False  # type: bool
 log_captured_exceptions = False  # type: bool
 # Used to determine in app paths for exception autocapture. Defaults to the current working directory


### PR DESCRIPTION
## :bulb: Motivation and Context

Remove the stale alpha warning comment from the public `enable_exception_autocapture` source configuration. The changelog remains unchanged.

## :green_heart: How did you test it?

- Searched the source for remaining `enable_exception_autocapture` alpha markers.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file
