### PR TITLE
chore: add client libraries team as Dependabot reviewer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,7 @@ updates:
       - dependency-name: "langgraph"
     open-pull-requests-limit: 1
     reviewers:
+      - "PostHog/team-client-libraries"
       - "PostHog/team-llm-analytics"
 
   - package-ecosystem: "pip"
@@ -54,6 +55,7 @@ updates:
       - dependency-name: "langgraph"
     open-pull-requests-limit: 1
     reviewers:
+      - "PostHog/team-client-libraries"
       - "PostHog/team-llm-analytics"
     # Uncomment below to enable auto-merge for minor updates when CI passes
     # pull-request-branch-name:


### PR DESCRIPTION
## :bulb: Motivation and Context
Dependabot PRs should request reviews from `PostHog/team-client-libraries`, matching the setup added in PostHog/posthog-js#3675.

This adds `PostHog/team-client-libraries` as a reviewer in `.github/dependabot.yml`.

## :green_heart: How did you test it?
- Parsed `.github/dependabot.yml` with Ruby YAML.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file
