### PR TITLE
ci: Allow flags board workflow to inherit secrets

### DIFF
--- a/.github/workflows/call-flags-project-board.yml
+++ b/.github/workflows/call-flags-project-board.yml
@@ -14,6 +14,8 @@ jobs:
             pr_number: ${{ github.event.pull_request.number }}
             pr_node_id: ${{ github.event.pull_request.node_id }}
             is_draft: ${{ github.event.pull_request.draft }}
-        secrets:
-            PROJECT_BOARD_BOT_APP_ID: ${{ secrets.PROJECT_BOARD_BOT_APP_ID }}
-            PROJECT_BOARD_BOT_PRIVATE_KEY: ${{ secrets.PROJECT_BOARD_BOT_PRIVATE_KEY }}
+        # The central .github reusable workflow does not declare workflow_call.secrets,
+        # so explicit secret mapping makes GitHub reject this caller at startup.
+        # It gates fork/Dependabot PRs before using secrets; keep this scoped call
+        # as an intentional exception to the broad-inheritance Semgrep rule.
+        secrets: inherit # nosemgrep


### PR DESCRIPTION
## :bulb: Motivation and Context
The feature flags project-board caller sometimes failed CI around Semgrep's broad `secrets: inherit` finding. Replacing it with explicit secret mapping caused GitHub to reject the reusable workflow at startup because the central `.github` workflow does not declare `workflow_call.secrets`.

This keeps the required inheritance for that reusable workflow and documents the Semgrep exception inline.

## :green_heart: How did you test it?
- Parsed `.github/workflows/call-flags-project-board.yml` with PyYAML and verified `secrets` resolves to `inherit`.
- Ran `git diff --check`.
- Ran Semgrep locally with a rule matching `secrets: inherit` and verified `# nosemgrep` suppresses the intentional exception.
- Ran the PostHog `.github` Semgrep rules locally against the workflow file.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi investigated the failing workflow behavior, confirmed explicit secret mapping is incompatible with the pinned central reusable workflow, and kept `secrets: inherit` as the required GitHub Actions configuration while adding a scoped Semgrep suppression with context for reviewers.
