### PR TITLE
chore: Correct Sentry Python attribution

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -22,12 +22,12 @@ SOFTWARE.
 
 ---
 
-Some files in this codebase contain code from getsentry/sentry-javascript by Software, Inc. dba Sentry.
+Some files in this codebase contain code from getsentry/sentry-python by Software, Inc. dba Sentry.
 In such cases it is explicitly stated in the file header. This license only applies to the relevant code in such cases.
 
 MIT License
 
-Copyright (c) 2012 Functional Software, Inc. dba Sentry
+Copyright (c) 2018 Functional Software, Inc. dba Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/posthog/exception_capture.py
+++ b/posthog/exception_capture.py
@@ -1,4 +1,4 @@
-# Portions of this file are derived from getsentry/sentry-javascript by Software, Inc. dba Sentry
+# Portions of this file are derived from getsentry/sentry-python by Software, Inc. dba Sentry
 # Licensed under the MIT License
 
 # 💖open source (under MIT License)

--- a/posthog/exception_utils.py
+++ b/posthog/exception_utils.py
@@ -1,4 +1,4 @@
-# Portions of this file are derived from getsentry/sentry-javascript by Software, Inc. dba Sentry
+# Portions of this file are derived from getsentry/sentry-python by Software, Inc. dba Sentry
 # Licensed under the MIT License
 
 # copied and adapted from https://github.com/getsentry/sentry-python/blob/269d96d6e9821122fbff280e6a26956e5ed03c0b/sentry_sdk/utils.py#L689


### PR DESCRIPTION
## :bulb: Motivation and Context
The exception capture files are copied/adapted from `getsentry/sentry-python`, but the license attribution referenced `getsentry/sentry-javascript`. This corrects the source attribution in the file headers and bundled license notice.


## :green_heart: How did you test it?

Not run (license/header text-only change).


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file

<!-- For more details check RELEASING.md -->
