### PR TITLE
feat(error-tracking): link exceptions to active spans

### DIFF
--- a/.sampo/changesets/capture-exception-otel-context.md
+++ b/.sampo/changesets/capture-exception-otel-context.md
@@ -1,0 +1,5 @@
+---
+pypi/posthog: minor
+---
+
+Add the active OpenTelemetry span's `$trace_id` and `$span_id` to events captured with `capture_exception`.

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -52,7 +52,7 @@ from posthog.exception_utils import (
     exc_info_from_error,
     exception_is_already_captured,
     exceptions_from_error_tuple,
-    get_current_otel_span_properties,
+    _get_current_otel_span_properties,
     handle_in_app,
     mark_exception_as_captured,
     try_attach_code_variables_to_frames,
@@ -1471,7 +1471,7 @@ class Client(object):
 
             properties = {
                 "$exception_list": all_exceptions_with_trace_and_in_app,
-                **get_current_otel_span_properties(),
+                **_get_current_otel_span_properties(),
                 **properties,
             }
 

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -52,6 +52,7 @@ from posthog.exception_utils import (
     exc_info_from_error,
     exception_is_already_captured,
     exceptions_from_error_tuple,
+    get_current_otel_span_properties,
     handle_in_app,
     mark_exception_as_captured,
     try_attach_code_variables_to_frames,
@@ -1405,6 +1406,9 @@ class Client(object):
         """
         Capture an exception for error tracking.
 
+        When OpenTelemetry is installed and a valid span is active, its trace and
+        span IDs are added as ``$trace_id`` and ``$span_id`` event properties.
+
         Args:
             exception: The exception to capture.
             distinct_id: The distinct ID of the user.
@@ -1467,6 +1471,7 @@ class Client(object):
 
             properties = {
                 "$exception_list": all_exceptions_with_trace_and_in_app,
+                **get_current_otel_span_properties(),
                 **properties,
             }
 

--- a/posthog/exception_utils.py
+++ b/posthog/exception_utils.py
@@ -98,6 +98,24 @@ _URL_CREDENTIALS_RE = re.compile(
 )
 
 
+def get_current_otel_span_properties() -> Dict[str, str]:
+    try:
+        from opentelemetry import trace
+    except ImportError:
+        return {}
+
+    try:
+        span_context = trace.get_current_span().get_span_context()
+        if not span_context.is_valid:
+            return {}
+        return {
+            "$trace_id": f"{span_context.trace_id:032x}",
+            "$span_id": f"{span_context.span_id:016x}",
+        }
+    except Exception:
+        return {}
+
+
 def _redact_url_credentials(value):
     if "://" not in value:
         return value

--- a/posthog/exception_utils.py
+++ b/posthog/exception_utils.py
@@ -98,7 +98,7 @@ _URL_CREDENTIALS_RE = re.compile(
 )
 
 
-def get_current_otel_span_properties() -> Dict[str, str]:
+def _get_current_otel_span_properties() -> Dict[str, str]:
     try:
         from opentelemetry import trace
     except ImportError:

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -4,9 +4,10 @@ import time
 import unittest
 import warnings
 from datetime import datetime
+from unittest import mock
 from uuid import UUID, uuid4
 
-from unittest import mock
+from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags, use_span
 from parameterized import parameterized
 
 from posthog.capture_compression import CaptureCompression
@@ -486,6 +487,58 @@ class TestClient(unittest.TestCase):
             capture_call = patch_capture.call_args
             self.assertEqual(capture_call[0][0], "$exception")
             self.assertEqual(capture_call[1]["distinct_id"], "distinct_id")
+
+    @parameterized.expand(
+        [
+            (
+                "active_context",
+                0x123,
+                0x456,
+                {},
+                "00000000000000000000000000000123",
+                "0000000000000456",
+            ),
+            (
+                "explicit_properties",
+                0x123,
+                0x456,
+                {"$trace_id": "custom-trace", "$span_id": "custom-span"},
+                "custom-trace",
+                "custom-span",
+            ),
+            ("invalid_context", 0, 0, {}, None, None),
+        ]
+    )
+    def test_capture_exception_uses_current_otel_span_context(
+        self,
+        _,
+        context_trace_id,
+        context_span_id,
+        properties,
+        expected_trace_id,
+        expected_span_id,
+    ):
+        span_context = SpanContext(
+            trace_id=context_trace_id,
+            span_id=context_span_id,
+            is_remote=False,
+            trace_flags=TraceFlags.SAMPLED,
+        )
+
+        with (
+            mock.patch("posthog.client.batch_post") as mock_post,
+            use_span(NonRecordingSpan(span_context)),
+        ):
+            client = Client(FAKE_TEST_API_KEY, sync_mode=True)
+            client.capture_exception(Exception("test exception"), properties=properties)
+
+        event = mock_post.call_args.kwargs["batch"][0]
+        if expected_trace_id is None:
+            self.assertNotIn("$trace_id", event["properties"])
+            self.assertNotIn("$span_id", event["properties"])
+        else:
+            self.assertEqual(event["properties"]["$trace_id"], expected_trace_id)
+            self.assertEqual(event["properties"]["$span_id"], expected_span_id)
 
     def test_basic_capture_exception_with_distinct_id(self):
         with mock.patch.object(Client, "capture", return_value=None) as patch_capture:


### PR DESCRIPTION
## :bulb: Motivation and Context

Exceptions captured inside instrumented code currently lose their active OpenTelemetry context, which prevents correlation with the trace and span where the exception occurred.

`capture_exception` now reads a valid active OpenTelemetry span when the optional dependency is available and adds zero-padded `$trace_id` and `$span_id` properties. Explicitly supplied properties retain precedence, and exception capture remains unchanged when OpenTelemetry is absent or no valid span is active.

## :green_heart: How did you test it?

- `uv run --extra test pytest posthog/test/test_client.py -k 'capture_exception' --verbose --timeout=30`
- `uv run ruff format --check . && uv run ruff check .`
- `uv run --extra dev --extra test mypy --no-site-packages --config-file mypy.ini . | uv run --extra dev mypy-baseline filter`
- `uv run make public_api_check`
- `uv run python -W error -c "import posthog"`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent. The active span is read through a lazy OpenTelemetry import so the SDK keeps its optional dependency behavior. Only valid contexts are emitted, identifiers use standard fixed-width lowercase hexadecimal formatting, and caller-supplied values take precedence. A focused branch was created from current `main` to avoid including unrelated local error-tracking work.