### PR TITLE
fix: no-op flag helpers on API errors

### DIFF
--- a/.sampo/changesets/noop-flag-api-errors.md
+++ b/.sampo/changesets/noop-flag-api-errors.md
@@ -1,0 +1,5 @@
+---
+pypi/posthog: patch
+---
+
+Return empty flag defaults from Client flag helpers when the flags API fails.

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -642,12 +642,16 @@ class Client(object):
         if flag_keys_to_evaluate:
             request_data["flag_keys_to_evaluate"] = flag_keys_to_evaluate
 
-        resp_data = flags(
-            self.api_key,
-            self.host,
-            timeout=self.feature_flags_request_timeout_seconds,
-            **request_data,
-        )
+        try:
+            resp_data = flags(
+                self.api_key,
+                self.host,
+                timeout=self.feature_flags_request_timeout_seconds,
+                **request_data,
+            )
+        except Exception as err:
+            self.log.exception("Unable to get feature flags: %s", err)
+            return normalize_flags_response({})
 
         return normalize_flags_response(resp_data)
 

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -611,6 +611,30 @@ class Client(object):
         Category:
             Feature flags
         """
+        try:
+            return self._get_flags_decision(
+                distinct_id,
+                groups,
+                person_properties,
+                group_properties,
+                disable_geoip,
+                flag_keys_to_evaluate,
+                device_id=device_id,
+            )
+        except Exception as err:
+            self.log.exception("Unable to get feature flags: %s", err)
+            return normalize_flags_response({})
+
+    def _get_flags_decision(
+        self,
+        distinct_id: Optional[ID_TYPES] = None,
+        groups: Optional[dict] = None,
+        person_properties=None,
+        group_properties=None,
+        disable_geoip=None,
+        flag_keys_to_evaluate: Optional[list[str]] = None,
+        device_id: Optional[str] = None,
+    ) -> FlagsResponse:
         if self.disabled:
             return normalize_flags_response({})
 
@@ -642,16 +666,12 @@ class Client(object):
         if flag_keys_to_evaluate:
             request_data["flag_keys_to_evaluate"] = flag_keys_to_evaluate
 
-        try:
-            resp_data = flags(
-                self.api_key,
-                self.host,
-                timeout=self.feature_flags_request_timeout_seconds,
-                **request_data,
-            )
-        except Exception as err:
-            self.log.exception("Unable to get feature flags: %s", err)
-            return normalize_flags_response({})
+        resp_data = flags(
+            self.api_key,
+            self.host,
+            timeout=self.feature_flags_request_timeout_seconds,
+            **request_data,
+        )
 
         return normalize_flags_response(resp_data)
 
@@ -2179,7 +2199,7 @@ class Client(object):
         Calls /flags and returns the flag details, request id, evaluated at timestamp,
         and whether there were errors while computing flags.
         """
-        resp_data = self.get_flags_decision(
+        resp_data = self._get_flags_decision(
             distinct_id,
             groups,
             person_properties,
@@ -2451,7 +2471,7 @@ class Client(object):
 
         if fallback_to_flags and not only_evaluate_locally:
             try:
-                decide_response = self.get_flags_decision(
+                decide_response = self._get_flags_decision(
                     distinct_id,
                     groups=groups,
                     person_properties=person_properties,
@@ -2588,11 +2608,11 @@ class Client(object):
             locally_evaluated_keys.add(key)
 
         # Fall back to remote evaluation for any flags the poller couldn't resolve locally.
-        # Use ``get_flags_decision`` directly so the resulting records carry id/version/reason
+        # Use the flags decision path directly so the resulting records carry id/version/reason
         # and fired ``$feature_flag_called`` events match what ``get_feature_flag()`` emits.
         if fallback_to_server and not only_evaluate_locally:
             try:
-                response = self.get_flags_decision(
+                response = self._get_flags_decision(
                     distinct_id,
                     groups=groups,
                     person_properties=person_properties,

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -111,13 +111,32 @@ class TestClient(unittest.TestCase):
         patch_flags.side_effect = APIError(401, "Unauthorized")
         client = Client(FAKE_TEST_API_KEY, send=False)
 
-        self.assertEqual(client.get_flags_decision("distinct_id")["flags"], {})
-        self.assertEqual(client.get_feature_variants("distinct_id"), {})
-        self.assertEqual(client.get_feature_payloads("distinct_id"), {})
-        self.assertEqual(
-            client.get_feature_flags_and_payloads("distinct_id"),
-            {"featureFlags": {}, "featureFlagPayloads": {}},
-        )
+        test_cases = [
+            (
+                "get_flags_decision",
+                lambda: client.get_flags_decision("distinct_id")["flags"],
+                {},
+            ),
+            (
+                "get_feature_variants",
+                lambda: client.get_feature_variants("distinct_id"),
+                {},
+            ),
+            (
+                "get_feature_payloads",
+                lambda: client.get_feature_payloads("distinct_id"),
+                {},
+            ),
+            (
+                "get_feature_flags_and_payloads",
+                lambda: client.get_feature_flags_and_payloads("distinct_id"),
+                {"featureFlags": {}, "featureFlagPayloads": {}},
+            ),
+        ]
+
+        for method_name, call_helper, expected in test_cases:
+            with self.subTest(method=method_name):
+                self.assertEqual(call_helper(), expected)
 
     def test_empty_flush(self):
         self.client.flush()

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -106,6 +106,19 @@ class TestClient(unittest.TestCase):
         )
         patch_flags.assert_not_called()
 
+    @mock.patch("posthog.client.flags")
+    def test_client_flag_helpers_return_defaults_on_api_error(self, patch_flags):
+        patch_flags.side_effect = APIError(401, "Unauthorized")
+        client = Client(FAKE_TEST_API_KEY, send=False)
+
+        self.assertEqual(client.get_flags_decision("distinct_id")["flags"], {})
+        self.assertEqual(client.get_feature_variants("distinct_id"), {})
+        self.assertEqual(client.get_feature_payloads("distinct_id"), {})
+        self.assertEqual(
+            client.get_feature_flags_and_payloads("distinct_id"),
+            {"featureFlags": {}, "featureFlagPayloads": {}},
+        )
+
     def test_empty_flush(self):
         self.client.flush()
 


### PR DESCRIPTION
## :bulb: Motivation and Context

The Python Client-only feature flag helpers should return default values instead of raising when `/flags` fails because the SDK is non-operational, for example due to an invalid non-empty project API key.

Changes:
- Catch flag API exceptions in `Client.get_flags_decision()` and return an empty normalized flags response.
- Cover the convenience helpers that depend on `get_flags_decision()` (`get_feature_variants`, `get_feature_payloads`, and `get_feature_flags_and_payloads`).
- Add a Sampo changeset.

## :green_heart: How did you test it?

- `uv run pytest posthog/test/test_client.py -q`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file
