### PR TITLE
fix: add explicit return types for public client APIs

### DIFF
--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -565,7 +565,7 @@ def alias(
 def capture_exception(
     exception: Optional[ExceptionArg] = None,
     **kwargs: Unpack[OptionalCaptureArgs],
-):
+) -> Optional[str]:
     """
     Capture exceptions that happen in your code.
 
@@ -1010,7 +1010,7 @@ def load_feature_flags():
     return _proxy("load_feature_flags")
 
 
-def flush():
+def flush() -> None:
     """
     Tell the client to flush all queued events.
 
@@ -1026,7 +1026,7 @@ def flush():
     _proxy("flush")
 
 
-def join():
+def join() -> None:
     """
     Block program until the client clears the queue. Used during program shutdown. You should use `shutdown()` directly in most cases.
 
@@ -1042,7 +1042,7 @@ def join():
     _proxy("join")
 
 
-def shutdown():
+def shutdown() -> None:
     """
     Flush all messages and cleanly shutdown the client.
 

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -1103,7 +1103,7 @@ class Client(object):
         self,
         exception: Optional[ExceptionArg],
         **kwargs: Unpack[OptionalCaptureArgs],
-    ):
+    ) -> Optional[str]:
         """
         Capture an exception for error tracking.
 
@@ -1225,6 +1225,7 @@ class Client(object):
             return res
         except Exception as e:
             self.log.exception(f"Failed to capture exception: {e}")
+            return None
 
     @staticmethod
     def _reinit_after_fork_weak(weak_self):
@@ -1380,7 +1381,7 @@ class Client(object):
             self.log.warning("analytics-python queue is full")
             return None
 
-    def flush(self):
+    def flush(self) -> None:
         """
         Force a flush from the internal queue to the server. Do not use directly, call `shutdown()` instead.
 
@@ -1396,7 +1397,7 @@ class Client(object):
         # Note that this message may not be precise, because of threading.
         self.log.debug("successfully flushed about %s items.", size)
 
-    def join(self):
+    def join(self) -> None:
         """
         End the consumer thread once the queue is empty. Do not use directly, call `shutdown()` instead.
 
@@ -1420,7 +1421,7 @@ class Client(object):
         # Shutdown the cache provider (release locks, cleanup)
         self._shutdown_flag_definition_cache_provider()
 
-    def shutdown(self):
+    def shutdown(self) -> None:
         """
         Flush all messages and cleanly shutdown the client. Call this before the process ends in serverless environments to avoid data loss.
 


### PR DESCRIPTION
## Summary
- annotate public module-level helpers and matching `Client` methods with their concrete return types
- return `None` explicitly from `capture_exception` when exception capture itself fails so the annotation stays accurate
- make the shutdown/flush/join public APIs clearer for static type checkers

## Validation
- python -m compileall posthog
- python -m pytest -q  *(local environment is missing the repo's optional test dependencies, so full pytest collection could not complete here)*