### PR TITLE
feat(ai): expose prompt config on fetched prompts

### DIFF
--- a/.sampo/changesets/prompt-config.md
+++ b/.sampo/changesets/prompt-config.md
@@ -1,0 +1,5 @@
+---
+pypi/posthog: minor
+---
+
+feat(ai): `Prompts.get(..., with_metadata=True)` results now include `config`, the JSON object of model parameters or agent configuration stored with the prompt version in PostHog prompt management (`None` when the version has none). Config is carried through the client-side cache and the stale-cache fallback. The hardcoded `fallback` string has no config, so use defensive access like `(result.config or {}).get("temperature", 0)`.

--- a/posthog/ai/prompts.py
+++ b/posthog/ai/prompts.py
@@ -32,6 +32,11 @@ class PromptResult:
 
     ``label`` is the label the prompt resolved through, populated from the API
     response when fetching with the ``label`` option; ``None`` otherwise.
+
+    ``config`` is the JSON object of model parameters or agent configuration
+    stored with the prompt version, or ``None`` when the version has none
+    (including on ``code_fallback`` results). Use defensive access, e.g.
+    ``(result.config or {}).get("temperature", 0)``.
     """
 
     source: PromptSource
@@ -39,6 +44,7 @@ class PromptResult:
     name: Optional[str] = None
     version: Optional[int] = None
     label: Optional[str] = None
+    config: Optional[Dict[str, Any]] = None
 
 
 class CachedPrompt:
@@ -51,12 +57,14 @@ class CachedPrompt:
         name: str,
         version: int,
         label: Optional[str] = None,
+        config: Optional[Dict[str, Any]] = None,
     ):
         self.prompt = prompt
         self.fetched_at = fetched_at
         self.name = name
         self.version = version
         self.label = label
+        self.config = config
 
 
 def _cache_key(
@@ -81,6 +89,12 @@ def _prompt_reference(
     if label is not None:
         return f'{reference} label "{label}"'
     return reference
+
+
+def _extract_config(data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Read config from an API response, tolerating servers that don't send it."""
+    config = data.get("config")
+    return config if isinstance(config, dict) else None
 
 
 def _is_prompt_api_response(data: Any) -> bool:
@@ -225,9 +239,9 @@ class Prompts:
         Fetch a prompt by name from the PostHog API.
 
         When ``with_metadata`` is ``True``, returns a :class:`PromptResult`
-        with ``source``, ``name``, and ``version`` metadata.  When omitted or
-        ``False``, returns a plain string (deprecated -- will be removed in a
-        future major version).
+        with ``source``, ``name``, ``version``, and ``config`` metadata.  When
+        omitted or ``False``, returns a plain string (deprecated -- will be
+        removed in a future major version).
 
         Args:
             name: The name of the prompt to fetch
@@ -319,6 +333,7 @@ class Prompts:
                     name=cached.name,
                     version=cached.version,
                     label=cached.label,
+                    config=cached.config,
                 )
 
         # Try to fetch from API
@@ -344,6 +359,7 @@ class Prompts:
                 name=data["name"],
                 version=data["version"],
                 label=data.get("label"),
+                config=_extract_config(data),
             )
 
             return PromptResult(
@@ -352,6 +368,7 @@ class Prompts:
                 name=data["name"],
                 version=data["version"],
                 label=data.get("label"),
+                config=_extract_config(data),
             )
 
         except Exception as error:
@@ -371,6 +388,7 @@ class Prompts:
                     name=cached.name,
                     version=cached.version,
                     label=cached.label,
+                    config=cached.config,
                 )
 
             raise

