### PR TITLE
chore: Split CI checks into separate jobs

### DIFF
--- a/.github/actions/setup-python-dev/action.yml
+++ b/.github/actions/setup-python-dev/action.yml
@@ -1,0 +1,26 @@
+name: Setup Python dev environment
+description: Set up Python, uv, and dev dependencies for CI checks.
+
+inputs:
+    python-version:
+        description: Python version to install.
+        required: false
+        default: 3.11.11
+
+runs:
+    using: composite
+    steps:
+        - name: Set up Python ${{ inputs.python-version }}
+          uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55
+          with:
+              python-version: ${{ inputs.python-version }}
+
+        - name: Install uv
+          uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+          with:
+              enable-cache: true
+
+        - name: Install dev dependencies
+          shell: bash
+          run: |
+              UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --extra dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,13 @@ on:
 permissions:
     contents: read
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
 jobs:
-    code-quality:
-        name: Code quality checks
+    ruff-format:
+        name: Ruff format
         runs-on: ubuntu-latest
 
         steps:
@@ -38,13 +42,85 @@ jobs:
               run: |
                   ruff format --check .
 
+    ruff-lint:
+        name: Ruff lint
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2
+              with:
+                  fetch-depth: 1
+
+            - name: Set up Python 3.11
+              uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55
+              with:
+                  python-version: 3.11.11
+
+            - name: Install uv
+              uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+              with:
+                  enable-cache: true
+
+            - name: Install dev dependencies
+              shell: bash
+              run: |
+                  UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --extra dev
+
             - name: Lint with ruff
               run: |
                   ruff check .
 
+    mypy:
+        name: Mypy
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2
+              with:
+                  fetch-depth: 1
+
+            - name: Set up Python 3.11
+              uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55
+              with:
+                  python-version: 3.11.11
+
+            - name: Install uv
+              uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+              with:
+                  enable-cache: true
+
+            - name: Install dev dependencies
+              shell: bash
+              run: |
+                  UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --extra dev
+
             - name: Check types with mypy
               run: |
                   mypy --no-site-packages --config-file mypy.ini  . | mypy-baseline filter
+
+    package-build:
+        name: Package build
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2
+              with:
+                  fetch-depth: 1
+
+            - name: Set up Python 3.11
+              uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55
+              with:
+                  python-version: 3.11.11
+
+            - name: Install uv
+              uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+              with:
+                  enable-cache: true
+
+            - name: Build and verify distributions
+              run: |
+                  uv build
+                  uv run --with twine twine check dist/*
 
     tests:
         name: Python ${{ matrix.python-version }} tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,20 +23,8 @@ jobs:
               with:
                   fetch-depth: 1
 
-            - name: Set up Python 3.11
-              uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55
-              with:
-                  python-version: 3.11.11
-
-            - name: Install uv
-              uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
-              with:
-                  enable-cache: true
-
-            - name: Install dev dependencies
-              shell: bash
-              run: |
-                  UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --extra dev
+            - name: Set up Python dev environment
+              uses: ./.github/actions/setup-python-dev
 
             - name: Check formatting with ruff
               run: |
@@ -51,20 +39,8 @@ jobs:
               with:
                   fetch-depth: 1
 
-            - name: Set up Python 3.11
-              uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55
-              with:
-                  python-version: 3.11.11
-
-            - name: Install uv
-              uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
-              with:
-                  enable-cache: true
-
-            - name: Install dev dependencies
-              shell: bash
-              run: |
-                  UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --extra dev
+            - name: Set up Python dev environment
+              uses: ./.github/actions/setup-python-dev
 
             - name: Lint with ruff
               run: |
@@ -79,20 +55,8 @@ jobs:
               with:
                   fetch-depth: 1
 
-            - name: Set up Python 3.11
-              uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55
-              with:
-                  python-version: 3.11.11
-
-            - name: Install uv
-              uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
-              with:
-                  enable-cache: true
-
-            - name: Install dev dependencies
-              shell: bash
-              run: |
-                  UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --extra dev
+            - name: Set up Python dev environment
+              uses: ./.github/actions/setup-python-dev
 
             - name: Check types with mypy
               run: |


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Split the combined code quality workflow into separate CI jobs so formatting, linting, typing, and package build checks report independently and can run/cancel more cleanly.

Changes:
- Added workflow concurrency to cancel superseded runs for the same PR/ref.
- Split Ruff format, Ruff lint, Mypy, and package build checks into separate jobs.
- Added a reusable local composite action for Python dev environment setup shared by the Ruff and Mypy jobs.
- Added a dedicated package build job that verifies distributions with `twine check`.

## :green_heart: How did you test it?

Reviewed the GitHub Actions workflow configuration and validated the workflow/action YAML parses successfully.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file

<!-- For more details check RELEASING.md -->
