### PR TITLE
fix(exceptions): restore exception hooks safely

### DIFF
--- a/.sampo/changesets/resolute-seer-ukko.md
+++ b/.sampo/changesets/resolute-seer-ukko.md
@@ -1,0 +1,5 @@
+---
+pypi/posthog: patch
+---
+
+Restore exception hooks safely

--- a/posthog/exception_capture.py
+++ b/posthog/exception_capture.py
@@ -36,8 +36,10 @@ class ExceptionCapture:
         self._closed = False
         self.original_excepthook = sys.excepthook
         self._original_threading_excepthook = threading.excepthook
-        sys.excepthook = self.exception_handler
-        threading.excepthook = self.thread_exception_handler
+        self._sys_excepthook = self.exception_handler
+        self._threading_excepthook = self.thread_exception_handler
+        sys.excepthook = self._sys_excepthook
+        threading.excepthook = self._threading_excepthook
         # opt-in client-side rate limiting: per exception type, allow a burst
         # of captures, then refill over time
         self._rate_limiter = None
@@ -53,18 +55,26 @@ class ExceptionCapture:
             return
 
         self._closed = True
-        if self._is_own_hook(sys.excepthook, "exception_handler"):
-            sys.excepthook = self._resolve_hook(
-                self.original_excepthook,
-                "exception_handler",
-                "original_excepthook",
-            )
-        if self._is_own_hook(threading.excepthook, "thread_exception_handler"):
-            threading.excepthook = self._resolve_hook(
-                self._original_threading_excepthook,
-                "thread_exception_handler",
-                "_original_threading_excepthook",
-            )
+        original_excepthook = self._resolve_hook(
+            self.original_excepthook,
+            "exception_handler",
+            "original_excepthook",
+        )
+        original_threading_excepthook = self._resolve_hook(
+            self._original_threading_excepthook,
+            "thread_exception_handler",
+            "_original_threading_excepthook",
+        )
+
+        # Keep each final ownership check and assignment together without a
+        # Python call between them. On supported GIL-enabled CPython builds,
+        # ordinary Python thread scheduling has no switch point inside either
+        # straight-line pair, minimizing the window for external hook writers.
+        if sys.excepthook is self._sys_excepthook:
+            sys.excepthook = original_excepthook
+        if threading.excepthook is self._threading_excepthook:
+            threading.excepthook = original_threading_excepthook
+
         if self._rate_limiter is not None:
             self._rate_limiter.stop()
 
@@ -87,11 +97,6 @@ class ExceptionCapture:
             "_original_threading_excepthook",
         )
         previous_hook(args)
-
-    def _is_own_hook(self, hook, handler_name):
-        return getattr(hook, "__self__", None) is self and hook == getattr(
-            self, handler_name
-        )
 
     @staticmethod
     def _resolve_hook(hook, handler_name, previous_hook_name):

--- a/posthog/exception_capture.py
+++ b/posthog/exception_capture.py
@@ -35,7 +35,7 @@ class ExceptionCapture:
         self.client = client
         self._closed = False
         self.original_excepthook = sys.excepthook
-        self.original_threading_excepthook = threading.excepthook
+        self._original_threading_excepthook = threading.excepthook
         sys.excepthook = self.exception_handler
         threading.excepthook = self.thread_exception_handler
         # opt-in client-side rate limiting: per exception type, allow a burst
@@ -61,9 +61,9 @@ class ExceptionCapture:
             )
         if self._is_own_hook(threading.excepthook, "thread_exception_handler"):
             threading.excepthook = self._resolve_hook(
-                self.original_threading_excepthook,
+                self._original_threading_excepthook,
                 "thread_exception_handler",
-                "original_threading_excepthook",
+                "_original_threading_excepthook",
             )
         if self._rate_limiter is not None:
             self._rate_limiter.stop()
@@ -82,9 +82,9 @@ class ExceptionCapture:
         if not self._closed:
             self.capture_exception((args.exc_type, args.exc_value, args.exc_traceback))
         previous_hook = self._resolve_hook(
-            self.original_threading_excepthook,
+            self._original_threading_excepthook,
             "thread_exception_handler",
-            "original_threading_excepthook",
+            "_original_threading_excepthook",
         )
         previous_hook(args)
 

--- a/posthog/exception_capture.py
+++ b/posthog/exception_capture.py
@@ -33,7 +33,9 @@ class ExceptionCapture:
         refill_interval_seconds=DEFAULT_REFILL_INTERVAL_SECONDS,
     ):
         self.client = client
+        self._closed = False
         self.original_excepthook = sys.excepthook
+        self.original_threading_excepthook = threading.excepthook
         sys.excepthook = self.exception_handler
         threading.excepthook = self.thread_exception_handler
         # opt-in client-side rate limiting: per exception type, allow a burst
