### PR TITLE
fix: mirror django request user agent into $raw_user_agent

### DIFF
--- a/.sampo/changesets/mirror-raw-user-agent.md
+++ b/.sampo/changesets/mirror-raw-user-agent.md
@@ -1,5 +1,5 @@
 ---
-"posthog": patch
+"pypi/posthog": patch
 ---
 
 Django middleware also sends the request user agent as `$raw_user_agent`, the standardized property PostHog's server-side classification (e.g. bot detection) reads

--- a/.sampo/changesets/mirror-raw-user-agent.md
+++ b/.sampo/changesets/mirror-raw-user-agent.md
@@ -1,0 +1,5 @@
+---
+"posthog": patch
+---
+
+Django middleware also sends the request user agent as `$raw_user_agent`, the standardized property PostHog's server-side classification (e.g. bot detection) reads

--- a/posthog/integrations/django.py
+++ b/posthog/integrations/django.py
@@ -202,10 +202,12 @@ class PosthogContextMiddleware:
         if ip_address:
             tags["$ip"] = ip_address
 
-        # Extract user agent
+        # Extract user agent, mirrored into $raw_user_agent — the standardized
+        # property PostHog's server-side classification (e.g. bot detection) reads
         user_agent = request.headers.get("User-Agent")
         if user_agent:
             tags["$user_agent"] = user_agent
+            tags["$raw_user_agent"] = user_agent
 
         # Apply extra tags if configured
         if self.extra_tags:

--- a/posthog/test/integrations/test_middleware.py
+++ b/posthog/test/integrations/test_middleware.py
@@ -90,6 +90,7 @@ class TestPosthogContextMiddleware(unittest.TestCase):
                 headers={
                     "X-POSTHOG-SESSION-ID": "session-123",
                     "X-POSTHOG-DISTINCT-ID": "user-456",
+                    "User-Agent": "TestAgent/1.0",
                 },
                 method="POST",
                 path="/api/test",
@@ -103,6 +104,8 @@ class TestPosthogContextMiddleware(unittest.TestCase):
             self.assertEqual(get_context_distinct_id(), "user-456")
             self.assertEqual(tags["$current_url"], "https://example.com/api/test")
             self.assertEqual(tags["$request_method"], "POST")
+            self.assertEqual(tags["$user_agent"], "TestAgent/1.0")
+            self.assertEqual(tags["$raw_user_agent"], "TestAgent/1.0")
 
     def test_extract_tags_missing_headers(self):
         """Test tag extraction when PostHog headers are missing"""


### PR DESCRIPTION
## :bulb: Motivation and Context

The Django middleware tags all events in a request with `$user_agent`, but PostHog's server-side classification — web analytics bot detection (`$virt_is_bot` and friends) and the materialized-column fast path — keys on the standardized `$raw_user_agent` property (the one posthog-js sends). Server-side-tracked pageviews forwarding a real client UA are exactly the traffic where bot classification matters, and today they miss it.

PostHog/posthog#68253 removes the `$user_agent` query-time fallback for performance (it forced a full properties-blob read on every classification query — see the PR for production measurements), so this change mirrors the header into `$raw_user_agent`, aligning the middleware with the standardized property. Related: PostHog/posthog#68232.

`$user_agent` is still sent for backwards compatibility.

## :green_heart: How did you test it?

Agent-authored. Extended `test_extract_tags_basic` to assert both properties carry the request's User-Agent header; ran the middleware extract_tags tests locally (11 passed).

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] Changeset added in `.sampo/changesets/`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code as part of a cross-repo effort to standardize on `$raw_user_agent` (PostHog/posthog#68232, PostHog/posthog#68253, with sibling PRs to posthog-android and posthog-ruby).
