### PR TITLE
feat(feature-flags): support early_exit in local evaluation

### DIFF
--- a/.sampo/changesets/feature-flag-early-exit.md
+++ b/.sampo/changesets/feature-flag-early-exit.md
@@ -1,0 +1,5 @@
+---
+pypi/posthog: minor
+---
+
+feat(feature-flags): support the `early_exit` condition option in local evaluation. When a flag enables early exit, evaluation now stops and returns `False` as soon as a condition group's property filters match but the rollout percentage excludes the user, instead of falling through to later groups — matching the server-side evaluation behavior.

--- a/posthog/feature_flags.py
+++ b/posthog/feature_flags.py
@@ -4,6 +4,7 @@ import hashlib
 import logging
 import re
 import warnings
+from enum import Enum
 from typing import Optional
 
 from posthog import utils
@@ -15,6 +16,20 @@ __LONG_SCALE__ = float(0xFFFFFFFFFFFFFFF)
 log = logging.getLogger("posthog")
 
 NONE_VALUES_ALLOWED_OPERATORS = ["is_not"]
+
+
+class ConditionMatch(Enum):
+    """Outcome of evaluating a single condition group.
+
+    OUT_OF_ROLLOUT_BOUND means the group's property filters matched (or there were none)
+    but the rollout percentage excluded the user — the only case that triggers a flag's
+    ``early_exit`` short-circuit. Mirrors the server-side (Rust) engine's match cases.
+    """
+
+    MATCH = "match"
+    NO_MATCH = "no_match"
+    OUT_OF_ROLLOUT_BOUND = "out_of_rollout_bound"
+
 
 # All operators supported by match_property, grouped by category.
 EQUALITY_OPERATORS = ("exact", "is_not", "is_set", "is_not_set")