@@ -47,17 +49,60 @@ class ExceptionCapture:
             )
 
     def close(self):
-        sys.excepthook = self.original_excepthook
+        if self._closed:
+            return
+
+        self._closed = True
+        if self._is_own_hook(sys.excepthook, "exception_handler"):
+            sys.excepthook = self._resolve_hook(
+                self.original_excepthook,
+                "exception_handler",
+                "original_excepthook",
+            )
+        if self._is_own_hook(threading.excepthook, "thread_exception_handler"):
+            threading.excepthook = self._resolve_hook(
+                self.original_threading_excepthook,
+                "thread_exception_handler",
+                "original_threading_excepthook",
+            )
         if self._rate_limiter is not None:
             self._rate_limiter.stop()
 
     def exception_handler(self, exc_type, exc_value, exc_traceback):
-        # don't affect default behaviour.
-        self.capture_exception((exc_type, exc_value, exc_traceback))
-        self.original_excepthook(exc_type, exc_value, exc_traceback)
+        if not self._closed:
+            self.capture_exception((exc_type, exc_value, exc_traceback))
+        previous_hook = self._resolve_hook(
+            self.original_excepthook,
+            "exception_handler",
+            "original_excepthook",
+        )
+        previous_hook(exc_type, exc_value, exc_traceback)
 
     def thread_exception_handler(self, args):
-        self.capture_exception((args.exc_type, args.exc_value, args.exc_traceback))
+        if not self._closed:
+            self.capture_exception((args.exc_type, args.exc_value, args.exc_traceback))
+        previous_hook = self._resolve_hook(
+            self.original_threading_excepthook,
+            "thread_exception_handler",
+            "original_threading_excepthook",
+        )
+        previous_hook(args)
+
+    def _is_own_hook(self, hook, handler_name):
+        return getattr(hook, "__self__", None) is self and hook == getattr(
+            self, handler_name
+        )
+
+    @staticmethod
+    def _resolve_hook(hook, handler_name, previous_hook_name):
+        """Skip closed ExceptionCapture hooks while preserving the hook chain."""
+        while True:
+            owner = getattr(hook, "__self__", None)
+            if not isinstance(owner, ExceptionCapture) or not owner._closed:
+                return hook
+            if hook != getattr(owner, handler_name):
+                return hook
+            hook = getattr(owner, previous_hook_name)
 
     def exception_receiver(self, exc_info, extra_properties):
         if "distinct_id" in extra_properties:

--- a/posthog/test/test_exception_capture.py
+++ b/posthog/test/test_exception_capture.py
@@ -1,6 +1,8 @@
 import subprocess
 import sys
+import threading
 from textwrap import dedent
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -131,6 +133,118 @@ def test_rate_limit_keys_on_outermost_of_chained_exceptions():
         assert client.capture_exception.call_count == 10
     finally:
         capture.close()
