### PR TITLE
ci: Verify public API snapshot check

### DIFF
--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -71,6 +71,12 @@ from posthog.version import VERSION
 
 __version__ = VERSION
 
+
+def public_api_snapshot_probe() -> str:
+    """Temporary public API used to verify the snapshot CI check."""
+    return "public-api-snapshot-probe"
+
+
 """Context management."""
 
 


### PR DESCRIPTION
## :bulb: Motivation and Context

Open a draft PR that intentionally adds a new public API without updating `references/public_api_snapshot.txt`, so we can verify the new public API snapshot CI check fails as expected.

## :green_heart: How did you test it?

- `uv run --extra dev ruff format --check posthog/__init__.py`
- `uv run --extra dev ruff check posthog/__init__.py`
- `uv run --extra dev mypy --no-site-packages --config-file mypy.ini posthog/__init__.py | uv run --extra dev mypy-baseline filter`
- `uv run --extra dev python .github/scripts/check_public_api.py` (expected failure: snapshot is out of date and shows `posthog.public_api_snapshot_probe` in the generated API)

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file
