### PR TITLE
chore: bump litellm to 1.84.0 in dspy example

### DIFF
--- a/examples/example-ai-dspy/pyproject.toml
+++ b/examples/example-ai-dspy/pyproject.toml
@@ -5,5 +5,5 @@ requires-python = ">=3.10"
 dependencies = [
     "posthog==7.9.12",
     "dspy>=2.5.0",
-    "litellm>=1.83.7",
+    "litellm==1.84.0",
 ]

--- a/examples/example-ai-dspy/uv.lock
+++ b/examples/example-ai-dspy/uv.lock
@@ -464,7 +464,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "dspy", specifier = ">=2.5.0" },
-    { name = "litellm", specifier = ">=1.83.7" },
+    { name = "litellm", specifier = "==1.84.0" },
     { name = "posthog", specifier = "==7.9.12" },
 ]
 
@@ -1002,7 +1002,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.83.7"
+version = "1.84.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1018,9 +1018,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/2b/b58bf6bbcbc3d0e55d0a84fdf9128e5b1436517f46fce89b1cd8948ebb81/litellm-1.83.7.tar.gz", hash = "sha256:e2f2cb99df2e2b2eab63f1354faa45c88dd7c8d40c18eb648afb1b349c689633", size = 17791694, upload-time = "2026-04-13T17:35:01.606Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dd/e9/8941b7e72a187000561d932c0f2f2ed2b0fd080dfc33ba6e05961d45ca7d/litellm-1.84.0.tar.gz", hash = "sha256:b8ad0cbea11a5941b18d5af973017a340abd3d3ab41cb86e5401b970626d71a6", size = 15103206, upload-time = "2026-05-14T05:45:53.017Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/80/caeb4cdcad96451ba83ad3ba2a9da08b1e1a915fa845c489f56ea044488b/litellm-1.83.7-py3-none-any.whl", hash = "sha256:5784a1d9a9a4a8acd6ca1e347003a5e2e1b3c749b4d41e7da4904577adade111", size = 16069807, upload-time = "2026-04-13T17:34:58.36Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a6/77fa1bbf5e42eb596b06318b3f7e6af5d0f44028046d1d598c6a595d028f/litellm-1.84.0-py3-none-any.whl", hash = "sha256:2a58d6041e6aa27d1a28dc8d8828ab500fef1a00ef74ca65e60899035010c2f2", size = 16735062, upload-time = "2026-05-14T05:45:49.927Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps the pinned `litellm` in the `example-ai-dspy` example from `1.83.7` to `1.84.0` to pull in upstream fixes.

`1.83.7` predated several patched litellm advisories (auth-bypass and route-access issues resolved in `1.83.10`/`1.83.14`, and a host-header-injection auth bypass resolved in `1.84.0`). The other AI examples (`example-ai-litellm`, `example-ai-crewai`) were already on `1.84.0`.

## Changes
- `examples/example-ai-dspy/pyproject.toml`: `litellm>=1.83.7` -> `litellm==1.84.0`
- `examples/example-ai-dspy/uv.lock`: regenerated (litellm `1.83.7` -> `1.84.0`)

Pinned exactly to `1.84.0` rather than a `>=` floor so the lock stays on the intended version (the repo's `exclude-newer = "7 days"` window otherwise resolves a `>=` floor up to the latest available release).