### PR TITLE
ci: skip flags project board workflow for Dependabot PRs

### DIFF
--- a/.github/workflows/call-flags-project-board.yml
+++ b/.github/workflows/call-flags-project-board.yml
@@ -9,6 +9,11 @@ on:
 
 jobs:
     call-flags-project:
+        # Dependabot-triggered runs execute in a restricted secret context without
+        # access to the GitHub App credentials this workflow needs, so the reusable
+        # workflow's token step always hard-fails. Skip it for Dependabot — dependency
+        # bumps don't belong on the feature flags board anyway.
+        if: ${{ github.actor != 'dependabot[bot]' }}
         uses: PostHog/.github/.github/workflows/flags-project-board.yml@d8b55d05dc5150f05c24542a6397ff3ecfbfb56d
         with:
             pr_number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/call-flags-project-board.yml
+++ b/.github/workflows/call-flags-project-board.yml
@@ -9,10 +9,6 @@ on:
 
 jobs:
     call-flags-project:
-        # Dependabot-triggered runs execute in a restricted secret context without
-        # access to the GitHub App credentials this workflow needs, so the reusable
-        # workflow's token step always hard-fails. Skip it for Dependabot — dependency
-        # bumps don't belong on the feature flags board anyway.
         if: ${{ github.actor != 'dependabot[bot]' }}
         uses: PostHog/.github/.github/workflows/flags-project-board.yml@d8b55d05dc5150f05c24542a6397ff3ecfbfb56d
         with:


### PR DESCRIPTION
## Problem

The `call-flags-project / add-to-project-board` check fails on **every Dependabot PR**, and has been doing so since ~2026-05-08. Currently-failing examples:

- #649 — https://github.com/PostHog/posthog-python/pull/649
- #650 — https://github.com/PostHog/posthog-python/pull/650
- #651 — https://github.com/PostHog/posthog-python/pull/651

The reusable `PostHog/.github` flags-project-board workflow generates a GitHub App token as its **first, unconditional step**:

```yaml
- name: Generate GitHub App Token
  uses: actions/create-github-app-token@...
  with:
      app-id: ${{ secrets.PROJECT_BOARD_BOT_APP_ID }}
      private-key: ${{ secrets.PROJECT_BOARD_BOT_PRIVATE_KEY }}
```

Dependabot-triggered workflow runs execute in a **restricted secret context** (GitHub deliberately withholds normal Actions/org secrets from Dependabot to limit supply-chain blast radius). So those secrets resolve to empty and the step hard-fails:

```
Error: The 'client-id' (or deprecated 'app-id') input must be set to a non-empty string.
Token is not set
```

This has been red on every dependency bump since the upstream **2025-09-09 "Migrate from PAT to GitHub App authentication"** change.

## Fix

Guard the job with `github.actor != 'dependabot[bot]'`.

- **Functionally safe:** the board job only does anything when a Feature Flags team member is requested as a reviewer — dependency bumps never are. It's project-management automation, not a test/lint/correctness gate, so no coverage is lost.
- **Safer than the alternative:** adding `PROJECT_BOARD_BOT_APP_ID`/`PRIVATE_KEY` to Dependabot secrets would also fix it, but would hand an org-write GitHub App key to the untrusted Dependabot context — exactly what GitHub's secret isolation protects against.
- **No branch-protection limbo:** a job-level `if` reports the check as *skipped*, which branch protection treats as non-blocking (unlike a workflow-level `paths`/trigger filter, which can leave a check stuck "waiting for status").
