### PR TITLE
fix: include group context in $feature_flag_called dedupe key

### DIFF
--- a/.sampo/changesets/include-group-context-in-flag-called-dedupe.md
+++ b/.sampo/changesets/include-group-context-in-flag-called-dedupe.md
@@ -1,0 +1,5 @@
+---
+pypi/posthog: patch
+---
+
+Include group context in the `$feature_flag_called` dedupe key so group-scoped flags fire a separate event for each group a user is evaluated under, instead of being dedup-ed against the first group context the same `(distinct_id, flag, response)` was seen under.

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -2221,7 +2221,9 @@ class Client(object):
         ``FeatureFlagEvaluations.is_enabled() / get_flag()`` so both paths dedupe
         identically.
         """
-        groups_key = tuple(sorted((str(k), str(v)) for k, v in groups.items())) if groups else ()
+        groups_key = (
+            tuple(sorted((str(k), str(v)) for k, v in groups.items())) if groups else ()
+        )
         feature_flag_reported_key = (key, response, groups_key)
 
         reported_flags = self.distinct_ids_feature_flags_reported.get(distinct_id)

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -2221,12 +2221,8 @@ class Client(object):
         ``FeatureFlagEvaluations.is_enabled() / get_flag()`` so both paths dedupe
         identically.
         """
-        response_repr = "::null::" if response is None else str(response)
-        if groups:
-            groups_repr = json.dumps(sorted(groups.items()), separators=(",", ":"))
-            feature_flag_reported_key = f"{key}_{response_repr}_{groups_repr}"
-        else:
-            feature_flag_reported_key = f"{key}_{response_repr}"
+        groups_key = tuple(sorted((str(k), str(v)) for k, v in groups.items())) if groups else ()
+        feature_flag_reported_key = (key, response, groups_key)
 
         reported_flags = self.distinct_ids_feature_flags_reported.get(distinct_id)
         if reported_flags is None:

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -2214,14 +2214,19 @@ class Client(object):
         groups: Optional[Dict[str, str]] = None,
         disable_geoip: Optional[bool] = None,
     ) -> None:
