### PR TITLE
feat(metrics): support metrics config via module-level settings

### DIFF
--- a/.sampo/changesets/module-level-metrics-config.md
+++ b/.sampo/changesets/module-level-metrics-config.md
@@ -1,0 +1,5 @@
+---
+'pypi/posthog': minor
+---
+
+The `client.metrics` config can now be set through module-level settings: assign `posthog.metrics = {"service_name": ..., ...}` alongside `posthog.api_key` and the dict is applied when `setup()` builds the global client. Previously module-configured apps had no way to pass the metrics config, so every series recorded through the global client shipped `service.name='unknown_service'`. Late assignment (e.g. a Django `ready()` hook running after an early `setup()`) still applies on the next `setup()` call, as long as the metrics API hasn't been used yet.

--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -329,6 +329,10 @@ Attributes:
         requests after network, transport, or timeout failures. Defaults to 1.
         Set to 0 to disable retries.
     super_properties: Properties merged into every captured event.
+    metrics: Config dict for the ``client.metrics`` API (``service_name``,
+        ``service_version``, ``environment``, ``flush_interval``, ...). Applied
+        when ``setup()`` builds the global client, or on a later ``setup()``
+        call if the metrics API hasn't been used yet.
     enable_exception_autocapture: Automatically capture uncaught exceptions.
     log_captured_exceptions: Also log exceptions captured by error tracking.
     before_send: Optional callback that can modify or drop events before upload.
@@ -374,6 +378,7 @@ is_server = True  # type: bool
 feature_flags_request_timeout_seconds = 3  # type: int
 feature_flags_request_max_retries = 1  # type: int
 super_properties = None  # type: Optional[Dict]
+metrics = None  # type: Optional[Dict]
 enable_exception_autocapture = False  # type: bool
 log_captured_exceptions = False  # type: bool
 # Used to determine in app paths for exception autocapture. Defaults to the current working directory
@@ -1169,6 +1174,7 @@ def setup() -> Client:
             feature_flags_request_timeout_seconds=feature_flags_request_timeout_seconds,
             feature_flags_request_max_retries=feature_flags_request_max_retries,
             super_properties=super_properties,
+            metrics=metrics,
             # TODO: Currently this monitoring begins only when the Client is initialised (which happens when you do something with the SDK)
             # This kind of initialisation is very annoying for exception capture. We need to figure out a way around this,
             # or deprecate this proxy option fully (it's already in the process of deprecation, no new clients should be using this method since like 5-6 months)
@@ -1195,6 +1201,11 @@ def setup() -> Client:
     default_client.disabled = disabled or not default_client.api_key
     default_client.debug = debug
     default_client._set_before_send(before_send)
+    # Metrics config is consumed lazily on first `.metrics` access, so late
+    # module-attr assignment (e.g. a Django ready() hook running after something
+    # already forced setup()) still applies until the metrics API is first used.
+    if default_client._metrics is None:
+        default_client._metrics_config = metrics
 
     return default_client
 

--- a/posthog/test/test_metrics.py
+++ b/posthog/test/test_metrics.py
@@ -313,6 +313,78 @@ class TestMetricsDelivery:
                 posthog.sync_mode,
             ) = saved
 
