### PR TITLE
ci: clean up workflow warnings and pin tooling

### DIFF
--- a/.github/actions/setup-python-dev/action.yml
+++ b/.github/actions/setup-python-dev/action.yml
@@ -11,13 +11,14 @@ runs:
     using: composite
     steps:
         - name: Set up Python ${{ inputs.python-version }}
-          uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55
+          uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
           with:
               python-version: ${{ inputs.python-version }}
 
         - name: Install uv
-          uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+          uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
           with:
+              version: "0.11.32"
               enable-cache: true
 
         - name: Install dev dependencies

--- a/.github/workflows/call-flags-project-board.yml
+++ b/.github/workflows/call-flags-project-board.yml
@@ -14,6 +14,8 @@ jobs:
             pr_number: ${{ github.event.pull_request.number }}
             pr_node_id: ${{ github.event.pull_request.node_id }}
             is_draft: ${{ github.event.pull_request.draft }}
-        secrets:
-            PROJECT_BOARD_BOT_APP_ID: ${{ secrets.PROJECT_BOARD_BOT_APP_ID }}
-            PROJECT_BOARD_BOT_PRIVATE_KEY: ${{ secrets.PROJECT_BOARD_BOT_PRIVATE_KEY }}
+        # The central .github reusable workflow does not declare workflow_call.secrets,
+        # so explicit secret mapping makes GitHub reject this caller at startup.
+        # It gates fork/Dependabot PRs before using secrets; keep this scoped call
+        # as an intentional exception to the broad-inheritance Semgrep rule.
+        secrets: inherit # nosemgrep

--- a/.github/workflows/call-flags-project-board.yml
+++ b/.github/workflows/call-flags-project-board.yml
@@ -9,13 +9,11 @@ on:
 
 jobs:
     call-flags-project:
-        uses: PostHog/.github/.github/workflows/flags-project-board.yml@69336b569d22687f8982eea6ff7d450a885cda05
+        uses: PostHog/.github/.github/workflows/flags-project-board.yml@a0b36e0021c4bf3d8a5d99972ac993ae54686ba8
         with:
             pr_number: ${{ github.event.pull_request.number }}
             pr_node_id: ${{ github.event.pull_request.node_id }}
             is_draft: ${{ github.event.pull_request.draft }}
