### PR TITLE
chore: Update Sentry license attribution

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -22,19 +22,19 @@ SOFTWARE.
 
 ---
 
-Some files in this codebase contain code from getsentry/sentry-python by Software, Inc. dba Sentry.
+Some files in this codebase contain code from getsentry/sentry-python.
 In such cases it is explicitly stated in the file header. This license only applies to the relevant code in such cases.
 
 MIT License
 
 Copyright (c) 2018 Functional Software, Inc. dba Sentry
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-of the Software, and to permit persons to whom the Software is furnished to do
-so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.

--- a/posthog/exception_capture.py
+++ b/posthog/exception_capture.py
@@ -1,5 +1,6 @@
-# Portions of this file are derived from getsentry/sentry-python by Software, Inc. dba Sentry
-# Licensed under the MIT License
+# Portions of this file are derived from getsentry/sentry-python
+# Copyright (c) 2018 Functional Software, Inc. dba Sentry
+# Licensed under the MIT License: https://github.com/getsentry/sentry-python/blob/master/LICENSE
 
 # 💖open source (under MIT License)
 

--- a/posthog/exception_utils.py
+++ b/posthog/exception_utils.py
@@ -1,7 +1,7 @@
-# Portions of this file are derived from getsentry/sentry-python by Software, Inc. dba Sentry
-# Licensed under the MIT License
+# Portions of this file are derived from getsentry/sentry-python
+# Copyright (c) 2018 Functional Software, Inc. dba Sentry
+# Licensed under the MIT License: https://github.com/getsentry/sentry-python/blob/master/LICENSE
 
-# copied and adapted from https://github.com/getsentry/sentry-python/blob/269d96d6e9821122fbff280e6a26956e5ed03c0b/sentry_sdk/utils.py#L689
 # 💖open source (under MIT License)
 # We want to keep payloads as similar to Sentry as possible for easy interoperability
 


### PR DESCRIPTION
## :bulb: Motivation and Context

Correct Sentry attribution in files that include code derived from getsentry/sentry-python and make the associated MIT license notice clearer.

## :green_heart: How did you test it?

Not run (license/comment-only change).

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file
