### PR TITLE
docs: remove experimental flag definition cache labels

### DIFF
--- a/posthog/flag_definition_cache.py
+++ b/posthog/flag_definition_cache.py
@@ -1,8 +1,6 @@
 """
 Flag Definition Cache Provider interface for multi-worker environments.
 
-EXPERIMENTAL: This API may change in future minor version bumps.
-
 This module provides an interface for external caching of feature flag definitions,
 enabling multi-worker environments (Kubernetes, load-balanced servers, serverless
 functions) to share flag definitions and reduce API calls.
@@ -56,8 +54,6 @@ class FlagDefinitionCacheProvider(Protocol):
 
     Enables multi-worker environments to share flag definitions, reducing API
     calls while ensuring all workers have consistent data.
-
-    EXPERIMENTAL: This API may change in future minor version bumps.
 
     Methods may be implemented as either synchronous functions or async
     functions. If a method returns an awaitable, the SDK runs it to completion


### PR DESCRIPTION
## :bulb: Motivation and Context

The flag definition cache provider is now supported and should no longer be documented as experimental.

Companion Ruby PR: https://github.com/PostHog/posthog-ruby/pull/157
Docs PR: https://github.com/PostHog/posthog.com/pull/17075

## :green_heart: How did you test it?

Verified there are no remaining `experimental` references with:

```bash
rg -n -i "experimental" .
```

No test suite run; this is a docs/comment-only change.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file