@@ -307,6 +322,7 @@ def match_feature_flag_properties(
     flag_filters = flag.get("filters") or {}
     flag_conditions = flag_filters.get("groups") or []
     flag_aggregation = flag_filters.get("aggregation_group_type_index")
+    early_exit_enabled = flag_filters.get("early_exit") or False
     is_inconclusive = False
     cohort_properties = cohort_properties or {}
     groups = groups or {}
@@ -349,7 +365,7 @@ def match_feature_flag_properties(
                 effective_properties = properties
                 effective_bucketing = bucketing_value
 
-            if is_condition_match(
+            match_result = is_condition_match(
                 flag,
                 distinct_id,
                 condition,
@@ -359,13 +375,22 @@ def match_feature_flag_properties(
                 evaluation_cache,
                 bucketing_value=effective_bucketing,
                 device_id=device_id,
-            ):
+            )
+            if match_result == ConditionMatch.MATCH:
                 variant_override = condition.get("variant")
                 if variant_override and variant_override in valid_variant_keys:
                     variant = variant_override
                 else:
                     variant = get_matching_variant(flag, effective_bucketing)
                 return variant or True
+            elif (
+                early_exit_enabled
+                and match_result == ConditionMatch.OUT_OF_ROLLOUT_BOUND
+            ):
+                # The condition's property filters (if any) matched and only the rollout check
+                # failed, so re-evaluating later groups can't change the outcome. Return a
+                # deterministic False, mirroring the server-side engine.
+                return False
         except RequiresServerEvaluation:
             # Static cohort or other missing server-side data - must fallback to API
             raise
@@ -395,7 +420,7 @@ def is_condition_match(
     *,
     bucketing_value,
     device_id=None,
-) -> bool:
+) -> ConditionMatch:
     rollout_percentage = condition.get("rollout_percentage")
     if len(condition.get("properties") or []) > 0:
         for prop in condition.get("properties"):
@@ -423,17 +448,19 @@ def is_condition_match(
             else:
                 matches = match_property(prop, properties)
             if not matches:
-                return False
+                return ConditionMatch.NO_MATCH
 
         if rollout_percentage is None:
-            return True
+            return ConditionMatch.MATCH
 
+    # Property filters (if any) matched; only the rollout check remains. A failure here means
+    # the user was targeted but excluded by rollout — the server-side engine's OutOfRolloutBound.
     if rollout_percentage is not None and _hash(
         feature_flag["key"], bucketing_value
     ) > (rollout_percentage / 100):
-        return False
+        return ConditionMatch.OUT_OF_ROLLOUT_BOUND
 
-    return True
+    return ConditionMatch.MATCH
 
 
 def match_property(property, property_values) -> bool:

--- a/posthog/feature_flags.py
+++ b/posthog/feature_flags.py
@@ -322,7 +322,7 @@ def match_feature_flag_properties(
     flag_filters = flag.get("filters") or {}
     flag_conditions = flag_filters.get("groups") or []
     flag_aggregation = flag_filters.get("aggregation_group_type_index")
-    early_exit_enabled = flag_filters.get("early_exit") or False
+    early_exit_enabled = flag_filters.get("early_exit")
     is_inconclusive = False
     cohort_properties = cohort_properties or {}
     groups = groups or {}

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -268,6 +268,57 @@ class TestLocalEvaluation(unittest.TestCase):
             )
         )
 
+    def test_early_exit_on_multivariate_flag(self):
+        self.client.feature_flags = [
+            {
+                "id": 1,
+                "name": "Early Exit Multivariate",
+                "key": "early-exit-multivariate",
+                "active": True,
+                "filters": {
+                    "early_exit": True,
+                    "multivariate": {
+                        "variants": [
+                            {"key": "control", "rollout_percentage": 50},
+                            {"key": "test", "rollout_percentage": 50},
+                        ]
+                    },
+                    "groups": [
+                        {
+                            "properties": [
+                                {
+                                    "key": "region",
+                                    "operator": "exact",
+                                    "value": ["USA"],
+                                    "type": "person",
+                                }
+                            ],
+                            "rollout_percentage": 0,
+                        },
+                        {
+                            "properties": [
+                                {
+                                    "key": "region",
+                                    "operator": "exact",
+                                    "value": ["USA"],
+                                    "type": "person",
+                                }
+                            ],
+                            "rollout_percentage": 100,
+                        },
+                    ],
+                },
+            }
+        ]
+
+        self.assertFalse(
+            self.client.get_feature_flag(
+                "early-exit-multivariate",
+                "some-distinct-id",
+                person_properties={"region": "USA"},
+            )
+        )
+
     @mock.patch("posthog.client.flags")
     @mock.patch("posthog.client.get")
     def test_flag_group_properties(self, patch_get, patch_flags):

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -141,6 +141,133 @@ class TestLocalEvaluation(unittest.TestCase):
             )
         )
 
