### PR TITLE
fix: Clear feature flag called cache on shutdown

### DIFF
--- a/.sampo/changesets/venerable-runesinger-vainamoinen.md
+++ b/.sampo/changesets/venerable-runesinger-vainamoinen.md
@@ -1,0 +1,5 @@
+---
+pypi/posthog: patch
+---
+
+Clear feature flag called cache on shutdown

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -1716,6 +1716,7 @@ class Client(object):
         """
         self.flush(timeout_seconds=None)
         self.join()
+        self.distinct_ids_feature_flags_reported.clear()
 
         if self.exception_capture:
             self.exception_capture.close()

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -2026,6 +2026,14 @@ class TestClient(unittest.TestCase):
         for consumer in client.consumers:
             self.assertFalse(consumer.is_alive())
 
+    def test_shutdown_clears_feature_flag_called_dedupe_cache(self):
+        client = Client(FAKE_TEST_API_KEY, send=False, thread=0)
+        client.distinct_ids_feature_flags_reported["user"] = {("flag", True, ())}
+
+        client.shutdown()
+
+        self.assertEqual(len(client.distinct_ids_feature_flags_reported), 0)
+
     def test_shutdown_flushes_without_timeout(self):
         client = Client(FAKE_TEST_API_KEY, send=False, thread=0)
 


### PR DESCRIPTION
## :bulb: Motivation and Context

Shutting down a `Client` did not reset the in-memory feature flag `$feature_flag_called` dedupe cache, so a reused client instance could keep stale per-distinct-id feature flag reporting state after shutdown.

## :green_heart: How did you test it?

- `uv run pytest posthog/test/test_client.py::TestClient::test_shutdown_clears_feature_flag_called_dedupe_cache --verbose --timeout=30`
- `uv run pytest posthog/test/test_client.py -k shutdown --verbose --timeout=30`
- `uv run python -W error -c "import posthog"`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A coding agent prepared this PR from the existing `fix/ff-called-cache-shutdown` worktree. The change clears the feature flag called dedupe cache during shutdown, adds a focused regression test, and includes a Sampo patch changeset for release automation.