+
+
+def test_exception_hooks_delegate_and_restore_previous_hooks(monkeypatch):
+    from posthog.exception_capture import ExceptionCapture
+
+    sys_hook = MagicMock()
+    thread_hook = MagicMock()
+    monkeypatch.setattr(sys, "excepthook", sys_hook)
+    monkeypatch.setattr(threading, "excepthook", thread_hook)
+    client = MagicMock()
+    capture = ExceptionCapture(client)
+    exc_info = _exc_info(ValueError("boom"))
+    thread_args = SimpleNamespace(
+        exc_type=exc_info[0],
+        exc_value=exc_info[1],
+        exc_traceback=exc_info[2],
+        thread=threading.current_thread(),
+    )
+
+    capture.exception_handler(*exc_info)
+    capture.thread_exception_handler(thread_args)
+    capture.close()
+
+    assert client.capture_exception.call_count == 2
+    sys_hook.assert_called_once_with(*exc_info)
+    thread_hook.assert_called_once_with(thread_args)
+    assert sys.excepthook is sys_hook
+    assert threading.excepthook is thread_hook
+
+
+def test_close_does_not_overwrite_hooks_installed_later(monkeypatch):
+    from posthog.exception_capture import ExceptionCapture
+
+    monkeypatch.setattr(sys, "excepthook", MagicMock())
+    monkeypatch.setattr(threading, "excepthook", MagicMock())
+    capture = ExceptionCapture(MagicMock())
+    replacement_sys_hook = MagicMock()
+    replacement_thread_hook = MagicMock()
+    sys.excepthook = replacement_sys_hook
+    threading.excepthook = replacement_thread_hook
+
+    capture.close()
+
+    assert sys.excepthook is replacement_sys_hook
+    assert threading.excepthook is replacement_thread_hook
+
+
+def test_multiple_captures_support_out_of_order_close(monkeypatch):
+    from posthog.exception_capture import ExceptionCapture
+
+    sys_hook = MagicMock()
+    thread_hook = MagicMock()
+    monkeypatch.setattr(sys, "excepthook", sys_hook)
+    monkeypatch.setattr(threading, "excepthook", thread_hook)
+    first_client = MagicMock()
+    second_client = MagicMock()
+    first = ExceptionCapture(first_client)
+    second = ExceptionCapture(second_client)
+
+    first.close()
+    assert sys.excepthook == second.exception_handler
+    assert threading.excepthook == second.thread_exception_handler
+
+    exc_info = _exc_info(RuntimeError("boom"))
+    thread_args = SimpleNamespace(
+        exc_type=exc_info[0],
+        exc_value=exc_info[1],
+        exc_traceback=exc_info[2],
+        thread=threading.current_thread(),
+    )
+    second.exception_handler(*exc_info)
+    second.thread_exception_handler(thread_args)
+
+    assert first_client.capture_exception.call_count == 0
+    assert second_client.capture_exception.call_count == 2
+    sys_hook.assert_called_once_with(*exc_info)
+    thread_hook.assert_called_once_with(thread_args)
+
+    second.close()
+    assert sys.excepthook is sys_hook
+    assert threading.excepthook is thread_hook
+
+
+def test_uncaught_thread_exception_preserves_default_diagnostic():
+    script = dedent(
+        """
+        import threading
+        from posthog.exception_capture import ExceptionCapture
+
+        class Client:
+            def capture_exception(self, exception, distinct_id=None):
+                print(f"captured:{exception[0].__name__}")
+
+        capture = ExceptionCapture(Client())
+
+        def fail():
+            raise RuntimeError("thread failure")
+
+        thread = threading.Thread(target=fail, name="failing-thread")
+        thread.start()
+        thread.join()
+        capture.close()
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, check=True
+    )
+
+    assert "captured:RuntimeError" in result.stdout
+    assert "Exception in thread failing-thread" in result.stderr
+    assert "RuntimeError: thread failure" in result.stderr
 
 
 def test_excepthook(tmpdir):

--- a/posthog/test/test_exception_capture.py
+++ b/posthog/test/test_exception_capture.py
@@ -180,6 +180,31 @@ def test_close_does_not_overwrite_hooks_installed_later(monkeypatch):
     assert threading.excepthook is replacement_thread_hook
 
 
+def test_close_does_not_overwrite_hooks_replaced_while_resolving(monkeypatch):
+    from posthog.exception_capture import ExceptionCapture
+
+    monkeypatch.setattr(sys, "excepthook", MagicMock())
+    monkeypatch.setattr(threading, "excepthook", MagicMock())
+    capture = ExceptionCapture(MagicMock())
+    replacement_sys_hook = MagicMock()
+    replacement_thread_hook = MagicMock()
+    original_resolve_hook = capture._resolve_hook
+
+    def replace_hook_while_resolving(hook, handler_name, previous_hook_name):
+        if handler_name == "exception_handler":
+            sys.excepthook = replacement_sys_hook
+        else:
+            threading.excepthook = replacement_thread_hook
+        return original_resolve_hook(hook, handler_name, previous_hook_name)
+
+    monkeypatch.setattr(capture, "_resolve_hook", replace_hook_while_resolving)
+
+    capture.close()
+
+    assert sys.excepthook is replacement_sys_hook
+    assert threading.excepthook is replacement_thread_hook
+
+
 def test_multiple_captures_support_out_of_order_close(monkeypatch):
     from posthog.exception_capture import ExceptionCapture
 


### PR DESCRIPTION
## :bulb: Motivation and Context

`ExceptionCapture` replaced Python's process and thread exception hooks without preserving the full hook lifecycle. This could suppress the standard uncaught-thread diagnostic, overwrite hooks installed by other libraries during shutdown, or restore stale capture handlers when multiple clients closed out of order.

This change delegates to the preceding process and thread hooks, restores only hooks still owned by the closing capture, skips closed handlers in multi-client chains, and makes cleanup idempotent.

## :green_heart: How did you test it?

- `python -m pytest posthog/test/test_exception_capture.py -q` (14 passed)
- `ruff check posthog/exception_capture.py posthog/test/test_exception_capture.py`
- `ruff format --check posthog/exception_capture.py posthog/test/test_exception_capture.py`
- `git diff --check`

Regression coverage includes custom-hook delegation/restoration, later-installed hook preservation, out-of-order multi-client close, and an uncaught subprocess thread that retains Python's standard traceback diagnostic.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file

<!-- For more details check RELEASING.md -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A Pi worker implemented the targeted lifecycle fix and regression tests under human direction. Pi autoreview checked the local patch and reported no actionable findings; the human driver remains the DRI and this PR requires human review.
