### PR TITLE
fix: fall back when payload compression fails

### DIFF
--- a/.sampo/changesets/doughty-princess-loviatar.md
+++ b/.sampo/changesets/doughty-princess-loviatar.md
@@ -1,0 +1,5 @@
+---
+pypi/posthog: patch
+---
+
+Fall back to uncompressed uploads when gzip compression fails

--- a/posthog/request.py
+++ b/posthog/request.py
@@ -240,13 +240,16 @@ def post(
     log.debug("making request: %s to url: %s", data, url)
     headers = {"Content-Type": "application/json", "User-Agent": USER_AGENT}
     if gzip:
-        headers["Content-Encoding"] = "gzip"
-        buf = BytesIO()
-        with GzipFile(fileobj=buf, mode="w") as gz:
-            # 'data' was produced by json.dumps(),
-            # whose default encoding is utf-8.
-            gz.write(cast(str, data).encode("utf-8"))
-        data = buf.getvalue()
+        try:
+            buf = BytesIO()
+            with GzipFile(fileobj=buf, mode="w") as gz:
+                # 'data' was produced by json.dumps(),
+                # whose default encoding is utf-8.
+                gz.write(cast(str, data).encode("utf-8"))
+            data = buf.getvalue()
+            headers["Content-Encoding"] = "gzip"
+        except OSError as exc:
+            log.warning("failed to gzip request body, sending uncompressed: %s", exc)
 
     res = (session or _get_session()).post(
         url, data=data, headers=headers, timeout=timeout

--- a/posthog/request.py
+++ b/posthog/request.py
@@ -248,7 +248,7 @@ def post(
                 gz.write(cast(str, data).encode("utf-8"))
             data = buf.getvalue()
             headers["Content-Encoding"] = "gzip"
-        except OSError as exc:
+        except Exception as exc:
             log.warning("failed to gzip request body, sending uncompressed: %s", exc)
 
     res = (session or _get_session()).post(

--- a/posthog/request.py
+++ b/posthog/request.py
@@ -2,6 +2,7 @@ import json
 import logging
 import re
 import socket
+import zlib
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from gzip import GzipFile
@@ -248,7 +249,7 @@ def post(
                 gz.write(cast(str, data).encode("utf-8"))
             data = buf.getvalue()
             headers["Content-Encoding"] = "gzip"
-        except Exception as exc:
+        except (OSError, zlib.error) as exc:
             log.warning("failed to gzip request body, sending uncompressed: %s", exc)
 
     res = (session or _get_session()).post(

--- a/posthog/test/test_request.py
+++ b/posthog/test/test_request.py
@@ -179,6 +179,27 @@ class TestRequests(unittest.TestCase):
         self.assertIsInstance(data, bytes)
         self.assertEqual(headers["Content-Encoding"], "gzip")
 
+    def test_post_falls_back_to_uncompressed_payload_when_gzip_fails(self):
+        mock_response = requests.Response()
+        mock_response.status_code = 200
+        mock_session = mock.MagicMock()
+        mock_session.post.return_value = mock_response
+
+        with mock.patch.object(request_module, "GzipFile", side_effect=OSError("boom")):
+            request_module.post(
+                TEST_API_KEY,
+                host="https://test.posthog.com",
+                path="/batch/",
+                gzip=True,
+                session=mock_session,
+                batch=[],
+            )
+
+        data = mock_session.post.call_args.kwargs["data"]
+        headers = mock_session.post.call_args.kwargs["headers"]
+        self.assertIsInstance(data, str)
+        self.assertNotIn("Content-Encoding", headers)
+
     def test_datetime_serialization(self):
         data = {"created": datetime(2012, 3, 4, 5, 6, 7, 891011)}
         result = json.dumps(data, cls=DatetimeSerializer)

--- a/posthog/test/test_request.py
+++ b/posthog/test/test_request.py
@@ -1,5 +1,6 @@
 import json
 import unittest
+import zlib
 from datetime import date, datetime
 from unittest import mock
 
@@ -180,25 +181,27 @@ class TestRequests(unittest.TestCase):
         self.assertEqual(headers["Content-Encoding"], "gzip")
 
     def test_post_falls_back_to_uncompressed_payload_when_gzip_fails(self):
-        mock_response = requests.Response()
-        mock_response.status_code = 200
-        mock_session = mock.MagicMock()
-        mock_session.post.return_value = mock_response
+        for compression_error in [OSError("boom"), zlib.error("boom")]:
+            with self.subTest(compression_error=type(compression_error)):
+                mock_response = requests.Response()
+                mock_response.status_code = 200
+                mock_session = mock.MagicMock()
+                mock_session.post.return_value = mock_response
 
-        with mock.patch.object(request_module, "GzipFile", side_effect=OSError("boom")):
-            request_module.post(
-                TEST_API_KEY,
-                host="https://test.posthog.com",
-                path="/batch/",
-                gzip=True,
-                session=mock_session,
-                batch=[],
-            )
+                with mock.patch.object(request_module, "GzipFile", side_effect=compression_error):
+                    request_module.post(
+                        TEST_API_KEY,
+                        host="https://test.posthog.com",
+                        path="/batch/",
+                        gzip=True,
+                        session=mock_session,
+                        batch=[],
+                    )
 
-        data = mock_session.post.call_args.kwargs["data"]
-        headers = mock_session.post.call_args.kwargs["headers"]
-        self.assertIsInstance(data, str)
-        self.assertNotIn("Content-Encoding", headers)
+                data = mock_session.post.call_args.kwargs["data"]
+                headers = mock_session.post.call_args.kwargs["headers"]
+                self.assertIsInstance(data, str)
+                self.assertNotIn("Content-Encoding", headers)
 
     def test_datetime_serialization(self):
         data = {"created": datetime(2012, 3, 4, 5, 6, 7, 891011)}

--- a/posthog/test/test_request.py
+++ b/posthog/test/test_request.py
@@ -188,7 +188,9 @@ class TestRequests(unittest.TestCase):
                 mock_session = mock.MagicMock()
                 mock_session.post.return_value = mock_response
 
-                with mock.patch.object(request_module, "GzipFile", side_effect=compression_error):
+                with mock.patch.object(
+                    request_module, "GzipFile", side_effect=compression_error
+                ):
                     request_module.post(
                         TEST_API_KEY,
                         host="https://test.posthog.com",


### PR DESCRIPTION
## :bulb: Motivation and Context

When `gzip=True`, local gzip failures should not prevent the SDK from sending the batch. The SDK should fall back to the original uncompressed JSON payload without a `Content-Encoding` header.

This catches local gzip errors during request construction and keeps the upload path uncompressed. A unit test covers the fallback.

## :green_heart: How did you test it?

- `uv run --extra test pytest posthog/test/test_request.py -q`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented as part of a cross-SDK consistency pass for client-side compression failure fallback. Kept the change scoped to request construction and added a focused regression test.
