### PR TITLE
fix: track OpenAI chat completions parse calls

### DIFF
--- a/.sampo/changesets/wily-shaman-lempo.md
+++ b/.sampo/changesets/wily-shaman-lempo.md
@@ -1,0 +1,5 @@
+---
+pypi/posthog: patch
+---
+
+Track OpenAI chat completions parse calls

--- a/posthog/ai/openai/openai.py
+++ b/posthog/ai/openai/openai.py
@@ -26,6 +26,7 @@ from posthog.ai.openai.openai_converter import (
 from posthog.ai.sanitization import sanitize_openai, sanitize_openai_response
 from posthog.client import Client as PostHogClient
 from posthog import setup
+from posthog.ai.openai.wrapper_utils import warn_on_fallback
 
 
 class OpenAI(openai.OpenAI):
@@ -67,6 +68,29 @@ class OpenAI(openai.OpenAI):
             self.responses = WrappedResponses(self, self._original_responses)
 
 
+def _parse_and_track(
+    wrapper,
+    posthog_distinct_id: Optional[str],
+    posthog_trace_id: Optional[str],
+    posthog_properties: Optional[Dict[str, Any]],
+    posthog_privacy_mode: bool,
+    posthog_groups: Optional[Dict[str, Any]],
+    **kwargs: Any,
+):
+    return call_llm_and_track_usage(
+        posthog_distinct_id,
+        wrapper._client._ph_client,
+        "openai",
+        posthog_trace_id,
+        posthog_properties,
+        posthog_privacy_mode,
+        posthog_groups,
+        wrapper._client.base_url,
+        wrapper._original.parse,
+        **kwargs,
+    )
+
+
 class WrappedResponses:
     """Wrapper for OpenAI responses that tracks usage in PostHog."""
 
@@ -76,6 +100,7 @@ class WrappedResponses:
 
     def __getattr__(self, name):
         """Fallback to original responses object for any methods we don't explicitly handle."""
+        warn_on_fallback(self.__class__.__name__, name)
         return getattr(self._original, name)
 
     def create(
@@ -276,16 +301,13 @@ class WrappedResponses:
         Returns:
             The response from OpenAI's responses.parse call.
         """
-        return call_llm_and_track_usage(
+        return _parse_and_track(
+            self,
             posthog_distinct_id,
-            self._client._ph_client,
-            "openai",
             posthog_trace_id,
             posthog_properties,
             posthog_privacy_mode,
             posthog_groups,
-            self._client.base_url,
-            self._original.parse,
             **kwargs,
         )
 
@@ -299,6 +321,7 @@ class WrappedChat:
 
     def __getattr__(self, name):
         """Fallback to original chat object for any methods we don't explicitly handle."""
+        warn_on_fallback(self.__class__.__name__, name)
         return getattr(self._original, name)
 
     @property
@@ -316,7 +339,41 @@ class WrappedCompletions:
 
     def __getattr__(self, name):
         """Fallback to original completions object for any methods we don't explicitly handle."""
+        warn_on_fallback(self.__class__.__name__, name)
         return getattr(self._original, name)
+
+    def parse(
+        self,
+        posthog_distinct_id: Optional[str] = None,
+        posthog_trace_id: Optional[str] = None,
+        posthog_properties: Optional[Dict[str, Any]] = None,
+        posthog_privacy_mode: bool = False,
+        posthog_groups: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ):
+        """
+        Parse an OpenAI chat completion while tracking usage in PostHog.
+
+        Args:
+            posthog_distinct_id: Optional distinct ID to associate with the usage event.
+            posthog_trace_id: Optional trace ID. Generated automatically when omitted.
+            posthog_properties: Additional properties to include with the usage event.
+            posthog_privacy_mode: Whether to redact captured input and output.
+            posthog_groups: Optional PostHog groups to associate with the event.
+            **kwargs: Arguments passed to OpenAI's ``chat.completions.parse`` API.
+
+        Returns:
+            The parsed response from OpenAI.
+        """
+        return _parse_and_track(
+            self,
+            posthog_distinct_id,
+            posthog_trace_id,
+            posthog_properties,
+            posthog_privacy_mode,
+            posthog_groups,
+            **kwargs,
+        )
 
     def create(
         self,
@@ -518,6 +575,7 @@ class WrappedEmbeddings:
 
     def __getattr__(self, name):
         """Fallback to original embeddings object for any methods we don't explicitly handle."""
+        warn_on_fallback(self.__class__.__name__, name)
         return getattr(self._original, name)
 
     def create(
@@ -602,6 +660,7 @@ class WrappedBeta:
 
     def __getattr__(self, name):
         """Fallback to original beta object for any methods we don't explicitly handle."""
+        warn_on_fallback(self.__class__.__name__, name)
         return getattr(self._original, name)
 
     @property
@@ -619,6 +678,7 @@ class WrappedBetaChat:
 
     def __getattr__(self, name):
         """Fallback to original beta chat object for any methods we don't explicitly handle."""
+        warn_on_fallback(self.__class__.__name__, name)
         return getattr(self._original, name)
 
     @property
@@ -636,6 +696,7 @@ class WrappedBetaCompletions:
 
     def __getattr__(self, name):
         """Fallback to original beta completions object for any methods we don't explicitly handle."""
+        warn_on_fallback(self.__class__.__name__, name)
         return getattr(self._original, name)
 
     def parse(
@@ -661,15 +722,12 @@ class WrappedBetaCompletions:
         Returns:
             The parsed response from OpenAI.
         """
-        return call_llm_and_track_usage(
+        return _parse_and_track(
+            self,
             posthog_distinct_id,
-            self._client._ph_client,
-            "openai",
             posthog_trace_id,
             posthog_properties,
             posthog_privacy_mode,
             posthog_groups,
-            self._client.base_url,
-            self._original.parse,
             **kwargs,
         )

--- a/posthog/ai/openai/openai_async.py
+++ b/posthog/ai/openai/openai_async.py
@@ -28,6 +28,7 @@ from posthog.ai.openai.openai_converter import (
 )
 from posthog.ai.sanitization import sanitize_openai, sanitize_openai_response
 from posthog.client import Client as PostHogClient
+from posthog.ai.openai.wrapper_utils import warn_on_fallback
 
 
 class AsyncOpenAI(openai.AsyncOpenAI):
@@ -69,6 +70,29 @@ class AsyncOpenAI(openai.AsyncOpenAI):
             self.responses = WrappedResponses(self, self._original_responses)
 
 
+async def _parse_and_track(
+    wrapper,
+    posthog_distinct_id: Optional[str],
+    posthog_trace_id: Optional[str],
+    posthog_properties: Optional[Dict[str, Any]],
+    posthog_privacy_mode: bool,
+    posthog_groups: Optional[Dict[str, Any]],
+    **kwargs: Any,
+):
+    return await call_llm_and_track_usage_async(
+        posthog_distinct_id,
+        wrapper._client._ph_client,
+        "openai",
+        posthog_trace_id,
+        posthog_properties,
+        posthog_privacy_mode,
+        posthog_groups,
+        wrapper._client.base_url,
+        wrapper._original.parse,
+        **kwargs,
+    )
+
+
 class WrappedResponses:
     """Async wrapper for OpenAI responses that tracks usage in PostHog."""
 
@@ -78,7 +102,7 @@ class WrappedResponses:
 
     def __getattr__(self, name):
         """Fallback to original responses object for any methods we don't explicitly handle."""
-
+        warn_on_fallback(self.__class__.__name__, name)
         return getattr(self._original, name)
 
     async def create(
@@ -305,16 +329,13 @@ class WrappedResponses:
         Returns:
             The response from OpenAI's responses.parse call.
         """
-        return await call_llm_and_track_usage_async(
+        return await _parse_and_track(
+            self,
             posthog_distinct_id,
-            self._client._ph_client,
-            "openai",
             posthog_trace_id,
             posthog_properties,
             posthog_privacy_mode,
             posthog_groups,
-            self._client.base_url,
-            self._original.parse,
             **kwargs,
         )
 
@@ -328,6 +349,7 @@ class WrappedChat:
 
     def __getattr__(self, name):
         """Fallback to original chat object for any methods we don't explicitly handle."""
+        warn_on_fallback(self.__class__.__name__, name)
         return getattr(self._original, name)
 
     @property
@@ -345,7 +367,41 @@ class WrappedCompletions:
 
     def __getattr__(self, name):
         """Fallback to original completions object for any methods we don't explicitly handle."""
+        warn_on_fallback(self.__class__.__name__, name)
         return getattr(self._original, name)
+
+    async def parse(
+        self,
+        posthog_distinct_id: Optional[str] = None,
+        posthog_trace_id: Optional[str] = None,
+        posthog_properties: Optional[Dict[str, Any]] = None,
+        posthog_privacy_mode: bool = False,
+        posthog_groups: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ):
+        """
+        Parse an OpenAI chat completion while tracking usage in PostHog.
+
+        Args:
+            posthog_distinct_id: Optional distinct ID to associate with the usage event.
+            posthog_trace_id: Optional trace ID. Generated automatically when omitted.
+            posthog_properties: Additional properties to include with the usage event.
+            posthog_privacy_mode: Whether to redact captured input and output.
+            posthog_groups: Optional PostHog groups to associate with the event.
+            **kwargs: Arguments passed to OpenAI's async ``chat.completions.parse`` API.
+
+        Returns:
+            The parsed response from OpenAI.
+        """
+        return await _parse_and_track(
+            self,
+            posthog_distinct_id,
+            posthog_trace_id,
+            posthog_properties,
+            posthog_privacy_mode,
+            posthog_groups,
+            **kwargs,
+        )
 
     async def create(
         self,
@@ -574,7 +630,7 @@ class WrappedEmbeddings:
 
     def __getattr__(self, name):
         """Fallback to original embeddings object for any methods we don't explicitly handle."""
-
+        warn_on_fallback(self.__class__.__name__, name)
         return getattr(self._original, name)
 
     async def create(
@@ -660,7 +716,7 @@ class WrappedBeta:
 
     def __getattr__(self, name):
         """Fallback to original beta object for any methods we don't explicitly handle."""
-
+        warn_on_fallback(self.__class__.__name__, name)
         return getattr(self._original, name)
 
     @property
@@ -678,7 +734,7 @@ class WrappedBetaChat:
 
     def __getattr__(self, name):
         """Fallback to original beta chat object for any methods we don't explicitly handle."""
-
+        warn_on_fallback(self.__class__.__name__, name)
         return getattr(self._original, name)
 
     @property
@@ -696,7 +752,7 @@ class WrappedBetaCompletions:
 
     def __getattr__(self, name):
         """Fallback to original beta completions object for any methods we don't explicitly handle."""
-
+        warn_on_fallback(self.__class__.__name__, name)
         return getattr(self._original, name)
 
     async def parse(
@@ -722,15 +778,12 @@ class WrappedBetaCompletions:
         Returns:
             The parsed response from OpenAI.
         """
-        return await call_llm_and_track_usage_async(
+        return await _parse_and_track(
+            self,
             posthog_distinct_id,
-            self._client._ph_client,
-            "openai",
             posthog_trace_id,
             posthog_properties,
             posthog_privacy_mode,
             posthog_groups,
-            self._client.base_url,
-            self._original.parse,
             **kwargs,
         )

--- a/posthog/ai/openai/wrapper_utils.py
+++ b/posthog/ai/openai/wrapper_utils.py
@@ -5,6 +5,10 @@ log = logging.getLogger("posthog")
 _fallback_warnings: set[tuple[str, str]] = set()
 
 
+def reset_fallback_warnings() -> None:
+    _fallback_warnings.clear()
+
+
 def warn_on_fallback(wrapper_name: str, name: str) -> None:
     key = (wrapper_name, name)
     if key in _fallback_warnings:

--- a/posthog/ai/openai/wrapper_utils.py
+++ b/posthog/ai/openai/wrapper_utils.py
@@ -1,0 +1,19 @@
+import logging
+
+
+log = logging.getLogger("posthog")
+_fallback_warnings: set[tuple[str, str]] = set()
+
+
+def warn_on_fallback(wrapper_name: str, name: str) -> None:
+    key = (wrapper_name, name)
+    if key in _fallback_warnings:
+        return
+
+    _fallback_warnings.add(key)
+    log.warning(
+        "Falling back to unwrapped OpenAI API for %s.%s; PostHog LLM tracking "
+        "and posthog_* arguments will not be applied.",
+        wrapper_name,
+        name,
+    )

--- a/posthog/test/ai/openai/test_openai.py
+++ b/posthog/test/ai/openai/test_openai.py
@@ -38,6 +38,7 @@ try:
 
     from posthog.ai.openai import OpenAI
     from posthog.ai.openai.openai_async import AsyncOpenAI
+    from posthog.ai.openai.wrapper_utils import reset_fallback_warnings
 
     OPENAI_AVAILABLE = True
 except ImportError:
@@ -1193,15 +1194,47 @@ async def test_async_chat_completions_parse(mock_client, mock_openai_response):
         assert isinstance(props["$ai_latency"], float)
 
 
-def test_fallback_logs_warning(mock_client, caplog):
-    client = OpenAI(api_key="test-key", posthog_client=mock_client)
+@pytest.mark.parametrize(
+    "client_factory, wrapper_accessor, wrapper_name",
+    [
+        (OpenAI, lambda client: client.responses, "WrappedResponses"),
+        (OpenAI, lambda client: client.chat, "WrappedChat"),
+        (OpenAI, lambda client: client.chat.completions, "WrappedCompletions"),
+        (OpenAI, lambda client: client.embeddings, "WrappedEmbeddings"),
+        (OpenAI, lambda client: client.beta, "WrappedBeta"),
+        (OpenAI, lambda client: client.beta.chat, "WrappedBetaChat"),
+        (
+            OpenAI,
+            lambda client: client.beta.chat.completions,
+            "WrappedBetaCompletions",
+        ),
+        (AsyncOpenAI, lambda client: client.responses, "WrappedResponses"),
+        (AsyncOpenAI, lambda client: client.chat, "WrappedChat"),
+        (AsyncOpenAI, lambda client: client.chat.completions, "WrappedCompletions"),
+        (AsyncOpenAI, lambda client: client.embeddings, "WrappedEmbeddings"),
+        (AsyncOpenAI, lambda client: client.beta, "WrappedBeta"),
+        (AsyncOpenAI, lambda client: client.beta.chat, "WrappedBetaChat"),
+        (
+            AsyncOpenAI,
+            lambda client: client.beta.chat.completions,
+            "WrappedBetaCompletions",
+        ),
+    ],
+)
+def test_fallback_logs_warning(
+    mock_client, caplog, client_factory, wrapper_accessor, wrapper_name
+):
+    reset_fallback_warnings()
+    caplog.clear()
+    client = client_factory(api_key="test-key", posthog_client=mock_client)
+    wrapper = wrapper_accessor(client)
 
     with caplog.at_level(logging.WARNING, logger="posthog"):
         with pytest.raises(AttributeError):
-            client.chat.posthog_unwrapped_test_attribute
+            wrapper.posthog_unwrapped_test_attribute
 
     assert "Falling back to unwrapped OpenAI API" in caplog.text
-    assert "WrappedChat.posthog_unwrapped_test_attribute" in caplog.text
+    assert f"{wrapper_name}.posthog_unwrapped_test_attribute" in caplog.text
 
 
 def test_responses_api_streaming_with_tokens(mock_client):

--- a/posthog/test/ai/openai/test_openai.py
+++ b/posthog/test/ai/openai/test_openai.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import time
 from unittest.mock import AsyncMock, patch
@@ -1110,6 +1111,97 @@ def test_responses_parse(mock_client, mock_parsed_response):
         assert props["$ai_http_status"] == 200
         assert props["foo"] == "bar"
         assert isinstance(props["$ai_latency"], float)
+
+
+def test_chat_completions_parse(mock_client, mock_openai_response):
+    with patch(
+        "openai.resources.chat.completions.Completions.parse",
+        return_value=mock_openai_response,
+    ) as mock_parse:
+        client = OpenAI(api_key="test-key", posthog_client=mock_client)
+        response = client.chat.completions.parse(
+            model="gpt-4",
+            messages=[{"role": "user", "content": "Hello"}],
+            response_format={"type": "json_object"},
+            posthog_distinct_id="test-id",
+            posthog_properties={"foo": "bar"},
+        )
+
+        assert response == mock_openai_response
+        assert mock_parse.call_count == 1
+        assert "posthog_distinct_id" not in mock_parse.call_args.kwargs
+        assert mock_client.capture.call_count == 1
+
+        call_args = mock_client.capture.call_args[1]
+        props = call_args["properties"]
+
+        assert call_args["distinct_id"] == "test-id"
+        assert call_args["event"] == "$ai_generation"
+        assert props["$ai_provider"] == "openai"
+        assert props["$ai_model"] == "gpt-4"
+        assert props["$ai_input"] == [{"role": "user", "content": "Hello"}]
+        assert props["$ai_output_choices"] == [
+            {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Test response"}],
+            }
+        ]
+        assert props["$ai_input_tokens"] == 20
+        assert props["$ai_output_tokens"] == 10
+        assert props["foo"] == "bar"
+        assert isinstance(props["$ai_latency"], float)
+
+
+@pytest.mark.asyncio
+async def test_async_chat_completions_parse(mock_client, mock_openai_response):
+    mock_parse = AsyncMock(return_value=mock_openai_response)
+
+    with patch(
+        "openai.resources.chat.completions.AsyncCompletions.parse", new=mock_parse
+    ):
+        client = AsyncOpenAI(api_key="test-key", posthog_client=mock_client)
+        response = await client.chat.completions.parse(
+            model="gpt-4",
+            messages=[{"role": "user", "content": "Hello"}],
+            response_format={"type": "json_object"},
+            posthog_distinct_id="test-id",
+            posthog_properties={"foo": "bar"},
+        )
+
+        assert response == mock_openai_response
+        mock_parse.assert_awaited_once()
+        assert "posthog_distinct_id" not in mock_parse.call_args.kwargs
+        assert mock_client.capture.call_count == 1
+
+        call_args = mock_client.capture.call_args[1]
+        props = call_args["properties"]
+
+        assert call_args["distinct_id"] == "test-id"
+        assert call_args["event"] == "$ai_generation"
+        assert props["$ai_provider"] == "openai"
+        assert props["$ai_model"] == "gpt-4"
+        assert props["$ai_input"] == [{"role": "user", "content": "Hello"}]
+        assert props["$ai_output_choices"] == [
+            {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Test response"}],
+            }
+        ]
+        assert props["$ai_input_tokens"] == 20
+        assert props["$ai_output_tokens"] == 10
+        assert props["foo"] == "bar"
+        assert isinstance(props["$ai_latency"], float)
+
+
+def test_fallback_logs_warning(mock_client, caplog):
+    client = OpenAI(api_key="test-key", posthog_client=mock_client)
+
+    with caplog.at_level(logging.WARNING, logger="posthog"):
+        with pytest.raises(AttributeError):
+            client.chat.posthog_unwrapped_test_attribute
+
+    assert "Falling back to unwrapped OpenAI API" in caplog.text
+    assert "WrappedChat.posthog_unwrapped_test_attribute" in caplog.text
 
 
 def test_responses_api_streaming_with_tokens(mock_client):


### PR DESCRIPTION
## :bulb: Motivation and Context
Fixes https://github.com/PostHog/posthog-python/issues/614.

OpenAI `chat.completions.parse` calls were falling through to the raw OpenAI SDK object, so PostHog tracking was skipped and `posthog_*` arguments could be forwarded to OpenAI and crash. Unsupported fallback wrapper access now also logs a warning when tracking is bypassed.

## :green_heart: How did you test it?

- `uv run ruff check posthog/ai/openai/openai.py posthog/ai/openai/openai_async.py posthog/ai/openai/wrapper_utils.py posthog/test/ai/openai/test_openai.py`
- `uv run --extra test pytest posthog/test/ai/openai/test_openai.py -q`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file

<!-- For more details check RELEASING.md -->
