### PR TITLE
chore: add dependency update delay settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       day: "monday"
       time: "10:00"
       timezone: "UTC"
+    cooldown:
+      default-days: 7
     exclude-paths:
       - "examples/**"
       - "integration_tests/**"
@@ -36,6 +38,8 @@ updates:
       day: "monday"
       time: "10:00"
       timezone: "UTC"
+    cooldown:
+      default-days: 7
     exclude-paths:
       - "examples/**"
       - "integration_tests/**"


### PR DESCRIPTION
## :bulb: Motivation and Context
Dependency automation should avoid opening updates immediately after packages are published. This adds the requested Dependabot cooldown configuration.


## :green_heart: How did you test it?
Not run (configuration-only change).


## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file
