### PR TITLE
fix(ai): support `async with` on async streaming responses (Fixes #393)

### DIFF
--- a/.sampo/changesets/async-stream-context-manager.md
+++ b/.sampo/changesets/async-stream-context-manager.md
@@ -1,0 +1,5 @@
+---
+pypi/posthog: patch
+---
+
+Fix `TypeError: 'async_generator' object does not support the asynchronous context manager protocol` when using the async AI wrappers (`posthog.ai.openai.AsyncOpenAI`, `posthog.ai.anthropic.AsyncAnthropic`) with libraries such as pydantic-ai that consume streaming responses via `async with`. Streaming responses now support both `async for` and `async with`, and exiting the context closes the underlying provider stream.

--- a/.sampo/changesets/async-stream-context-manager.md
+++ b/.sampo/changesets/async-stream-context-manager.md
@@ -2,4 +2,6 @@
 pypi/posthog: patch
 ---
 
-Fix `TypeError: 'async_generator' object does not support the asynchronous context manager protocol` when using the async AI wrappers (`posthog.ai.openai.AsyncOpenAI`, `posthog.ai.anthropic.AsyncAnthropic`) with libraries such as pydantic-ai that consume streaming responses via `async with`. Streaming responses now support both `async for` and `async with`, and exiting the context closes the underlying provider stream.
+Fix `TypeError: 'async_generator' object does not support the asynchronous context manager protocol` when using the async AI wrappers (`posthog.ai.openai.AsyncOpenAI`, `posthog.ai.anthropic.AsyncAnthropic`, `posthog.ai.gemini.AsyncClient`) with libraries such as pydantic-ai that consume streaming responses via `async with`. Streaming responses now support both `async for` and `async with`, and exiting the context closes the underlying provider stream.
+
+Note: the async streaming return type changes from a bare `AsyncGenerator` to `AsyncStreamWrapper` (`async for`, `await response.aclose()`, and attribute access like `.response` are preserved, but `inspect.isasyncgen(response)` is now `False`). Sync streaming wrappers are unchanged and still return a bare generator.

--- a/.sampo/changesets/async-stream-context-manager.md
+++ b/.sampo/changesets/async-stream-context-manager.md
@@ -2,6 +2,4 @@
 pypi/posthog: patch
 ---
 
-Fix `TypeError: 'async_generator' object does not support the asynchronous context manager protocol` when using the async AI wrappers (`posthog.ai.openai.AsyncOpenAI`, `posthog.ai.anthropic.AsyncAnthropic`, `posthog.ai.gemini.AsyncClient`) with libraries such as pydantic-ai that consume streaming responses via `async with`. Streaming responses now support both `async for` and `async with`, and exiting the context closes the underlying provider stream.
-
-Note: the async streaming return type changes from a bare `AsyncGenerator` to `AsyncStreamWrapper` (`async for`, `await response.aclose()`, and attribute access like `.response` are preserved, but `inspect.isasyncgen(response)` is now `False`). Sync streaming wrappers are unchanged and still return a bare generator.
+Fix async streaming responses from the AI wrappers (OpenAI, Anthropic, Gemini) so they support `async with` as well as `async for`. Previously, consuming a stream via `async with` (e.g. with pydantic-ai) raised `TypeError: 'async_generator' object does not support the asynchronous context manager protocol`.

--- a/posthog/ai/anthropic/anthropic_async.py
+++ b/posthog/ai/anthropic/anthropic_async.py
@@ -226,7 +226,7 @@ class AsyncWrappedMessages(AsyncMessages):
                     stop_reason=stop_reason,
                 )
 