-        # The central .github reusable workflow does not declare workflow_call.secrets,
-        # so explicit secret mapping makes GitHub reject this caller at startup.
-        # It gates fork/Dependabot PRs before using secrets; keep this scoped call
-        # as an intentional exception to the broad-inheritance Semgrep rule.
-        secrets: inherit # nosemgrep
+        secrets:
+            PROJECT_BOARD_BOT_APP_ID: ${{ secrets.PROJECT_BOARD_BOT_APP_ID }}
+            PROJECT_BOARD_BOT_PRIVATE_KEY: ${{ secrets.PROJECT_BOARD_BOT_PRIVATE_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   fetch-depth: 1
 
@@ -35,7 +35,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   fetch-depth: 1
 
@@ -51,7 +51,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   fetch-depth: 1
 
@@ -67,7 +67,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Set up Python dev environment
               uses: ./.github/actions/setup-python-dev
@@ -82,12 +82,12 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   fetch-depth: 1
 
             - name: Set up Python 3.11
-              uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55
+              uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
               with:
                   python-version: 3.11.11
 
@@ -99,18 +99,19 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   fetch-depth: 1
 
             - name: Set up Python 3.11
-              uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55
+              uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
               with:
                   python-version: 3.11.11
 
             - name: Install uv
-              uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+              uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
               with:
+                  version: "0.11.32"
                   enable-cache: true
 
             - name: Build and verify distributions
@@ -126,18 +127,19 @@ jobs:
                 python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
         steps:
-            - uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   fetch-depth: 1
 
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55
+              uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
               with:
                   python-version: ${{ matrix.python-version }}
 
             - name: Install uv
-              uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+              uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
               with:
+                  version: "0.11.32"
                   enable-cache: true
 
             - name: Install test dependencies
@@ -154,7 +156,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   fetch-depth: 0
 
@@ -188,14 +190,15 @@ jobs:
 
             - name: Set up Python 3.11
               if: steps.changes.outputs.changed == 'true'
-              uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55
+              uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
               with:
                   python-version: 3.11.11
 
             - name: Install uv
               if: steps.changes.outputs.changed == 'true'
-              uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+              uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
               with:
+                  version: "0.11.32"
                   enable-cache: true
 
             - name: Check utils CRAP score
@@ -241,12 +244,12 @@ jobs:
                 python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
         steps:
-            - uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   fetch-depth: 1
 
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55
+              uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
               with:
                   python-version: ${{ matrix.python-version }}
 
@@ -264,18 +267,19 @@ jobs:
                 python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
         steps:
-            - uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   fetch-depth: 1
 
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55
+              uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
               with:
                   python-version: ${{ matrix.python-version }}
 
             - name: Install uv
-              uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+              uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
               with:
+                  version: "0.11.32"
                   enable-cache: true
 
             # openfeature-provider-posthog is a uv workspace member (declared in
@@ -318,18 +322,19 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   fetch-depth: 1
 
             - name: Set up Python 3.12
-              uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55
+              uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
               with:
                   python-version: 3.12
 
             - name: Install uv
-              uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+              uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
               with:
+                  version: "0.11.32"
                   enable-cache: true
 
             - name: Install Django 5 test project dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,8 +101,9 @@ jobs:
           python-version: 3.11.11
 
       - name: Install uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
+          version: "0.11.32"
           enable-cache: true
 
       - name: Install Rust
@@ -304,8 +305,9 @@ jobs:
           python-version: 3.11.11
 
       - name: Install uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
+          version: "0.11.32"
           enable-cache: true
 
       - name: Install dependencies
@@ -453,8 +455,9 @@ jobs:
           python-version: 3.11.11
 
       - name: Install uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
+          version: "0.11.32"
           enable-cache: true
 
       - name: Install Rust

--- a/.github/workflows/sdk-compliance.yml
+++ b/.github/workflows/sdk-compliance.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   compliance:
     name: PostHog SDK compliance tests (capture v0)
-    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@02c049e529001d02f37a534745678e057d371fb0
+    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@eea2a62aa490b1bfa2e2b3488fc0042b89cfa5ed
     with:
       adapter-dockerfile: "sdk_compliance_adapter/Dockerfile"
       adapter-context: "."
@@ -23,7 +23,7 @@ jobs:
 
   compliance-v1:
     name: PostHog SDK compliance tests (capture v1)
-    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@02c049e529001d02f37a534745678e057d371fb0
+    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@eea2a62aa490b1bfa2e2b3488fc0042b89cfa5ed
     with:
       adapter-dockerfile: "sdk_compliance_adapter/Dockerfile.v1"
       adapter-context: "."

--- a/openfeature-provider/pyproject.toml
+++ b/openfeature-provider/pyproject.toml
@@ -9,13 +9,12 @@ description = "Official PostHog provider for the OpenFeature Python SDK."
 readme = "README.md"
 authors = [{ name = "PostHog", email = "engineering@posthog.com" }]
 maintainers = [{ name = "PostHog", email = "engineering@posthog.com" }]
-license = { text = "MIT" }
+license = "MIT"
 requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/posthog/ai/openai/openai.py
+++ b/posthog/ai/openai/openai.py
@@ -162,7 +162,7 @@ class WrappedResponses(_OpenAIWrapperResource):
 
         def generator():
             nonlocal usage_stats
-            nonlocal final_content  # noqa: F824
+            nonlocal final_content
             nonlocal model_from_response
             nonlocal stop_reason
 
@@ -417,7 +417,7 @@ class WrappedCompletions(_OpenAIWrapperResource):
 
         def generator():
             nonlocal usage_stats
-            nonlocal accumulated_content  # noqa: F824
+            nonlocal accumulated_content
             nonlocal accumulated_tool_calls
             nonlocal model_from_response
             nonlocal stop_reason

--- a/posthog/ai/openai/openai_async.py
+++ b/posthog/ai/openai/openai_async.py
@@ -166,7 +166,7 @@ class WrappedResponses(_OpenAIWrapperResource):
 
         async def async_generator():
             nonlocal usage_stats
-            nonlocal final_content  # noqa: F824
+            nonlocal final_content
             nonlocal model_from_response
             nonlocal stop_reason
 
@@ -459,7 +459,7 @@ class WrappedCompletions(_OpenAIWrapperResource):
 
         async def async_generator():
             nonlocal usage_stats
-            nonlocal accumulated_content  # noqa: F824
+            nonlocal accumulated_content
             nonlocal accumulated_tool_calls
             nonlocal model_from_response
             nonlocal stop_reason

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,14 +8,13 @@ version = "7.33.0"
 description = "Integrate PostHog into any python application."
 authors = [{ name = "PostHog", email = "engineering@posthog.com" }]
 maintainers = [{ name = "PostHog", email = "engineering@posthog.com" }]
-license = { text = "MIT" }
+license = "MIT"
 readme = "README.md"
 requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
## :bulb: Motivation and Context

An audit of the CI logs for #795 found a transient failure while `setup-uv` resolved the latest uv release, Node.js 20 action deprecation warnings, deprecated package metadata, invalid Ruff suppressions, and warnings from outdated shared workflows.

This makes CI tooling deterministic and updates warning-producing configuration without changing SDK behavior. SDK compliance checks intentionally remain non-blocking for now.

## :green_heart: How did you test it?

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run --extra test pytest posthog/test/ai/openai/test_openai.py --timeout=30 -q` (55 passed, 1 skipped)
- Built both distributions with `uv build` and validated them with `twine check`
- Confirmed both wheels contain `License-Expression: MIT` and no deprecated license classifier
- Parsed the modified YAML and TOML files and ran `git diff --check`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent after a user-directed audit of all CI logs for #795. The changes pin uv exactly, move affected actions and shared workflows to Node.js 24-compatible revisions, retain the existing project-board secret inheritance, modernize license metadata, and remove invalid Ruff suppressions. Expected pytest deprecation noise and third-party Python 3.14 warnings were left for separate follow-up work rather than globally suppressed.

