### PR TITLE
chore(flags): add README so PyPI shows a project description

### DIFF
--- a/.sampo/changesets/openfeature-provider-readme.md
+++ b/.sampo/changesets/openfeature-provider-readme.md
@@ -1,0 +1,5 @@
+---
+'pypi/openfeature-provider-posthog': patch
+---
+
+Add a README so PyPI renders a project description instead of showing none.

--- a/openfeature-provider/README.md
+++ b/openfeature-provider/README.md
@@ -1,0 +1,9 @@
+# openfeature-provider-posthog
+
+Official PostHog provider for the [OpenFeature](https://openfeature.dev) Python SDK, backed by [posthog-python](https://github.com/PostHog/posthog-python).
+
+## Documentation
+
+Installation and usage instructions live in the PostHog docs, so they stay in one place and don't drift:
+
+https://posthog.com/docs/feature-flags/installation/openfeature

--- a/openfeature-provider/pyproject.toml
+++ b/openfeature-provider/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "openfeature-provider-posthog"
 version = "0.1.0"
 description = "Official PostHog provider for the OpenFeature Python SDK."
+readme = "README.md"
 authors = [{ name = "PostHog", email = "engineering@posthog.com" }]
 maintainers = [{ name = "PostHog", email = "engineering@posthog.com" }]
 license = { text = "MIT" }


### PR DESCRIPTION
## :bulb: Motivation and Context

`openfeature-provider-posthog` has no `readme` field in its `pyproject.toml`, so its PyPI page renders no long description. This adds a short README (pointing to the PostHog docs for install/usage, same pattern as `@posthog/openfeature-web-provider` on npm) and wires it up via `readme = "README.md"`.

## :green_heart: How did you test it?

Ran `uv build --package openfeature-provider-posthog` locally and inspected the built wheel's `METADATA` file to confirm the README is now embedded as the package description.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Used Claude Code to draft the README copy (matching the style of `@posthog/openfeature-web-provider`'s npm README — a one-line summary plus a pointer to docs) and to wire up `readme = "README.md"` in `pyproject.toml`.
- Verified locally via `uv build` that PyPI will now pick up the README as the long description, since the field was previously missing entirely.
- Added a Sampo changeset for a patch release.