### PR TITLE
chore: stabilize sdk compliance adapter

### DIFF
--- a/.github/workflows/sdk-compliance.yml
+++ b/.github/workflows/sdk-compliance.yml
@@ -14,8 +14,8 @@ on:
 jobs:
   compliance:
     name: PostHog SDK compliance tests
-    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@39d05346c4638d24f94e591ab89c9c6fcdb52d6b
+    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@85e2901ea3260a28e07a83086d59b4fb4dfc814f
     with:
       adapter-dockerfile: "sdk_compliance_adapter/Dockerfile"
       adapter-context: "."
-      test-harness-version: "latest"
+      test-harness-version: "main-85e2901@sha256:4c8eac34e7ff66554a2c6947788c0a42b82456bc949c03bd8f6b9a10bef23ef5"

--- a/sdk_compliance_adapter/adapter.py
+++ b/sdk_compliance_adapter/adapter.py
@@ -69,6 +69,22 @@ class SDKState:
 
     def reset(self):
         """Reset all state"""
+        client_to_shutdown = None
+        with self.lock:
+            client_to_shutdown = self.client
+            self.client = None
+
+        if client_to_shutdown:
+            # Flush and shutdown the existing client outside state.lock.
+            # The patched transport records successful flush requests through
+            # SDKState.record_request(), which also needs state.lock. Holding the
+            # lock while shutdown() waits for the queue to drain can deadlock when
+            # a pending background event is being flushed during test reset.
+            try:
+                client_to_shutdown.shutdown()
+            except Exception as e:
+                logger.warning(f"Error shutting down client: {e}")
+
         with self.lock:
             self.pending_events = 0
             self.total_events_captured = 0
@@ -77,13 +93,6 @@ class SDKState:
             self.last_error = None
             self.requests_made = []
             self.retry_attempts = {}
-            if self.client:
-                # Flush and shutdown existing client
-                try:
-                    self.client.shutdown()
-                except Exception as e:
-                    logger.warning(f"Error shutting down client: {e}")
-                self.client = None
 
     def increment_captured(self):
         """Increment total events captured"""
@@ -235,6 +244,10 @@ def init():
             gzip=enable_compression,
             max_retries=max_retries,
             debug=True,
+            # Compliance tests assert the request-level default when callers omit
+            # disable_geoip. Configure the adapter to exercise geoip-enabled
+            # /flags requests by default while still allowing per-call overrides.
+            disable_geoip=False,
         )
 
         state.client = client
@@ -392,6 +405,12 @@ def get_feature_flag():
             disable_geoip=disable_geoip,
             only_evaluate_locally=not force_remote,
         )
+
+        # Ensure the SDK's side-effect $feature_flag_called event is sent before
+        # the adapter action returns. Otherwise the harness may reset mock-server
+        # state for the next test while the background consumer is still flushing,
+        # leaking the previous test's event into the next test.
+        state.client.flush()
 
         logger.info(f"Feature flag {key} for {distinct_id}: {value}")
 


### PR DESCRIPTION
## :bulb: Motivation and Context

Fix the SDK compliance adapter state handling for the Feature_Flags compliance suite.

The adapter could deadlock during test reset because it held `SDKState.lock` while `client.shutdown()` flushed pending events through the patched transport, which also records requests under the same lock. Feature flag side-effect events could also be flushed after an adapter action returned, leaking into the next compliance test's mock-server state.

This also updates the compliance workflow to use the released `posthog-sdk-test-harness` fix from https://github.com/PostHog/posthog-sdk-test-harness/pull/19. The reusable workflow is pinned to full commit SHA `85e2901ea3260a28e07a83086d59b4fb4dfc814f`, and the harness image is pinned by digest.

## :green_heart: How did you test it?

- `uv run --with flask --with python-dateutil python sdk_compliance_adapter/adapter.py`
- From `/Users/marandaneto/Github/posthog-sdk-test-harness`:
  - `uv run posthog-test-harness run --adapter-url http://localhost:18080 --suite feature_flags --output text --concurrency 1`
  - Result: 16/16 Feature_Flags tests passed
- `uv run --with pyyaml python - <<'PY' ... yaml.safe_load(...) ... PY`
- `docker manifest inspect 'ghcr.io/posthog/sdk-test-harness:main-85e2901@sha256:4c8eac34e7ff66554a2c6947788c0a42b82456bc949c03bd8f6b9a10bef23ef5'`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file

<!-- For more details check RELEASING.md -->