-        return AsyncStreamWrapper(generator(), response)
+        return AsyncStreamWrapper(generator(), stream=response)
 
     async def _capture_streaming_event(
         self,

--- a/posthog/ai/anthropic/anthropic_async.py
+++ b/posthog/ai/anthropic/anthropic_async.py
@@ -11,6 +11,7 @@ import uuid
 from typing import Any, Dict, List, Optional
 
 from posthog import setup
+from posthog.ai.stream import AsyncStreamWrapper
 from posthog.ai.types import StreamingContentBlock, TokenUsage, ToolInProgress
 from posthog.ai.utils import (
     call_llm_and_track_usage_async,
@@ -225,7 +226,7 @@ class AsyncWrappedMessages(AsyncMessages):
                     stop_reason=stop_reason,
                 )
 
-        return generator()
+        return AsyncStreamWrapper(generator(), response)
 
     async def _capture_streaming_event(
         self,

--- a/posthog/ai/gemini/gemini_async.py
+++ b/posthog/ai/gemini/gemini_async.py
@@ -3,6 +3,7 @@ import time
 import uuid
 from typing import Any, Dict, Optional
 
+from posthog.ai.stream import AsyncStreamWrapper
 from posthog.ai.types import TokenUsage, StreamingEventData
 from posthog.ai.utils import merge_system_prompt
 
@@ -354,7 +355,7 @@ class AsyncModels:
                     stop_reason=stop_reason,
                 )
 
-        return async_generator()
+        return AsyncStreamWrapper(async_generator(), stream=response)
 
     def _capture_streaming_event(
         self,

--- a/posthog/ai/openai/openai_async.py
+++ b/posthog/ai/openai/openai_async.py
@@ -222,7 +222,7 @@ class WrappedResponses(_OpenAIWrapperResource):
                     stop_reason=stop_reason,
                 )
 
-        return AsyncStreamWrapper(async_generator(), response)
+        return AsyncStreamWrapper(async_generator(), stream=response)
 
     async def _capture_streaming_event(
         self,
@@ -516,7 +516,7 @@ class WrappedCompletions(_OpenAIWrapperResource):
                     stop_reason=stop_reason,
                 )
 
-        return AsyncStreamWrapper(async_generator(), response)
+        return AsyncStreamWrapper(async_generator(), stream=response)
 
     async def _capture_streaming_event(
         self,

--- a/posthog/ai/openai/openai_async.py
+++ b/posthog/ai/openai/openai_async.py
@@ -2,6 +2,7 @@ import time
 import uuid
 from typing import Any, Dict, List, Optional
 
+from posthog.ai.stream import AsyncStreamWrapper
 from posthog.ai.types import TokenUsage
 
 try:
@@ -221,7 +222,7 @@ class WrappedResponses(_OpenAIWrapperResource):
                     stop_reason=stop_reason,
                 )
 
-        return async_generator()
+        return AsyncStreamWrapper(async_generator(), response)
 
     async def _capture_streaming_event(
         self,
@@ -515,7 +516,7 @@ class WrappedCompletions(_OpenAIWrapperResource):
                     stop_reason=stop_reason,
                 )
 
-        return async_generator()
+        return AsyncStreamWrapper(async_generator(), response)
 
     async def _capture_streaming_event(
         self,

--- a/posthog/ai/stream.py
+++ b/posthog/ai/stream.py
@@ -6,28 +6,14 @@ T = TypeVar("T")
 
 
 class AsyncStreamWrapper(Generic[T]):
-    """Wraps an async generator so it also implements the async context manager protocol.
+    """Adds the async context manager protocol to a PostHog streaming generator.
 
-    The OpenAI and Anthropic SDKs return stream objects that support both
-    ``async for`` iteration **and** ``async with`` (i.e. they are both async
-    iterators and async context managers).  PostHog's streaming wrappers
-    previously returned a bare async generator, which only supports ``async
-    for``.  Libraries such as pydantic-ai call ``async with response:`` before
-    iterating, causing::
-
-        TypeError: 'async_generator' object does not support the
-        asynchronous context manager protocol
-
-    This class wraps the PostHog tracking generator and adds the missing
-    ``__aenter__`` / ``__aexit__`` methods.  When available, it also keeps a
-    reference to the original provider stream so that:
-
-    - On ``__aexit__`` the tracking generator is closed (so the ``finally``
-      block that fires the PostHog usage event always runs, even on early
-      exit) **and** the underlying provider stream is closed (releasing the
-      HTTP connection, matching the native SDK behaviour).
-    - Attribute access not handled here is proxied to the provider stream, so
-      provider-specific metadata such as ``.response`` keeps working.
+    The OpenAI and Anthropic SDK streams support both ``async for`` and
+    ``async with``. PostHog's wrappers returned a bare async generator, which
+    only supports ``async for``, so ``async with response:`` (used by
+    pydantic-ai) raised a TypeError. This wraps the tracking generator and,
+    when given the original provider stream, closes it and proxies attribute
+    access (e.g. ``.response``) to it.
     """
 
     def __init__(
@@ -38,46 +24,30 @@ class AsyncStreamWrapper(Generic[T]):
         self._generator = generator
         self._stream = stream
 
-    # ------------------------------------------------------------------ #
-    # Async iterator protocol                                              #
-    # ------------------------------------------------------------------ #
-
     def __aiter__(self) -> "AsyncStreamWrapper[T]":
         return self
 
     async def __anext__(self) -> T:
         return await self._generator.__anext__()
 
-    # ------------------------------------------------------------------ #
-    # Async context manager protocol                                       #
-    # ------------------------------------------------------------------ #
-
     async def __aenter__(self) -> "AsyncStreamWrapper[T]":
         return self
 
     async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> bool:
-        # Close our tracking generator first so its `finally` block runs and
-        # the PostHog usage event is captured, even when the caller breaks out
-        # of the loop early. If it is already exhausted this is a no-op.
-        await self._generator.aclose()
-
-        # Then close the underlying provider stream to release the HTTP
-        # connection, matching native SDK behaviour. Provider streams expose an
-        # async `close()`; bare async generators (e.g. in tests) expose
-        # `aclose()`.
-        if self._stream is not None:
-            close = getattr(self._stream, "aclose", None) or getattr(
-                self._stream, "close", None
-            )
-            if close is not None:
-                await close()
+        # Close the tracking generator first so its `finally` block captures the
+        # PostHog event, even on early exit. try/finally guarantees the provider
+        # stream is still closed if that capture raises.
+        try:
+            await self._generator.aclose()
+        finally:
+            if self._stream is not None:
+                close = getattr(self._stream, "aclose", None) or getattr(
+                    self._stream, "close", None
+                )
+                if close is not None:
+                    await close()
 
         return False
-
-    # ------------------------------------------------------------------ #
-    # Attribute proxy – forward any other attribute access to the         #
-    # underlying provider stream (e.g. `.response`) when available.       #
-    # ------------------------------------------------------------------ #
 
     def __getattr__(self, name: str) -> Any:
         target = self._stream if self._stream is not None else self._generator

--- a/posthog/ai/stream.py
+++ b/posthog/ai/stream.py
@@ -50,5 +50,10 @@ class AsyncStreamWrapper(Generic[T]):
         return False
 
     def __getattr__(self, name: str) -> Any:
+        # Only proxy public attributes (e.g. `.response`). Private/dunder names
+        # are not forwarded — this avoids infinite recursion if `_stream` isn't
+        # set yet and stops `hasattr`/copy probes leaking to the provider stream.
+        if name.startswith("_"):
+            raise AttributeError(name)
         target = self._stream if self._stream is not None else self._generator
         return getattr(target, name)

--- a/posthog/ai/stream.py
+++ b/posthog/ai/stream.py
@@ -49,11 +49,20 @@ class AsyncStreamWrapper(Generic[T]):
 
         return False
 
+    # Async-generator protocol methods belong to the tracking generator, not
+    # the provider stream (provider AsyncStreams expose `close()`, not these).
+    # Forwarding `aclose()` to the generator preserves the pre-wrapper behaviour
+    # where `await response.aclose()` runs the generator's `finally` (firing the
+    # PostHog event) instead of raising AttributeError.
+    _GENERATOR_METHODS = ("aclose", "asend", "athrow")
+
     def __getattr__(self, name: str) -> Any:
         # Only proxy public attributes (e.g. `.response`). Private/dunder names
         # are not forwarded — this avoids infinite recursion if `_stream` isn't
         # set yet and stops `hasattr`/copy probes leaking to the provider stream.
         if name.startswith("_"):
             raise AttributeError(name)
+        if name in self._GENERATOR_METHODS:
+            return getattr(self._generator, name)
         target = self._stream if self._stream is not None else self._generator
         return getattr(target, name)

--- a/posthog/ai/stream.py
+++ b/posthog/ai/stream.py
@@ -1,11 +1,11 @@
 """Shared async streaming utilities for PostHog AI wrappers."""
 
-from typing import Any, AsyncGenerator, Optional, TypeVar
+from typing import Any, AsyncGenerator, Generic, Optional, TypeVar
 
 T = TypeVar("T")
 
 
-class AsyncStreamWrapper:
+class AsyncStreamWrapper(Generic[T]):
     """Wraps an async generator so it also implements the async context manager protocol.
 
     The OpenAI and Anthropic SDKs return stream objects that support both
@@ -42,7 +42,7 @@ class AsyncStreamWrapper:
     # Async iterator protocol                                              #
     # ------------------------------------------------------------------ #
 
-    def __aiter__(self) -> "AsyncStreamWrapper":
+    def __aiter__(self) -> "AsyncStreamWrapper[T]":
         return self
 
     async def __anext__(self) -> T:
@@ -52,7 +52,7 @@ class AsyncStreamWrapper:
     # Async context manager protocol                                       #
     # ------------------------------------------------------------------ #
 
-    async def __aenter__(self) -> "AsyncStreamWrapper":
+    async def __aenter__(self) -> "AsyncStreamWrapper[T]":
         return self
 
     async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> bool:

--- a/posthog/ai/stream.py
+++ b/posthog/ai/stream.py
@@ -34,9 +34,8 @@ class AsyncStreamWrapper(Generic[T]):
         return self
 
     async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> bool:
-        # Close the tracking generator first so its `finally` block captures the
-        # PostHog event, even on early exit. try/finally guarantees the provider
-        # stream is still closed if that capture raises.
+        # Close the generator first so its `finally` captures the event, even on
+        # early exit. try/finally still closes the provider stream if that raises.
         try:
             await self._generator.aclose()
         finally:
@@ -49,17 +48,12 @@ class AsyncStreamWrapper(Generic[T]):
 
         return False
 
-    # Async-generator protocol methods belong to the tracking generator, not
-    # the provider stream (provider AsyncStreams expose `close()`, not these).
-    # Forwarding `aclose()` to the generator preserves the pre-wrapper behaviour
-    # where `await response.aclose()` runs the generator's `finally` (firing the
-    # PostHog event) instead of raising AttributeError.
+    # aclose/asend/athrow belong to the generator; provider streams expose
+    # close(), not these. Forwarding aclose() keeps it firing the event.
     _GENERATOR_METHODS = ("aclose", "asend", "athrow")
 
     def __getattr__(self, name: str) -> Any:
-        # Only proxy public attributes (e.g. `.response`). Private/dunder names
-        # are not forwarded — this avoids infinite recursion if `_stream` isn't
-        # set yet and stops `hasattr`/copy probes leaking to the provider stream.
+        # Proxy only public attributes (e.g. `.response`) to the provider stream.
         if name.startswith("_"):
             raise AttributeError(name)
         if name in self._GENERATOR_METHODS:

--- a/posthog/ai/stream.py
+++ b/posthog/ai/stream.py
@@ -1,0 +1,84 @@
+"""Shared async streaming utilities for PostHog AI wrappers."""
+
+from typing import Any, AsyncGenerator, Optional, TypeVar
+
+T = TypeVar("T")
+
+
+class AsyncStreamWrapper:
+    """Wraps an async generator so it also implements the async context manager protocol.
+
+    The OpenAI and Anthropic SDKs return stream objects that support both
+    ``async for`` iteration **and** ``async with`` (i.e. they are both async
+    iterators and async context managers).  PostHog's streaming wrappers
+    previously returned a bare async generator, which only supports ``async
+    for``.  Libraries such as pydantic-ai call ``async with response:`` before
+    iterating, causing::
+
+        TypeError: 'async_generator' object does not support the
+        asynchronous context manager protocol
+
+    This class wraps the PostHog tracking generator and adds the missing
+    ``__aenter__`` / ``__aexit__`` methods.  When available, it also keeps a
+    reference to the original provider stream so that:
+
+    - On ``__aexit__`` the tracking generator is closed (so the ``finally``
+      block that fires the PostHog usage event always runs, even on early
+      exit) **and** the underlying provider stream is closed (releasing the
+      HTTP connection, matching the native SDK behaviour).
+    - Attribute access not handled here is proxied to the provider stream, so
+      provider-specific metadata such as ``.response`` keeps working.
+    """
+
+    def __init__(
+        self,
+        generator: AsyncGenerator[T, None],
+        stream: Optional[Any] = None,
+    ) -> None:
+        self._generator = generator
+        self._stream = stream
+
+    # ------------------------------------------------------------------ #
+    # Async iterator protocol                                              #
+    # ------------------------------------------------------------------ #
+
+    def __aiter__(self) -> "AsyncStreamWrapper":
+        return self
+
+    async def __anext__(self) -> T:
+        return await self._generator.__anext__()
+
+    # ------------------------------------------------------------------ #
+    # Async context manager protocol                                       #
+    # ------------------------------------------------------------------ #
+
+    async def __aenter__(self) -> "AsyncStreamWrapper":
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> bool:
+        # Close our tracking generator first so its `finally` block runs and
+        # the PostHog usage event is captured, even when the caller breaks out
+        # of the loop early. If it is already exhausted this is a no-op.
+        await self._generator.aclose()
+
+        # Then close the underlying provider stream to release the HTTP
+        # connection, matching native SDK behaviour. Provider streams expose an
+        # async `close()`; bare async generators (e.g. in tests) expose
+        # `aclose()`.
+        if self._stream is not None:
+            close = getattr(self._stream, "aclose", None) or getattr(
+                self._stream, "close", None
+            )
+            if close is not None:
+                await close()
+
+        return False
+
+    # ------------------------------------------------------------------ #
+    # Attribute proxy – forward any other attribute access to the         #
+    # underlying provider stream (e.g. `.response`) when available.       #
+    # ------------------------------------------------------------------ #
+
+    def __getattr__(self, name: str) -> Any:
+        target = self._stream if self._stream is not None else self._generator
+        return getattr(target, name)

--- a/posthog/test/ai/anthropic/test_anthropic.py
+++ b/posthog/test/ai/anthropic/test_anthropic.py
@@ -10,6 +10,7 @@ try:
     from anthropic.types import Message, Usage
 
     from posthog.ai.anthropic import Anthropic, AsyncAnthropic
+    from posthog.test.ai.utils import RecordingAsyncStream
 
     ANTHROPIC_AVAILABLE = True
 except ImportError:
@@ -1423,26 +1424,6 @@ def test_integration_stop_reason(mock_client):
     assert props["$ai_input_tokens"] > 0
 
 
-class _RecordingAnthropicStream:
-    """Mock Anthropic async stream that is iterable and records when closed."""
-
-    def __init__(self, events):
-        self._events = list(events)
-        self.closed = False
-        self.response = "provider-response"
-
-    def __aiter__(self):
-        return self
-
-    async def __anext__(self):
-        if not self._events:
-            raise StopAsyncIteration
-        return self._events.pop(0)
-
-    async def close(self):
-        self.closed = True
-
-
 def _anthropic_stream_events():
     final = MockStreamEvent("message_delta")
     final.usage = MockUsage(
@@ -1464,7 +1445,7 @@ async def test_async_messages_create_streaming_supports_async_with(mock_client):
     `async with`."""
 
     async def mock_async_create(**kwargs):
-        return _RecordingAnthropicStream(_anthropic_stream_events())
+        return RecordingAsyncStream(_anthropic_stream_events())
 
     with patch(
         "anthropic.resources.messages.AsyncMessages.create",
@@ -1489,7 +1470,7 @@ async def test_async_messages_create_streaming_supports_async_with(mock_client):
 async def test_async_messages_streaming_early_exit_closes_provider_stream(mock_client):
     """Breaking out early must close the underlying Anthropic stream and still
     capture the event."""
-    source = _RecordingAnthropicStream(_anthropic_stream_events())
+    source = RecordingAsyncStream(_anthropic_stream_events())
 
     async def mock_async_create(**kwargs):
         return source
@@ -1508,7 +1489,7 @@ async def test_async_messages_streaming_early_exit_closes_provider_stream(mock_c
 
         async with response as stream:
             async for _ in stream:
-                break  # early exit
+                break
 
     assert source.closed is True
     assert mock_client.capture.call_count == 1

--- a/posthog/test/ai/anthropic/test_anthropic.py
+++ b/posthog/test/ai/anthropic/test_anthropic.py
@@ -1421,3 +1421,94 @@ def test_integration_stop_reason(mock_client):
     assert props["$ai_stop_reason"] in ("end_turn", "max_tokens")
     assert props["$ai_provider"] == "anthropic"
     assert props["$ai_input_tokens"] > 0
+
+
+class _RecordingAnthropicStream:
+    """Mock Anthropic async stream that is iterable and records when closed."""
+
+    def __init__(self, events):
+        self._events = list(events)
+        self.closed = False
+        self.response = "provider-response"
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._events:
+            raise StopAsyncIteration
+        return self._events.pop(0)
+
+    async def close(self):
+        self.closed = True
+
+
+def _anthropic_stream_events():
+    final = MockStreamEvent("message_delta")
+    final.usage = MockUsage(
+        input_tokens=10,
+        output_tokens=5,
+        cache_read_input_tokens=0,
+        cache_creation_input_tokens=0,
+    )
+    return [
+        MockStreamEvent("message_start"),
+        MockStreamEvent("content_block_delta", text="Hi"),
+        final,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_async_messages_create_streaming_supports_async_with(mock_client):
+    """Regression test for #393: messages.create(stream=True) must support
+    `async with`."""
+
+    async def mock_async_create(**kwargs):
+        return _RecordingAnthropicStream(_anthropic_stream_events())
+
+    with patch(
+        "anthropic.resources.messages.AsyncMessages.create",
+        side_effect=mock_async_create,
+    ):
+        client = AsyncAnthropic(posthog_client=mock_client)
+        response = await client.messages.create(
+            model="claude-3-opus-20240229",
+            messages=[{"role": "user", "content": "Foo"}],
+            stream=True,
+            max_tokens=1,
+        )
+
+        async with response as stream:
+            events = [event async for event in stream]
+
+    assert len(events) == 3
+    assert mock_client.capture.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_async_messages_streaming_early_exit_closes_provider_stream(mock_client):
+    """Breaking out early must close the underlying Anthropic stream and still
+    capture the event."""
+    source = _RecordingAnthropicStream(_anthropic_stream_events())
+
+    async def mock_async_create(**kwargs):
+        return source
+
+    with patch(
+        "anthropic.resources.messages.AsyncMessages.create",
+        side_effect=mock_async_create,
+    ):
+        client = AsyncAnthropic(posthog_client=mock_client)
+        response = await client.messages.create(
+            model="claude-3-opus-20240229",
+            messages=[{"role": "user", "content": "Foo"}],
+            stream=True,
+            max_tokens=1,
+        )
+
+        async with response as stream:
+            async for _ in stream:
+                break  # early exit
+
+    assert source.closed is True
+    assert mock_client.capture.call_count == 1

--- a/posthog/test/ai/gemini/test_gemini_async.py
+++ b/posthog/test/ai/gemini/test_gemini_async.py
@@ -1110,3 +1110,43 @@ async def test_async_embed_content_integration_batch(mock_client):
 
     assert response.embeddings is not None
     assert len(response.embeddings) == len(inputs)
+
+
+async def test_async_client_streaming_supports_async_with(
+    mock_client, mock_google_genai_client
+):
+    """Regression test for #393: generate_content_stream must support `async with`."""
+
+    async def mock_streaming_response():
+        chunk = MagicMock()
+        chunk.text = "Hi"
+        usage = MagicMock()
+        usage.prompt_token_count = 5
+        usage.candidates_token_count = 3
+        usage.cached_content_token_count = 0
+        usage.thoughts_token_count = 0
+        chunk.usage_metadata = usage
+        yield chunk
+
+    mock_google_genai_client.aio.models.generate_content_stream = AsyncMock(
+        return_value=mock_streaming_response()
+    )
+
+    client = AsyncClient(api_key="test-key", posthog_client=mock_client)
+
+    response = await client.models.generate_content_stream(
+        model="gemini-2.0-flash",
+        contents=["Hi"],
+        posthog_distinct_id="test-id",
+    )
+
+    chunks = []
+    async with response as stream:
+        async for chunk in stream:
+            chunks.append(chunk)
+
+    assert len(chunks) == 1
+    assert mock_client.capture.call_count == 1
+    call_args = mock_client.capture.call_args[1]
+    assert call_args["event"] == "$ai_generation"
+    assert call_args["properties"]["$ai_provider"] == "gemini"

--- a/posthog/test/ai/openai/test_openai.py
+++ b/posthog/test/ai/openai/test_openai.py
@@ -39,6 +39,7 @@ try:
     from posthog.ai.openai import OpenAI
     from posthog.ai.openai.openai_async import AsyncOpenAI
     from posthog.ai.openai.wrapper_utils import reset_fallback_warnings
+    from posthog.test.ai.utils import RecordingAsyncStream
 
     OPENAI_AVAILABLE = True
 except ImportError:
@@ -2354,30 +2355,6 @@ def test_integration_stop_reason(mock_client):
     assert props["$ai_input_tokens"] > 0
 
 
-class _RecordingAsyncStream:
-    """Mock OpenAI async stream that is iterable and records when closed.
-
-    Mirrors the real ``openai.AsyncStream``: it supports ``async for`` and
-    exposes an async ``close()`` plus a ``response`` attribute.
-    """
-
-    def __init__(self, chunks):
-        self._chunks = list(chunks)
-        self.closed = False
-        self.response = "provider-response"
-
-    def __aiter__(self):
-        return self
-
-    async def __anext__(self):
-        if not self._chunks:
-            raise StopAsyncIteration
-        return self._chunks.pop(0)
-
-    async def close(self):
-        self.closed = True
-
-
 @pytest.mark.asyncio
 async def test_async_chat_streaming_supports_async_with(
     mock_client, streaming_tool_call_chunks
@@ -2386,7 +2363,7 @@ async def test_async_chat_streaming_supports_async_with(
     `async with` (the protocol pydantic-ai relies on)."""
 
     async def mock_create(self, **kwargs):
-        return _RecordingAsyncStream(streaming_tool_call_chunks)
+        return RecordingAsyncStream(streaming_tool_call_chunks)
 
     with patch(
         "openai.resources.chat.completions.AsyncCompletions.create", new=mock_create
@@ -2420,7 +2397,7 @@ async def test_async_responses_streaming_supports_async_with(mock_client):
     chunk.text = "hello"
 
     async def mock_create(self, **kwargs):
-        return _RecordingAsyncStream([chunk])
+        return RecordingAsyncStream([chunk])
 
     with patch("openai.resources.responses.AsyncResponses.create", new=mock_create):
         client = AsyncOpenAI(api_key="test-key", posthog_client=mock_client)
@@ -2445,7 +2422,7 @@ async def test_async_chat_streaming_early_exit_closes_provider_stream(
 ):
     """Breaking out of the stream early must close the underlying provider
     stream (release the HTTP connection) and still capture the event."""
-    source = _RecordingAsyncStream(streaming_tool_call_chunks)
+    source = RecordingAsyncStream(streaming_tool_call_chunks)
 
     async def mock_create(self, **kwargs):
         return source
@@ -2464,7 +2441,7 @@ async def test_async_chat_streaming_early_exit_closes_provider_stream(
 
         async with response as stream:
             async for _ in stream:
-                break  # early exit
+                break
 
     assert source.closed is True
     assert mock_client.capture.call_count == 1

--- a/posthog/test/ai/openai/test_openai.py
+++ b/posthog/test/ai/openai/test_openai.py
@@ -2384,6 +2384,11 @@ async def test_async_chat_streaming_supports_async_with(
 
     assert chunks == streaming_tool_call_chunks
     assert mock_client.capture.call_count == 1
+    call_args = mock_client.capture.call_args[1]
+    props = call_args["properties"]
+    assert call_args["event"] == "$ai_generation"
+    assert props["$ai_provider"] == "openai"
+    assert props["$ai_model"] == "gpt-4"
 
 
 @pytest.mark.asyncio

--- a/posthog/test/ai/openai/test_openai.py
+++ b/posthog/test/ai/openai/test_openai.py
@@ -2352,3 +2352,119 @@ def test_integration_stop_reason(mock_client):
     assert props["$ai_stop_reason"] in ("stop", "length")
     assert props["$ai_provider"] == "openai"
     assert props["$ai_input_tokens"] > 0
+
+
+class _RecordingAsyncStream:
+    """Mock OpenAI async stream that is iterable and records when closed.
+
+    Mirrors the real ``openai.AsyncStream``: it supports ``async for`` and
+    exposes an async ``close()`` plus a ``response`` attribute.
+    """
+
+    def __init__(self, chunks):
+        self._chunks = list(chunks)
+        self.closed = False
+        self.response = "provider-response"
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._chunks:
+            raise StopAsyncIteration
+        return self._chunks.pop(0)
+
+    async def close(self):
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_async_chat_streaming_supports_async_with(
+    mock_client, streaming_tool_call_chunks
+):
+    """Regression test for #393: chat completions stream=True must support
+    `async with` (the protocol pydantic-ai relies on)."""
+
+    async def mock_create(self, **kwargs):
+        return _RecordingAsyncStream(streaming_tool_call_chunks)
+
+    with patch(
+        "openai.resources.chat.completions.AsyncCompletions.create", new=mock_create
+    ):
+        client = AsyncOpenAI(api_key="test-key", posthog_client=mock_client)
+
+        response = await client.chat.completions.create(
+            model="gpt-4",
+            messages=[{"role": "user", "content": "Hi"}],
+            stream=True,
+            posthog_distinct_id="test-id",
+        )
+
+        chunks = []
+        async with response as stream:
+            async for chunk in stream:
+                chunks.append(chunk)
+
+    assert chunks == streaming_tool_call_chunks
+    assert mock_client.capture.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_async_responses_streaming_supports_async_with(mock_client):
+    """Regression test for #393: responses stream=True must support
+    `async with`."""
+    from unittest.mock import MagicMock
+
+    chunk = MagicMock()
+    chunk.type = "response.text.delta"
+    chunk.text = "hello"
+
+    async def mock_create(self, **kwargs):
+        return _RecordingAsyncStream([chunk])
+
+    with patch("openai.resources.responses.AsyncResponses.create", new=mock_create):
+        client = AsyncOpenAI(api_key="test-key", posthog_client=mock_client)
+
+        response = await client.responses.create(
+            model="gpt-4o-mini",
+            input=[{"role": "user", "content": "Hi"}],
+            stream=True,
+            posthog_distinct_id="test-id",
+        )
+
+        async with response as stream:
+            received = [c async for c in stream]
+
+    assert received == [chunk]
+    assert mock_client.capture.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_async_chat_streaming_early_exit_closes_provider_stream(
+    mock_client, streaming_tool_call_chunks
+):
+    """Breaking out of the stream early must close the underlying provider
+    stream (release the HTTP connection) and still capture the event."""
+    source = _RecordingAsyncStream(streaming_tool_call_chunks)
+
+    async def mock_create(self, **kwargs):
+        return source
+
+    with patch(
+        "openai.resources.chat.completions.AsyncCompletions.create", new=mock_create
+    ):
+        client = AsyncOpenAI(api_key="test-key", posthog_client=mock_client)
+
+        response = await client.chat.completions.create(
+            model="gpt-4",
+            messages=[{"role": "user", "content": "Hi"}],
+            stream=True,
+            posthog_distinct_id="test-id",
+        )
+
+        async with response as stream:
+            async for _ in stream:
+                break  # early exit
+
+    assert source.closed is True
+    assert mock_client.capture.call_count == 1

--- a/posthog/test/ai/test_async_stream_wrapper.py
+++ b/posthog/test/ai/test_async_stream_wrapper.py
@@ -3,26 +3,7 @@
 import pytest
 
 from posthog.ai.stream import AsyncStreamWrapper
-
-
-class RecordingStream:
-    """Minimal async-iterable provider stream that records when it is closed."""
-
-    def __init__(self, items):
-        self._items = list(items)
-        self.closed = False
-        self.response = "provider-response"  # provider-specific metadata
-
-    def __aiter__(self):
-        return self
-
-    async def __anext__(self):
-        if not self._items:
-            raise StopAsyncIteration
-        return self._items.pop(0)
-
-    async def close(self):
-        self.closed = True
+from posthog.test.ai.utils import RecordingAsyncStream
 
 
 @pytest.mark.asyncio
@@ -73,7 +54,7 @@ async def test_finally_block_runs_on_exit(consume_all):
 
 @pytest.mark.asyncio
 async def test_exit_closes_underlying_provider_stream():
-    source = RecordingStream([1, 2, 3])
+    source = RecordingAsyncStream([1, 2, 3])
 
     async def gen():
         async for item in source:
@@ -81,19 +62,18 @@ async def test_exit_closes_underlying_provider_stream():
 
     async with AsyncStreamWrapper(gen(), source) as stream:
         async for _ in stream:
-            break  # early exit
+            break
 
     assert source.closed is True
 
 
 @pytest.mark.asyncio
 async def test_getattr_proxies_to_provider_stream():
-    source = RecordingStream([])
+    source = RecordingAsyncStream([])
 
     async def gen():
         if False:
             yield  # make this an async generator
 
     wrapper = AsyncStreamWrapper(gen(), source)
-    # `.response` lives on the provider stream, not the generator.
     assert wrapper.response == "provider-response"

--- a/posthog/test/ai/test_async_stream_wrapper.py
+++ b/posthog/test/ai/test_async_stream_wrapper.py
@@ -32,8 +32,6 @@ async def test_async_with_yields_self_and_iterates():
 @pytest.mark.asyncio
 @pytest.mark.parametrize("consume_all", [False, True])
 async def test_finally_block_runs_on_exit(consume_all):
-    """The generator's finally block must run on context exit, whether the
-    caller exhausts the stream or breaks out of it early."""
     captured = []
 
     async def gen():
@@ -69,8 +67,6 @@ async def test_exit_closes_underlying_provider_stream():
 
 @pytest.mark.asyncio
 async def test_provider_stream_closed_even_if_generator_aclose_raises():
-    """The try/finally in __aexit__ must still close the provider stream when
-    the generator's finally (the PostHog capture) raises."""
     source = RecordingAsyncStream([1, 2, 3])
 
     async def gen():
@@ -90,8 +86,6 @@ async def test_provider_stream_closed_even_if_generator_aclose_raises():
 
 @pytest.mark.asyncio
 async def test_exception_in_body_propagates():
-    """__aexit__ returns False, so exceptions in the body must propagate (not be
-    swallowed), and the provider stream is still closed on the error path."""
     source = RecordingAsyncStream([1, 2, 3])
 
     async def gen():
@@ -120,8 +114,6 @@ async def test_getattr_proxies_to_provider_stream():
 
 @pytest.mark.asyncio
 async def test_aclose_runs_generator_finally_and_captures():
-    """`await response.aclose()` must close the tracking generator (firing its
-    finally) rather than proxying to the provider stream, which has no aclose."""
     source = RecordingAsyncStream([1, 2, 3])
     captured = []
 

--- a/posthog/test/ai/test_async_stream_wrapper.py
+++ b/posthog/test/ai/test_async_stream_wrapper.py
@@ -1,0 +1,99 @@
+"""Unit tests for AsyncStreamWrapper (no external SDKs required)."""
+
+import pytest
+
+from posthog.ai.stream import AsyncStreamWrapper
+
+
+class RecordingStream:
+    """Minimal async-iterable provider stream that records when it is closed."""
+
+    def __init__(self, items):
+        self._items = list(items)
+        self.closed = False
+        self.response = "provider-response"  # provider-specific metadata
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._items:
+            raise StopAsyncIteration
+        return self._items.pop(0)
+
+    async def close(self):
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_async_for_iteration_still_works():
+    async def gen():
+        yield 1
+        yield 2
+        yield 3
+
+    wrapper = AsyncStreamWrapper(gen())
+    assert [item async for item in wrapper] == [1, 2, 3]
+
+
+@pytest.mark.asyncio
+async def test_async_with_yields_self_and_iterates():
+    async def gen():
+        yield "a"
+        yield "b"
+
+    wrapper = AsyncStreamWrapper(gen())
+    async with wrapper as stream:
+        assert stream is wrapper
+        assert [item async for item in stream] == ["a", "b"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("consume_all", [False, True])
+async def test_finally_block_runs_on_exit(consume_all):
+    """The generator's finally block must run on context exit, whether the
+    caller exhausts the stream or breaks out of it early."""
+    captured = []
+
+    async def gen():
+        try:
+            yield 1
+            yield 2
+            yield 3
+        finally:
+            captured.append("done")
+
+    async with AsyncStreamWrapper(gen()) as stream:
+        async for item in stream:
+            if not consume_all and item == 1:
+                break
+
+    assert captured == ["done"]
+
+
+@pytest.mark.asyncio
+async def test_exit_closes_underlying_provider_stream():
+    source = RecordingStream([1, 2, 3])
+
+    async def gen():
+        async for item in source:
+            yield item
+
+    async with AsyncStreamWrapper(gen(), source) as stream:
+        async for _ in stream:
+            break  # early exit
+
+    assert source.closed is True
+
+
+@pytest.mark.asyncio
+async def test_getattr_proxies_to_provider_stream():
+    source = RecordingStream([])
+
+    async def gen():
+        if False:
+            yield  # make this an async generator
+
+    wrapper = AsyncStreamWrapper(gen(), source)
+    # `.response` lives on the provider stream, not the generator.
+    assert wrapper.response == "provider-response"

--- a/posthog/test/ai/test_async_stream_wrapper.py
+++ b/posthog/test/ai/test_async_stream_wrapper.py
@@ -77,3 +77,15 @@ async def test_getattr_proxies_to_provider_stream():
 
     wrapper = AsyncStreamWrapper(gen(), source)
     assert wrapper.response == "provider-response"
+
+
+@pytest.mark.asyncio
+async def test_getattr_does_not_proxy_private_names():
+    source = RecordingAsyncStream([])
+
+    async def gen():
+        if False:
+            yield
+
+    wrapper = AsyncStreamWrapper(gen(), source)
+    assert not hasattr(wrapper, "_nonexistent_private")

--- a/posthog/test/ai/test_async_stream_wrapper.py
+++ b/posthog/test/ai/test_async_stream_wrapper.py
@@ -68,6 +68,45 @@ async def test_exit_closes_underlying_provider_stream():
 
 
 @pytest.mark.asyncio
+async def test_provider_stream_closed_even_if_generator_aclose_raises():
+    """The try/finally in __aexit__ must still close the provider stream when
+    the generator's finally (the PostHog capture) raises."""
+    source = RecordingAsyncStream([1, 2, 3])
+
+    async def gen():
+        try:
+            async for item in source:
+                yield item
+        finally:
+            raise RuntimeError("capture blew up")
+
+    with pytest.raises(RuntimeError, match="capture blew up"):
+        async with AsyncStreamWrapper(gen(), source) as stream:
+            async for _ in stream:
+                break
+
+    assert source.closed is True
+
+
+@pytest.mark.asyncio
+async def test_exception_in_body_propagates():
+    """__aexit__ returns False, so exceptions in the body must propagate (not be
+    swallowed), and the provider stream is still closed on the error path."""
+    source = RecordingAsyncStream([1, 2, 3])
+
+    async def gen():
+        async for item in source:
+            yield item
+
+    with pytest.raises(ValueError, match="boom"):
+        async with AsyncStreamWrapper(gen(), source) as stream:
+            async for _ in stream:
+                raise ValueError("boom")
+
+    assert source.closed is True
+
+
+@pytest.mark.asyncio
 async def test_getattr_proxies_to_provider_stream():
     source = RecordingAsyncStream([])
 
@@ -77,6 +116,27 @@ async def test_getattr_proxies_to_provider_stream():
 
     wrapper = AsyncStreamWrapper(gen(), source)
     assert wrapper.response == "provider-response"
+
+
+@pytest.mark.asyncio
+async def test_aclose_runs_generator_finally_and_captures():
+    """`await response.aclose()` must close the tracking generator (firing its
+    finally) rather than proxying to the provider stream, which has no aclose."""
+    source = RecordingAsyncStream([1, 2, 3])
+    captured = []
+
+    async def gen():
+        try:
+            async for item in source:
+                yield item
+        finally:
+            captured.append("done")
+
+    wrapper = AsyncStreamWrapper(gen(), source)
+    await wrapper.__anext__()
+    await wrapper.aclose()
+
+    assert captured == ["done"]
 
 
 @pytest.mark.asyncio

--- a/posthog/test/ai/utils.py
+++ b/posthog/test/ai/utils.py
@@ -1,0 +1,27 @@
+"""Shared test helpers for the AI wrapper test suites."""
+
+
+class RecordingAsyncStream:
+    """Mock provider async stream that is iterable and records when closed.
+
+    Mirrors the real ``openai.AsyncStream`` / ``anthropic.AsyncStream``: it
+    supports ``async for`` and exposes an async ``close()`` plus a ``response``
+    attribute, so tests can assert both iteration and that the underlying
+    stream is closed on context exit.
+    """
+
+    def __init__(self, items):
+        self._items = list(items)
+        self.closed = False
+        self.response = "provider-response"
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._items:
+            raise StopAsyncIteration
+        return self._items.pop(0)
+
+    async def close(self):
+        self.closed = True


### PR DESCRIPTION
## :bulb: Motivation and Context

Fixes #393. Supersedes #622 (rebased onto current `main`, with @marandaneto's review addressed).

The async AI wrappers returned a bare async generator for streaming responses, which supports `async for` but not `async with`. Libraries like pydantic-ai consume streams via `async with response:`, so they broke with:

```
TypeError: 'async_generator' object does not support the asynchronous context manager protocol
```

This adds an `AsyncStreamWrapper` that supports `async with` (closing the underlying provider stream on exit) while preserving `async for` and `await response.aclose()`. Applied to the OpenAI, Anthropic, and Gemini async streaming wrappers.

Out of scope: Anthropic `messages.stream()` (still `async def`) and the sync `with` gap — left for a follow-up.

## :green_heart: How did you test it?

Added unit tests for the wrapper (async with, async for, early-exit capture, provider-stream close, `aclose`, exception propagation) and real-client regression tests covering `async with` for OpenAI chat/responses, Anthropic `messages.create`, and Gemini streaming. Confirmed the tests reproduce the #393 `TypeError` without the fix. Full AI test suite passes; `ruff` and `mypy` clean.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file
