### PR TITLE
fix: add missing return type annotations

### DIFF
--- a/.sampo/changesets/missing-return-type-annotations.md
+++ b/.sampo/changesets/missing-return-type-annotations.md
@@ -1,0 +1,5 @@
+---
+pypi/posthog: patch
+---
+
+Add missing return type annotations to improve typing coverage without changing runtime behavior.

--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -581,7 +581,7 @@ def alias(
 def capture_exception(
     exception: Optional[ExceptionArg] = None,
     **kwargs: Unpack[OptionalCaptureArgs],
-):
+) -> Optional[str]:
     """
     Capture exceptions that happen in your code.
 
@@ -1026,7 +1026,7 @@ def load_feature_flags():
     return _proxy("load_feature_flags")
 
 
-def flush():
+def flush() -> None:
     """
     Tell the client to flush all queued events.
 
@@ -1042,7 +1042,7 @@ def flush():
     _proxy("flush")
 
 
-def join():
+def join() -> None:
     """
     Block program until the client clears the queue. Used during program shutdown. You should use `shutdown()` directly in most cases.
 
@@ -1058,7 +1058,7 @@ def join():
     _proxy("join")
 
 
-def shutdown():
+def shutdown() -> None:
     """
     Flush all messages and cleanly shutdown the client.
 

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -1139,7 +1139,7 @@ class Client(object):
         self,
         exception: Optional[ExceptionArg],
         **kwargs: Unpack[OptionalCaptureArgs],
-    ):
+    ) -> Optional[str]:
         """
         Capture an exception for error tracking.
 
@@ -1261,6 +1261,7 @@ class Client(object):
             return res
         except Exception as e:
             self.log.exception(f"Failed to capture exception: {e}")
+            return None
 
     @staticmethod
     def _reinit_after_fork_weak(weak_self):
@@ -1423,7 +1424,7 @@ class Client(object):
             self.log.warning("analytics-python queue is full")
             return None
 
-    def flush(self):
+    def flush(self) -> None:
         """
         Force a flush from the internal queue to the server. Do not use directly, call `shutdown()` instead.
 
@@ -1439,7 +1440,7 @@ class Client(object):
         # Note that this message may not be precise, because of threading.
         self.log.debug("successfully flushed about %s items.", size)
 
-    def join(self):
+    def join(self) -> None:
         """
         End the consumer thread once the queue is empty. Do not use directly, call `shutdown()` instead.
 
@@ -1463,7 +1464,7 @@ class Client(object):
         # Shutdown the cache provider (release locks, cleanup)
         self._shutdown_flag_definition_cache_provider()
 
-    def shutdown(self):
+    def shutdown(self) -> None:
         """
         Flush all messages and cleanly shutdown the client. Call this before the process ends in serverless environments to avoid data loss.
 


### PR DESCRIPTION
## Summary

Adds explicit return annotations for `Client.capture_exception`, the client lifecycle helpers (`flush`, `join`, `shutdown`), and the equivalent module-level helpers. `capture_exception` now also returns `None` explicitly if its defensive exception handler is reached.

This is a small incremental typing improvement related to #559.

## Validation

- `pytest posthog/test/test_client.py::TestClient::test_basic_capture_exception posthog/test/test_client.py::TestClient::test_basic_capture_exception_with_distinct_id posthog/test/test_client.py::TestClient::test_basic_capture_exception_with_correct_host_generation posthog/test/test_client.py::TestClient::test_basic_capture_exception_with_correct_host_generation_for_server_hosts posthog/test/test_client.py::TestClient::test_basic_capture_exception_with_no_exception_given posthog/test/test_client.py::TestClient::test_basic_capture_exception_with_no_exception_happening posthog/test/test_client.py::TestClient::test_capture_exception_logs_when_enabled posthog/test/test_client.py::TestClient::test_flush posthog/test/test_client.py::TestClient::test_shutdown posthog/test/test_module.py::TestModule::test_flush`
- `pyright typing_smoke.py` with `# pyright: strict` confirmed the updated helper return types as `str | None` or `None`.


<!-- retrigger semantic title check after title update -->