### PR TITLE
fix: no-op global client for blank api key

### DIFF
--- a/.sampo/changesets/haughty-thunderbearer-mielikki.md
+++ b/.sampo/changesets/haughty-thunderbearer-mielikki.md
@@ -1,0 +1,5 @@
+---
+pypi/posthog: patch
+---
+
+Make module-level setup no-op when API key is blank

--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -266,8 +266,8 @@ For new code, prefer creating an explicit ``Posthog``/``Client`` instance with
 the corresponding constructor arguments.
 
 Attributes:
-    api_key: Project API key/token used by the global client. Required before
-        calling any global capture or feature flag API.
+    api_key: Project API key/token used by the global client. Missing or blank
+        values create a disabled no-op global client.
     host: PostHog ingestion host. Defaults to the US ingestion endpoint when not
         set.
     on_error: Optional callback invoked by background consumers when event upload
@@ -1066,18 +1066,16 @@ def setup() -> Client:
     Returns:
         The global ``Client`` instance.
 
-    Raises:
-        ValueError: If ``api_key`` has not been configured.
+    If ``api_key`` is missing or blank, the returned client is disabled and
+    module-level calls become no-ops.
 
     Category:
         Initialization
     """
     global default_client
     if not default_client:
-        if not api_key:
-            raise ValueError("API key is required")
         default_client = Client(
-            api_key,
+            api_key or "",
             host=host,
             debug=debug,
             on_error=on_error,

--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -1064,18 +1064,17 @@ def setup() -> Client:
     ``setup()`` is called automatically by global APIs such as ``capture()``.
 
     Returns:
-        The global ``Client`` instance.
-
-    If ``api_key`` is missing or blank, the returned client is disabled and
-    module-level calls become no-ops.
+        The global ``Client`` instance. If ``api_key`` is missing or blank,
+        the client is disabled and module-level calls become no-ops.
 
     Category:
         Initialization
     """
     global default_client
     if not default_client:
+        configured_api_key = api_key.strip() if api_key else ""
         default_client = Client(
-            api_key or "",
+            configured_api_key,
             host=host,
             debug=debug,
             on_error=on_error,

--- a/posthog/test/test_module.py
+++ b/posthog/test/test_module.py
@@ -43,7 +43,6 @@ class TestModuleLevelSetup(unittest.TestCase):
         self._original_disabled = posthog.disabled
         self._original_send = posthog.send
         posthog.default_client = None
-        posthog.api_key = " \n\t "
         posthog.disabled = False
         posthog.send = False
 
@@ -53,12 +52,24 @@ class TestModuleLevelSetup(unittest.TestCase):
         posthog.disabled = self._original_disabled
         posthog.send = self._original_send
 
-    def test_setup_preserves_client_disabled_when_trimmed_api_key_is_empty(self):
-        posthog.setup()
+    @parameterized.expand(
+        [
+            ("unset", None),
+            ("empty", ""),
+            ("whitespace", " \n\t "),
+        ]
+    )
+    def test_setup_configures_disabled_client_when_api_key_is_blank(
+        self, _name, api_key
+    ):
+        posthog.api_key = api_key
 
-        self.assertIsNotNone(posthog.default_client)
-        self.assertEqual(posthog.default_client.api_key, "")
-        self.assertTrue(posthog.default_client.disabled)
+        client = posthog.setup()
+
+        self.assertIs(client, posthog.default_client)
+        self.assertEqual(client.api_key, "")
+        self.assertTrue(client.disabled)
+        self.assertIsNone(posthog.capture("Module Python Event", distinct_id="john"))
 
 
 class TestModuleLevelWrappers(unittest.TestCase):


### PR DESCRIPTION
## :bulb: Motivation and Context
Module-level setup should be safe when the global API key is unset or blank. Instead of raising during setup, blank API keys now create a disabled no-op global client so module-level calls are ignored consistently.

Changes:
- Strip the module-level API key before creating the global client.
- Treat missing, empty, and whitespace-only global API keys as a disabled no-op client.
- Update the module-level API key/setup documentation to describe the no-op behavior in the return value docs.
- Add parameterized coverage for unset, empty, and whitespace-only API keys.
- Add a Sampo patch changeset for the release note.

## :green_heart: How did you test it?
- `.venv/bin/python -m pytest posthog/test/test_module.py -q`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file

<!-- For more details check RELEASING.md -->
