### PR TITLE
ci: consolidate Dependabot skip into reusable flags-board workflow

### DIFF
--- a/.github/workflows/call-flags-project-board.yml
+++ b/.github/workflows/call-flags-project-board.yml
@@ -9,8 +9,7 @@ on:
 
 jobs:
     call-flags-project:
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        uses: PostHog/.github/.github/workflows/flags-project-board.yml@d8b55d05dc5150f05c24542a6397ff3ecfbfb56d
+        uses: PostHog/.github/.github/workflows/flags-project-board.yml@69336b569d22687f8982eea6ff7d450a885cda05
         with:
             pr_number: ${{ github.event.pull_request.number }}
             pr_node_id: ${{ github.event.pull_request.node_id }}


### PR DESCRIPTION
## What

The Dependabot skip for the `call-flags-project / add-to-project-board` check is now handled **centrally** in the reusable workflow — [PostHog/.github#52](https://github.com/PostHog/.github/pull/52) (merged). This repo was carrying the same `github.actor != 'dependabot[bot]'` conditional inline.

This PR consolidates it:
- Bumps the `flags-project-board.yml` pin to the merged SHA `69336b569d22687f8982eea6ff7d450a885cda05`.
- Drops the now-redundant inline Dependabot guard.

## Why it's safe

- **No behavior change** — Dependabot PRs are still skipped, just by the reusable workflow instead of here.
- The pin bump pulls in **only** that one workflow change (verified via the `d8b55d05...69336b56` compare — the sole diff to `flags-project-board.yml` is the Dependabot skip).
- Fork guard (where present) is left untouched.

## Background

The board's GitHub App token step hard-fails in Dependabot's restricted secret context (`The 'client-id'... must be set to a non-empty string`), which is why the check was red on every dependency bump until the skip was added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
