### PR TITLE
ci: Configure SDK compliance capture suite

### DIFF
--- a/.github/workflows/sdk-compliance.yml
+++ b/.github/workflows/sdk-compliance.yml
@@ -14,8 +14,11 @@ on:
 jobs:
   compliance:
     name: PostHog SDK compliance tests
-    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@be8b8d5a3f94a249659844e94832e874f049c1e4
+    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@fix/sdk-harness-options-20260630
     with:
       adapter-dockerfile: "sdk_compliance_adapter/Dockerfile"
       adapter-context: "."
       test-harness-version: "0.8.0"
+      suite: "capture"
+      sdk-type: "server"
+      continue-on-error: true

--- a/sdk_compliance_adapter/docker-compose.yml
+++ b/sdk_compliance_adapter/docker-compose.yml
@@ -14,7 +14,7 @@ services:
   # Test harness
   test-harness:
     image: ghcr.io/posthog/sdk-test-harness:0.8.0
-    command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081"]
+    command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081", "--sdk-type", "server", "--suite", "capture"]
     networks:
       - test-network
     depends_on:


### PR DESCRIPTION
## Problem

SDK compliance workflows need explicit harness suite/sdk-type selection and configurable blocking behavior so CI only runs the intended contract checks.

## Changes

- Point SDK compliance to the harness branch with new workflow inputs.
- Run capture v0 as a server SDK.
- Keep compliance failures non-blocking for now.
- Align local compose with the same suite/sdk type.

## Testing

- Parsed workflow YAML.
- Ran `docker compose config` for the adapter compose file.
- Ran `git diff --check`.

## Release / changeset

No SDK package changeset: CI/local compliance configuration only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Pi using dedicated git worktrees. The change was requested to align SDK compliance harness setup across SDK repositories while keeping non-ready SDKs non-blocking.