+    def test_module_metrics_config_flows_to_default_client(self):
+        # Module-level `posthog.metrics = {...}` must reach the client built by
+        # posthog.setup(), or apps configured via module settings get
+        # 'unknown_service' as service.name on every series.
+        saved = (
+            posthog.default_client,
+            posthog.api_key,
+            posthog.host,
+            posthog.sync_mode,
+            getattr(posthog, "metrics", None),
+        )
+        posthog.default_client = None
+        posthog.api_key = FAKE_API_KEY
+        posthog.host = "https://us.example.com"
+        posthog.sync_mode = True
+        posthog.metrics = {"service_name": "module-configured"}
+        try:
+            client = posthog.setup()
+            client.metrics.count("m", 1)
+            payload, _, _ = flush_and_capture(client)
+            resource_attrs = {
+                kv["key"]: kv["value"]
+                for kv in payload["resourceMetrics"][0]["resource"]["attributes"]
+            }
+            assert resource_attrs["service.name"] == {
+                "stringValue": "module-configured"
+            }
+        finally:
+            (
+                posthog.default_client,
+                posthog.api_key,
+                posthog.host,
+                posthog.sync_mode,
+                posthog.metrics,
+            ) = saved
+
+    def test_module_metrics_config_set_after_setup_applies_until_first_use(self):
+        # Django-style apps set module attrs in a ready() hook that can run after
+        # something else has already forced setup(). As long as `.metrics` hasn't
+        # been touched yet, a repeat setup() call must pick up the new config.
+        saved = (
+            posthog.default_client,
+            posthog.api_key,
+            posthog.host,
+            posthog.sync_mode,
+            getattr(posthog, "metrics", None),
+        )
+        posthog.default_client = None
+        posthog.api_key = FAKE_API_KEY
+        posthog.host = "https://us.example.com"
+        posthog.sync_mode = True
+        posthog.metrics = None
+        try:
+            posthog.setup()
+            posthog.metrics = {"service_name": "late-configured"}
+            client = posthog.setup()
+            client.metrics.count("m", 1)
+            payload, _, _ = flush_and_capture(client)
+            resource_attrs = {
+                kv["key"]: kv["value"]
+                for kv in payload["resourceMetrics"][0]["resource"]["attributes"]
+            }
+            assert resource_attrs["service.name"] == {"stringValue": "late-configured"}
+        finally:
+            (
+                posthog.default_client,
+                posthog.api_key,
+                posthog.host,
+                posthog.sync_mode,
+                posthog.metrics,
+            ) = saved
+
 
 class TestMetricsCrashSafety:
     # A telemetry SDK must never raise into the host application — these inputs all

--- a/references/public_api_snapshot.txt
+++ b/references/public_api_snapshot.txt
@@ -708,6 +708,7 @@ attribute posthog.mcp.types.UserIdentity.distinct_id: str
 attribute posthog.mcp.types.UserIdentity.groups: Optional[Dict[str, str]] = None
 attribute posthog.mcp.types.UserIdentity.properties: Optional[JsonRecord] = None
 attribute posthog.mcp.version.__version__ = '0.1.0'
+attribute posthog.metrics = None
 attribute posthog.metrics_capture.DEFAULT_HISTOGRAM_BOUNDS = [0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000]
 attribute posthog.metrics_capture.MetricAttributeValue = Union[str, int, float, bool]
 attribute posthog.metrics_capture.log = logging.getLogger('posthog')


### PR DESCRIPTION
## :bulb: Motivation and Context

Apps configured through module attributes (`posthog.api_key = ...` + implicit `setup()`) — including PostHog's own Django monorepo via `posthoganalytics` — have no way to pass the `metrics` config dict. Every series they record through `client.metrics` ships `service.name='unknown_service'`, which defeats the Metrics UI's service filtering.

This adds the module-level `metrics` attr (mirroring how every other `Client` kwarg is exposed as a module setting) and passes it through `setup()`. Because the config is consumed lazily on first `.metrics` access, a repeat `setup()` call also refreshes it until the metrics API is first used — Django `ready()` hooks that run after something already forced `setup()` still apply.

Groundwork for the monorepo's bump-ready `client.metrics` usage from web/celery (companion PR in PostHog/posthog).

## :green_heart: How did you test it?

- Two new tests in `posthog/test/test_metrics.py`, red before the change (`service.name` came back `unknown_service`): module attr flows into the `setup()` client's OTLP resource attributes, and late assignment applies on repeat `setup()` until first use.
- `pytest --timeout=30`: 1640 passed; the 9 failures are the pre-existing network-dependent `posthog/test/ai/*` integration tests (verified they fail identically on a clean checkout in the same sandbox).
- `ruff format --check`, `ruff check`, `mypy | mypy-baseline filter` (no issues), `python -W error -c "import posthog"` all clean.
- End to end: with this patch, a module-configured client in a forked child (celery-prefork shape) recorded and flushed real metrics that arrived in the Metrics product with the configured service name.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file (authored directly in `.sampo/changesets/module-level-metrics-config.md` — same format)

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude (PostHog Code session) while making the PostHog monorepo bump-ready for `client.metrics`. TDD: the two tests were written and observed failing before the implementation. The late-assignment refresh in `setup()` follows the existing "always set in case user changes it" post-construction block, and is limited to before first `.metrics` use so an active aggregation window is never reconfigured mid-flight.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*