--- a/posthog/ai/prompts.py
+++ b/posthog/ai/prompts.py
@@ -4,6 +4,7 @@ Prompt management for PostHog AI SDK.
 Fetch and compile LLM prompts from PostHog with caching and fallback support.
 """
 
+import copy
 import logging
 import re
 import time
@@ -333,7 +334,9 @@ class Prompts:
                     name=cached.name,
                     version=cached.version,
                     label=cached.label,
-                    config=cached.config,
+                    # Copied so a caller mutating result.config can't pollute the
+                    # cache entry that later cache hits are served from.
+                    config=copy.deepcopy(cached.config),
                 )
 
         # Try to fetch from API
@@ -352,6 +355,8 @@ class Prompts:
                     data.get("label"),
                 )
 
+            config = _extract_config(data)
+
             # Update cache
             self._cache[cache_key] = CachedPrompt(
                 prompt=data["prompt"],
@@ -359,7 +364,7 @@ class Prompts:
                 name=data["name"],
                 version=data["version"],
                 label=data.get("label"),
-                config=_extract_config(data),
+                config=config,
             )
 
             return PromptResult(
@@ -368,7 +373,7 @@ class Prompts:
                 name=data["name"],
                 version=data["version"],
                 label=data.get("label"),
-                config=_extract_config(data),
+                config=copy.deepcopy(config),
             )
 
         except Exception as error:
@@ -388,7 +393,7 @@ class Prompts:
                     name=cached.name,
                     version=cached.version,
                     label=cached.label,
-                    config=cached.config,
+                    config=copy.deepcopy(cached.config),
                 )
 
             raise

--- a/posthog/test/ai/test_prompts.py
+++ b/posthog/test/ai/test_prompts.py
@@ -769,6 +769,75 @@ class TestPromptsGetWithMetadata(TestPrompts):
         self.assertEqual(mock_get.call_count, 1)
 
 
+class TestPromptsConfig(TestPrompts):
+    """Tests for the config object attached to prompt versions."""
+
+    mock_config = {"model": "gpt-4o", "temperature": 0.2}
+
+    @patch("posthog.ai.prompts._get_session")
+    def test_config_flows_through_api_and_cache_results(self, mock_get_session):
+        """Config from the API response must survive both the fresh fetch and a cache hit."""
+        mock_get = mock_get_session.return_value.get
+        mock_get.return_value = MockResponse(
+            json_data={**self.mock_prompt_response, "config": self.mock_config}
+        )
+
+        prompts = Prompts(self.create_mock_posthog())
+
+        api_result = prompts.get("test-prompt", with_metadata=True)
+        cached_result = prompts.get("test-prompt", with_metadata=True)
+
+        self.assertEqual(api_result.source, "api")
+        self.assertEqual(api_result.config, self.mock_config)
+        self.assertEqual(cached_result.source, "cache")
+        self.assertEqual(cached_result.config, self.mock_config)
+        self.assertEqual(mock_get.call_count, 1)
+
+    @patch("posthog.ai.prompts._get_session")
+    @patch("posthog.ai.prompts.time.time")
+    def test_stale_cache_result_keeps_config(self, mock_time, mock_get_session):
+        """A fetch failure served from stale cache must not lose the config."""
+        mock_get = mock_get_session.return_value.get
+        mock_get.side_effect = [
+            MockResponse(
+                json_data={**self.mock_prompt_response, "config": self.mock_config}
+            ),
+            Exception("Network error"),
+        ]
+        mock_time.return_value = 1000.0
+
+        prompts = Prompts(self.create_mock_posthog())
+        prompts.get("test-prompt", with_metadata=True, cache_ttl_seconds=60)
+        mock_time.return_value = 1061.0
+
+        result = prompts.get("test-prompt", with_metadata=True, cache_ttl_seconds=60)
+
+        self.assertEqual(result.source, "stale_cache")
+        self.assertEqual(result.config, self.mock_config)
+
+    @parameterized.expand(
+        [
+            ("absent", {}),
+            ("null", {"config": None}),
+            ("non_dict", {"config": "gpt-4o"}),
+        ]
+    )
+    @patch("posthog.ai.prompts._get_session")
+    def test_missing_or_invalid_config_reads_as_none(
+        self, _scenario, extra, mock_get_session
+    ):
+        """Servers that omit config or send unexpected shapes read as None."""
+        mock_get = mock_get_session.return_value.get
+        mock_get.return_value = MockResponse(
+            json_data={**self.mock_prompt_response, **extra}
+        )
+
+        prompts = Prompts(self.create_mock_posthog())
+        result = prompts.get("test-prompt", with_metadata=True)
+
+        self.assertIsNone(result.config)
+
+
 class TestPromptsGetDeprecationWarning(TestPrompts):
     """Tests for the deprecation warning when with_metadata is not passed."""
 

--- a/posthog/test/ai/test_prompts.py
+++ b/posthog/test/ai/test_prompts.py
@@ -815,6 +815,28 @@ class TestPromptsConfig(TestPrompts):
         self.assertEqual(result.source, "stale_cache")
         self.assertEqual(result.config, self.mock_config)
 
+    @patch("posthog.ai.prompts._get_session")
+    def test_mutating_a_result_config_does_not_pollute_the_cache(
+        self, mock_get_session
+    ):
+        """Callers often mutate config before spreading it into an LLM call; that must not leak into later cache hits."""
+        mock_get = mock_get_session.return_value.get
+        mock_get.return_value = MockResponse(
+            json_data={**self.mock_prompt_response, "config": self.mock_config}
+        )
+
+        prompts = Prompts(self.create_mock_posthog())
+
+        first = prompts.get("test-prompt", with_metadata=True)
+        assert first.config is not None
+        first.config["temperature"] = 0.9
+        first.config.pop("model")
+
+        second = prompts.get("test-prompt", with_metadata=True)
+
+        self.assertEqual(second.source, "cache")
+        self.assertEqual(second.config, self.mock_config)
+
     @parameterized.expand(
         [
             ("absent", {}),


### PR DESCRIPTION
## :bulb: Motivation and Context

PostHog prompt versions can now store a `config` object next to the prompt content (PostHog/posthog#74264): model parameters, tools, or any agent configuration, versioned with the prompt and returned by the fetch endpoint. The SDK parses API responses into typed objects, so without this change the field is fetched and then thrown away.

With this change:

```python
result = prompts.get("summarizer", label="production", with_metadata=True)
client.chat.completions.create(
    model=(result.config or {}).get("model", "gpt-4o"),
    temperature=(result.config or {}).get("temperature", 0),
    messages=[{"role": "system", "content": result.prompt}],
)
```

`PromptResult` gains `config` (object or `None`), `CachedPrompt` stores it so cache hits and the stale-cache fallback keep it, and servers that don't send the field (or send an unexpected shape) read as `None`. The hardcoded `fallback` string has no config, hence the defensive access in the example.

## :green_heart: How did you test it?

Five new tests in `test_prompts.py`: config surviving the API fetch and a cache hit, the stale-cache path preserving it, and a parameterized matrix for responses where config is absent, null, or a non-object (all read as `None`). Full file (67 tests) green, ruff clean.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code authored this under my direction, as the SDK follow-up to PostHog/posthog#74264. The changeset file was written manually in `.sampo/changesets/` rather than via interactive `sampo add`. Docs for the config feature land separately on posthog.com once both SDKs support it.
