### PR TITLE
fix: say the event is dropped when the queue is full

### DIFF
--- a/.sampo/changesets/queue-full-log-message.md
+++ b/.sampo/changesets/queue-full-log-message.md
@@ -1,0 +1,5 @@
+---
+pypi/posthog: patch
+---
+
+Clarify the queue-full warning to say the event is being dropped, instead of only reporting that the queue is full.

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -1712,7 +1712,11 @@ class Client(object):
             self.log.debug("enqueued %s.", msg["event"])
             return sent_uuid
         except Full:
-            self.log.warning("analytics-python queue is full")
+            self.log.warning(
+                "event queue is full (maxsize %d), dropping event %s",
+                self.queue.maxsize,
+                msg["event"],
+            )
             return None
 
     def flush(self, timeout_seconds: Optional[float] = 10) -> None:

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -2114,9 +2114,11 @@ class TestClient(unittest.TestCase):
         for i in range(10):
             client.capture("test event", distinct_id="distinct_id")
 
-        msg_uuid = client.capture("test event", distinct_id="distinct_id")
+        with self.assertLogs("posthog", level="WARNING") as logs:
+            msg_uuid = client.capture("test event", distinct_id="distinct_id")
         # Make sure we are informed that the queue is at capacity
         self.assertIsNone(msg_uuid)
+        self.assertIn("dropping event", logs.output[0])
 
     def test_unicode(self):
         Client("unicode_key")


### PR DESCRIPTION
The queue-full warning now says the event is being dropped (with the queue maxsize and event name) instead of only reporting that the queue is full, and drops the stale analytics-python name.

Follows the discussion below: the original backpressure modes and the on_drop callback are gone, the public API is unchanged.

Context: #146