-        """Fire a ``$feature_flag_called`` event if the (distinct_id, flag, response)
-        triple hasn't already been reported on this client. Shared by the single-flag
-        evaluation path and ``FeatureFlagEvaluations.is_enabled() / get_flag()`` so
-        both paths dedupe identically.
+        """Fire a ``$feature_flag_called`` event if the (distinct_id, flag, response,
+        groups) tuple hasn't already been reported on this client. Group context is
+        included so that group-scoped flags fire a separate event for each group a
+        user is evaluated under. Shared by the single-flag evaluation path and
+        ``FeatureFlagEvaluations.is_enabled() / get_flag()`` so both paths dedupe
+        identically.
         """
-        feature_flag_reported_key = (
-            f"{key}_{'::null::' if response is None else str(response)}"
-        )
+        response_repr = "::null::" if response is None else str(response)
+        if groups:
+            groups_repr = json.dumps(sorted(groups.items()), separators=(",", ":"))
+            feature_flag_reported_key = f"{key}_{response_repr}_{groups_repr}"
+        else:
+            feature_flag_reported_key = f"{key}_{response_repr}"
 
         reported_flags = self.distinct_ids_feature_flags_reported.get(distinct_id)
         if reported_flags is None:

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -5304,10 +5304,24 @@ class TestCaptureCalls(unittest.TestCase):
         self.assertIn({"company": "org-a"}, flag_called_groups)
         self.assertIn({"company": "org-b"}, flag_called_groups)
 
+    @parameterized.expand(
+        [
+            (
+                "same_context",
+                {"company": "org-a"},
+                {"company": "org-a"},
+            ),
+            (
+                "different_key_order",
+                {"company": "org-a", "team": "red"},
+                {"team": "red", "company": "org-a"},
+            ),
+        ]
+    )
     @mock.patch.object(Client, "capture")
     @mock.patch("posthog.client.flags")
     def test_capture_dedupes_repeated_calls_under_same_group_context(
-        self, patch_flags, patch_capture
+        self, _name, first_groups, second_groups, patch_flags, patch_capture
     ):
         client = Client(FAKE_TEST_API_KEY, personal_api_key=FAKE_TEST_API_KEY)
         client.feature_flags = [
@@ -5322,48 +5336,8 @@ class TestCaptureCalls(unittest.TestCase):
             }
         ]
 
-        client.get_feature_flag(
-            "group-scoped-flag", "user-1", groups={"company": "org-a"}
-        )
-        client.get_feature_flag(
-            "group-scoped-flag", "user-1", groups={"company": "org-a"}
-        )
-
-        flag_called_count = sum(
-            1
-            for call in patch_capture.call_args_list
-            if call.args and call.args[0] == "$feature_flag_called"
-        )
-        self.assertEqual(flag_called_count, 1)
-
-    @mock.patch.object(Client, "capture")
-    @mock.patch("posthog.client.flags")
-    def test_capture_dedupes_when_groups_passed_in_different_key_order(
-        self, patch_flags, patch_capture
-    ):
-        client = Client(FAKE_TEST_API_KEY, personal_api_key=FAKE_TEST_API_KEY)
-        client.feature_flags = [
-            {
-                "id": 1,
-                "name": "Group flag",
-                "key": "group-scoped-flag",
-                "active": True,
-                "filters": {
-                    "groups": [{"properties": [], "rollout_percentage": 100}],
-                },
-            }
-        ]
-
-        client.get_feature_flag(
-            "group-scoped-flag",
-            "user-1",
-            groups={"company": "org-a", "team": "red"},
-        )
-        client.get_feature_flag(
-            "group-scoped-flag",
-            "user-1",
-            groups={"team": "red", "company": "org-a"},
-        )
+        client.get_feature_flag("group-scoped-flag", "user-1", groups=first_groups)
+        client.get_feature_flag("group-scoped-flag", "user-1", groups=second_groups)
 
         flag_called_count = sum(
             1

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -5273,6 +5273,107 @@ class TestCaptureCalls(unittest.TestCase):
 
     @mock.patch.object(Client, "capture")
     @mock.patch("posthog.client.flags")
+    def test_capture_fires_per_group_context(self, patch_flags, patch_capture):
+        client = Client(FAKE_TEST_API_KEY, personal_api_key=FAKE_TEST_API_KEY)
+        client.feature_flags = [
+            {
+                "id": 1,
+                "name": "Group flag",
+                "key": "group-scoped-flag",
+                "active": True,
+                "filters": {
+                    "groups": [{"properties": [], "rollout_percentage": 100}],
+                },
+            }
+        ]
+
+        # Same user, same flag, same response — but two different group contexts.
+        client.get_feature_flag(
+            "group-scoped-flag", "user-1", groups={"company": "org-a"}
+        )
+        client.get_feature_flag(
+            "group-scoped-flag", "user-1", groups={"company": "org-b"}
+        )
+
+        flag_called_groups = [
+            call.kwargs.get("groups")
+            for call in patch_capture.call_args_list
+            if call.args and call.args[0] == "$feature_flag_called"
+        ]
+        self.assertEqual(len(flag_called_groups), 2)
+        self.assertIn({"company": "org-a"}, flag_called_groups)
+        self.assertIn({"company": "org-b"}, flag_called_groups)
+
+    @mock.patch.object(Client, "capture")
+    @mock.patch("posthog.client.flags")
+    def test_capture_dedupes_repeated_calls_under_same_group_context(
+        self, patch_flags, patch_capture
+    ):
+        client = Client(FAKE_TEST_API_KEY, personal_api_key=FAKE_TEST_API_KEY)
+        client.feature_flags = [
+            {
+                "id": 1,
+                "name": "Group flag",
+                "key": "group-scoped-flag",
+                "active": True,
+                "filters": {
+                    "groups": [{"properties": [], "rollout_percentage": 100}],
+                },
+            }
+        ]
+
+        client.get_feature_flag(
+            "group-scoped-flag", "user-1", groups={"company": "org-a"}
+        )
+        client.get_feature_flag(
+            "group-scoped-flag", "user-1", groups={"company": "org-a"}
+        )
+
+        flag_called_count = sum(
+            1
+            for call in patch_capture.call_args_list
+            if call.args and call.args[0] == "$feature_flag_called"
+        )
+        self.assertEqual(flag_called_count, 1)
+
+    @mock.patch.object(Client, "capture")
+    @mock.patch("posthog.client.flags")
+    def test_capture_dedupes_when_groups_passed_in_different_key_order(
+        self, patch_flags, patch_capture
+    ):
+        client = Client(FAKE_TEST_API_KEY, personal_api_key=FAKE_TEST_API_KEY)
+        client.feature_flags = [
+            {
+                "id": 1,
+                "name": "Group flag",
+                "key": "group-scoped-flag",
+                "active": True,
+                "filters": {
+                    "groups": [{"properties": [], "rollout_percentage": 100}],
+                },
+            }
+        ]
+
+        client.get_feature_flag(
+            "group-scoped-flag",
+            "user-1",
+            groups={"company": "org-a", "team": "red"},
+        )
+        client.get_feature_flag(
+            "group-scoped-flag",
+            "user-1",
+            groups={"team": "red", "company": "org-a"},
+        )
+
+        flag_called_count = sum(
+            1
+            for call in patch_capture.call_args_list
+            if call.args and call.args[0] == "$feature_flag_called"
+        )
+        self.assertEqual(flag_called_count, 1)
+
+    @mock.patch.object(Client, "capture")
+    @mock.patch("posthog.client.flags")
     def test_capture_multiple_users_doesnt_out_of_memory(
         self, patch_flags, patch_capture
     ):


### PR DESCRIPTION
## :bulb: Motivation and Context

In `_capture_feature_flag_called_if_needed`, the per-`distinct_id` dedupe key only included the flag key and response. For group-scoped flags this meant that when the same user was evaluated under a different group, no new `$feature_flag_called` event was fired — causing per-group exposure undercount for experiments scoped to a group key.

This mirrors the posthog-node fix in PostHog/posthog-js#3658 (which closes PostHog/posthog-js#3651). Both SDKs share the same dedupe shape, so backend evaluation needs the same change.

## :green_heart: How did you test it?

Added three tests covering the new behavior:

- `test_capture_fires_per_group_context` — same user, same flag, same response, two different group contexts → two `$feature_flag_called` events.
- `test_capture_dedupes_repeated_calls_under_same_group_context` — repeated access under the same group → one event.
- `test_capture_dedupes_when_groups_passed_in_different_key_order` — same groups passed with keys in a different order → still one event (canonicalized via `sorted(groups.items())`).

All 143 existing tests in `test_feature_flags.py` still pass, plus the 29 in `test_evaluate_flags.py`.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*