+    @parameterized.expand(
+        [
+            # (description, early_exit value, expected result)
+            ("enabled", True, False),
+            ("not set", None, True),
+            ("explicitly disabled", False, True),
+        ]
+    )
+    def test_early_exit(self, _name, early_exit, expected):
+        # First group's properties match but its rollout (0%) excludes everyone; the second
+        # group would otherwise match. Mirrors the server-side OutOfRolloutBound short-circuit.
+        filters = {
+            "groups": [
+                {
+                    "properties": [
+                        {
+                            "key": "region",
+                            "operator": "exact",
+                            "value": ["USA"],
+                            "type": "person",
+                        }
+                    ],
+                    "rollout_percentage": 0,
+                },
+                {
+                    "properties": [
+                        {
+                            "key": "region",
+                            "operator": "exact",
+                            "value": ["USA"],
+                            "type": "person",
+                        }
+                    ],
+                    "rollout_percentage": 100,
+                },
+            ],
+        }
+        if early_exit is not None:
+            filters["early_exit"] = early_exit
+
+        self.client.feature_flags = [
+            {
+                "id": 1,
+                "name": "Early Exit Feature",
+                "key": "early-exit-flag",
+                "active": True,
+                "filters": filters,
+            }
+        ]
+
+        self.assertEqual(
+            self.client.get_feature_flag(
+                "early-exit-flag",
+                "some-distinct-id",
+                person_properties={"region": "USA"},
+            ),
+            expected,
+        )
+
+    def test_early_exit_on_rollout_only_group_with_no_property_filters(self):
+        self.client.feature_flags = [
+            {
+                "id": 1,
+                "name": "Early Exit Feature",
+                "key": "early-exit-flag",
+                "active": True,
+                "filters": {
+                    "early_exit": True,
+                    "groups": [
+                        {"rollout_percentage": 0},
+                        {"rollout_percentage": 100},
+                    ],
+                },
+            }
+        ]
+
+        self.assertFalse(
+            self.client.get_feature_flag("early-exit-flag", "some-distinct-id")
+        )
+
+    def test_early_exit_does_not_trigger_on_property_mismatch(self):
+        # First group fails on its property (region mismatch), not rollout — so even with
+        # early_exit enabled, evaluation must continue to the second group, which matches.
+        self.client.feature_flags = [
+            {
+                "id": 1,
+                "name": "Early Exit Feature",
+                "key": "early-exit-flag",
+                "active": True,
+                "filters": {
+                    "early_exit": True,
+                    "groups": [
+                        {
+                            "properties": [
+                                {
+                                    "key": "region",
+                                    "operator": "exact",
+                                    "value": ["Canada"],
+                                    "type": "person",
+                                }
+                            ],
+                            "rollout_percentage": 0,
+                        },
+                        {
+                            "properties": [
+                                {
+                                    "key": "region",
+                                    "operator": "exact",
+                                    "value": ["USA"],
+                                    "type": "person",
+                                }
+                            ],
+                            "rollout_percentage": 100,
+                        },
+                    ],
+                },
+            }
+        ]
+
+        self.assertTrue(
+            self.client.get_feature_flag(
+                "early-exit-flag",
+                "some-distinct-id",
+                person_properties={"region": "USA"},
+            )
+        )
+
     @mock.patch("posthog.client.flags")
     @mock.patch("posthog.client.get")
     def test_flag_group_properties(self, patch_get, patch_flags):


### PR DESCRIPTION
## :bulb: Motivation and Context

[PostHog/posthog#57321](https://github.com/PostHog/posthog/pull/57321) added an **early exit** option to feature flags: when enabled, condition evaluation stops and returns `false` as soon as a user matches a group's targeting but is excluded by its rollout percentage, instead of falling through to later groups. That was implemented server-side (Rust engine), and [PostHog/posthog-js#3705](https://github.com/PostHog/posthog-js/pull/3705) ported it to `posthog-node`'s local evaluation.

`posthog-python` re-implements the same matching loop, so without honoring `filters.early_exit` its locally-evaluated flags could diverge from server-side results. This PR applies the same approach to `posthog-python`.

## :green_heart: How did you test it?

Added unit tests in `test_feature_flags.py` covering early-exit enabled (returns `False` without evaluating later groups), unset/explicitly-disabled (falls through to a later matching group), a rollout-only group with no property filters, and a property-mismatch case (does not early exit). The full feature-flag suites pass (`test_feature_flags.py`, `test_feature_flag_result.py`, `test_client.py` — 285 tests). Lint (`ruff`) is clean.

## Changes

- Introduce a `ConditionMatch` tri-state (`MATCH` / `NO_MATCH` / `OUT_OF_ROLLOUT_BOUND`) returned by `is_condition_match`, so the evaluation loop can distinguish a rollout exclusion from a property mismatch.
- Honor `filters.early_exit` in `match_feature_flag_properties`: when enabled and a group's property filters match but rollout excludes the user (`OUT_OF_ROLLOUT_BOUND`), return `False` immediately rather than evaluating later groups. Property mismatches still fall through, mirroring the Rust semantics exactly.
- Both local-evaluation entry points (`get_feature_flag` and `evaluate_flags`) route through `match_feature_flag_properties`, so both honor the new behavior.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
