### PR TITLE
fix(contexts): reset context after fork

### DIFF
--- a/.sampo/changesets/stalwart-bard-goulven.md
+++ b/.sampo/changesets/stalwart-bard-goulven.md
@@ -2,4 +2,4 @@
 pypi/posthog: patch
 ---
 
-Reset PostHog context after fork
+Reset PostHog context after fork. Forked children no longer retain the parent process's active lexical context; they start without inherited context and can establish a new child-local context.

--- a/.sampo/changesets/stalwart-bard-goulven.md
+++ b/.sampo/changesets/stalwart-bard-goulven.md
@@ -1,0 +1,5 @@
+---
+pypi/posthog: patch
+---
+
+Reset PostHog context after fork

--- a/posthog/contexts.py
+++ b/posthog/contexts.py
@@ -1,4 +1,5 @@
 import contextvars
+import os
 from contextlib import contextmanager
 from typing import Optional, Any, Callable, Dict, TypeVar, cast, TYPE_CHECKING
 
@@ -14,8 +15,10 @@ class ContextScope:
         fresh: bool = False,
         capture_exceptions: bool = True,
         client: Optional["Client"] = None,
+        generation: int = 0,
     ):
         self.client: Optional[Client] = client
+        self.generation = generation
         self.parent = parent
         self.fresh = fresh
         self.capture_exceptions = capture_exceptions
@@ -128,10 +131,28 @@ class ContextScope:
 _context_stack: contextvars.ContextVar[Optional[ContextScope]] = contextvars.ContextVar(
     "posthog_context_stack", default=None
 )
+_context_generation = 0
+
+
+def _reset_context_after_fork() -> None:
+    global _context_generation
+
+    _context_generation += 1
+    _context_stack.set(None)
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_reset_context_after_fork)
 
 
 def _get_current_context() -> Optional[ContextScope]:
-    return _context_stack.get()
+    current_context = _context_stack.get()
+    if (
+        current_context is not None
+        and current_context.generation != _context_generation
+    ):
+        return None
+    return current_context
 
 
 def _default_capture_exceptions(client: Optional["Client"] = None) -> bool:
@@ -199,13 +220,18 @@ def new_context(
     from . import capture_exception
 
     current_context = _get_current_context()
+    context_generation = _context_generation
     resolved_capture_exceptions = (
         capture_exceptions
         if capture_exceptions is not None
         else _default_capture_exceptions(client)
     )
     new_context = ContextScope(
-        current_context, fresh, resolved_capture_exceptions, client
+        current_context,
+        fresh,
+        resolved_capture_exceptions,
+        client,
+        context_generation,
     )
     _context_stack.set(new_context)
 
@@ -219,7 +245,8 @@ def new_context(
                 capture_exception(e)
         raise
     finally:
-        _context_stack.set(new_context.get_parent())
+        if context_generation == _context_generation:
+            _context_stack.set(new_context.get_parent())
 
 
 def tag(key: str, value: Any) -> None:

--- a/posthog/contexts.py
+++ b/posthog/contexts.py
@@ -8,6 +8,9 @@ if TYPE_CHECKING:
     from posthog.client import Client
 
 
+_context_generation = 0
+
+
 class ContextScope:
     def __init__(
         self,
@@ -15,10 +18,9 @@ class ContextScope:
         fresh: bool = False,
         capture_exceptions: bool = True,
         client: Optional["Client"] = None,
-        generation: int = 0,
     ):
         self.client: Optional[Client] = client
-        self.generation = generation
+        self._generation = _context_generation
         self.parent = parent
         self.fresh = fresh
         self.capture_exceptions = capture_exceptions
@@ -131,7 +133,6 @@ class ContextScope:
 _context_stack: contextvars.ContextVar[Optional[ContextScope]] = contextvars.ContextVar(
     "posthog_context_stack", default=None
 )
-_context_generation = 0
 
 
 def _reset_context_after_fork() -> None:
@@ -149,7 +150,7 @@ def _get_current_context() -> Optional[ContextScope]:
     current_context = _context_stack.get()
     if (
         current_context is not None
-        and current_context.generation != _context_generation
+        and current_context._generation != _context_generation
     ):
         return None
     return current_context
@@ -231,7 +232,6 @@ def new_context(
         fresh,
         resolved_capture_exceptions,
         client,
-        context_generation,
     )
     _context_stack.set(new_context)
 

--- a/posthog/test/test_contexts.py
+++ b/posthog/test/test_contexts.py
@@ -293,50 +293,69 @@ class TestContexts(unittest.TestCase):
             )
 
         read_fd, write_fd = os.pipe()
-        with new_context(fresh=True):
-            identify_context("parent-user")
-            set_context_session("parent-session")
-            set_context_device_id("parent-device")
-            tag("parent-tag", "parent-value")
+        pid = -1
+        child_result = b""
+        child_exit_code = 1
+        try:
+            with new_context(fresh=True):
+                identify_context("parent-user")
+                set_context_session("parent-session")
+                set_context_device_id("parent-device")
+                tag("parent-tag", "parent-value")
 
-            with new_context():
-                copied_context = contextvars.copy_context()
-                pid = os.fork()
+                with new_context():
+                    copied_context = contextvars.copy_context()
+                    pid = os.fork()
+                    if pid == 0:
+                        os.close(read_fd)
+                        with new_context():
+                            identify_context("child-user")
+                            set_context_session("child-session")
+                            set_context_device_id("child-device")
+                            tag("child-tag", "child-value")
+                            child_local_state = context_state()
+                        child_state_after_local_scope = context_state()
+                    else:
+                        os.close(write_fd)
+
                 if pid == 0:
-                    os.close(read_fd)
-                    with new_context():
-                        identify_context("child-user")
-                        set_context_session("child-session")
-                        set_context_device_id("child-device")
-                        tag("child-tag", "child-value")
-                        child_local_state = context_state()
-                    child_state_after_local_scope = context_state()
+                    child_state_after_inner_scope = context_state()
                 else:
-                    os.close(write_fd)
+                    parent_state = context_state()
 
             if pid == 0:
-                child_state_after_inner_scope = context_state()
-            else:
-                parent_state = context_state()
-
-        if pid == 0:
-            child_states = (
-                child_local_state,
-                child_state_after_local_scope,
-                child_state_after_inner_scope,
-                context_state(),
-                copied_context.run(context_state),
-            )
-            os.write(write_fd, repr(child_states).encode())
-            os.close(write_fd)
-            os._exit(0)
+                child_states = (
+                    child_local_state,
+                    child_state_after_local_scope,
+                    child_state_after_inner_scope,
+                    context_state(),
+                    copied_context.run(context_state),
+                )
+                child_result = repr(child_states).encode()
+                child_exit_code = 0
+        except BaseException as error:
+            if pid != 0:
+                raise
+            child_result = f"{type(error).__name__}: {error}".encode()
+        finally:
+            if pid == 0:
+                try:
+                    os.write(write_fd, child_result)
+                finally:
+                    try:
+                        os.close(write_fd)
+                    finally:
+                        os._exit(child_exit_code)
 
         child_states = os.read(read_fd, 4096)
         os.close(read_fd)
         _, status = os.waitpid(pid, 0)
 
         empty_state = (None, None, None, {})
-        self.assertTrue(os.WIFEXITED(status) and os.WEXITSTATUS(status) == 0)
+        self.assertTrue(
+            os.WIFEXITED(status) and os.WEXITSTATUS(status) == 0,
+            child_states.decode(errors="replace"),
+        )
         child_local_state = (
             "child-user",
             "child-session",

--- a/posthog/test/test_contexts.py
+++ b/posthog/test/test_contexts.py
@@ -1,4 +1,6 @@
 import asyncio
+import contextvars
+import os
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -11,8 +13,10 @@ from posthog.contexts import (
     tag,
     identify_context,
     set_context_session,
+    set_context_device_id,
     get_context_session_id,
     get_context_distinct_id,
+    get_context_device_id,
 )
 
 
@@ -274,6 +278,68 @@ class TestContexts(unittest.TestCase):
             # Original context should still have original values
             assert get_context_distinct_id() == "user123"
             assert get_context_session_id() == "session456"
+
+    @unittest.skipUnless(
+        hasattr(os, "fork") and hasattr(os, "register_at_fork"),
+        "requires os.fork and os.register_at_fork",
+    )
+    def test_fork_clears_context_in_child_and_preserves_parent(self):
+        def context_state():
+            return (
+                get_context_distinct_id(),
+                get_context_session_id(),
+                get_context_device_id(),
+                get_tags(),
+            )
+
+        read_fd, write_fd = os.pipe()
+        with new_context(fresh=True):
+            identify_context("parent-user")
+            set_context_session("parent-session")
+            set_context_device_id("parent-device")
+            tag("parent-tag", "parent-value")
+
+            with new_context():
+                copied_context = contextvars.copy_context()
+                pid = os.fork()
+                if pid == 0:
+                    os.close(read_fd)
+                else:
+                    os.close(write_fd)
+
+            if pid == 0:
+                child_state_after_inner_scope = context_state()
+            else:
+                parent_state = context_state()
+
+        if pid == 0:
+            child_states = (
+                child_state_after_inner_scope,
+                context_state(),
+                copied_context.run(context_state),
+            )
+            os.write(write_fd, repr(child_states).encode())
+            os.close(write_fd)
+            os._exit(0)
+
+        child_states = os.read(read_fd, 4096)
+        os.close(read_fd)
+        _, status = os.waitpid(pid, 0)
+
+        empty_state = (None, None, None, {})
+        self.assertTrue(os.WIFEXITED(status) and os.WEXITSTATUS(status) == 0)
+        self.assertEqual(
+            child_states, repr((empty_state, empty_state, empty_state)).encode()
+        )
+        self.assertEqual(
+            parent_state,
+            (
+                "parent-user",
+                "parent-session",
+                "parent-device",
+                {"parent-tag": "parent-value"},
+            ),
+        )
 
     def test_child_tags_override_parent_tags_in_non_fresh_context(self):
         with new_context(fresh=True):

--- a/posthog/test/test_contexts.py
+++ b/posthog/test/test_contexts.py
@@ -304,6 +304,13 @@ class TestContexts(unittest.TestCase):
                 pid = os.fork()
                 if pid == 0:
                     os.close(read_fd)
+                    with new_context():
+                        identify_context("child-user")
+                        set_context_session("child-session")
+                        set_context_device_id("child-device")
+                        tag("child-tag", "child-value")
+                        child_local_state = context_state()
+                    child_state_after_local_scope = context_state()
                 else:
                     os.close(write_fd)
 
@@ -314,6 +321,8 @@ class TestContexts(unittest.TestCase):
 
         if pid == 0:
             child_states = (
+                child_local_state,
+                child_state_after_local_scope,
                 child_state_after_inner_scope,
                 context_state(),
                 copied_context.run(context_state),
@@ -328,8 +337,23 @@ class TestContexts(unittest.TestCase):
 
         empty_state = (None, None, None, {})
         self.assertTrue(os.WIFEXITED(status) and os.WEXITSTATUS(status) == 0)
+        child_local_state = (
+            "child-user",
+            "child-session",
+            "child-device",
+            {"child-tag": "child-value"},
+        )
         self.assertEqual(
-            child_states, repr((empty_state, empty_state, empty_state)).encode()
+            child_states,
+            repr(
+                (
+                    child_local_state,
+                    empty_state,
+                    empty_state,
+                    empty_state,
+                    empty_state,
+                )
+            ).encode(),
         )
         self.assertEqual(
             parent_state,

--- a/references/public_api_snapshot.txt
+++ b/references/public_api_snapshot.txt
@@ -612,6 +612,7 @@ attribute posthog.contexts.ContextScope.code_variables_mask_url_credentials: Opt
 attribute posthog.contexts.ContextScope.device_id: Optional[str] = None
 attribute posthog.contexts.ContextScope.distinct_id: Optional[str] = None
 attribute posthog.contexts.ContextScope.fresh = fresh
+attribute posthog.contexts.ContextScope.generation = generation
 attribute posthog.contexts.ContextScope.parent = parent
 attribute posthog.contexts.ContextScope.session_id: Optional[str] = None
 attribute posthog.contexts.ContextScope.tags: Dict[str, Any] = {}
@@ -910,7 +911,7 @@ class posthog.capture_mode.CaptureMode
 class posthog.capture_v1.CaptureV1Error(status: int | str, message: str, *, retry_after: Optional[float] = None, request_id: Optional[str] = None, attempts: Optional[int] = None, retry_exhausted: Optional[list[str]] = None, drops: Optional[list[tuple[str, Optional[str]]]] = None)
 class posthog.client.Client(project_api_key: str, host=None, debug=False, max_queue_size=10000, send=True, on_error=None, flush_at=100, flush_interval=5.0, gzip=False, max_retries=3, sync_mode=False, timeout=15, thread=1, poll_interval=30, personal_api_key=None, disabled=False, disable_geoip=True, is_server=True, historical_migration=False, feature_flags_request_timeout_seconds=3, feature_flags_request_max_retries=1, super_properties=None, enable_exception_autocapture=False, log_captured_exceptions=False, project_root=None, privacy_mode=False, before_send=None, flag_fallback_cache_url=None, enable_local_evaluation=True, flag_definition_cache_provider: Optional[FlagDefinitionCacheProvider] = None, capture_exception_code_variables=False, code_variables_mask_patterns=None, code_variables_ignore_patterns=None, code_variables_mask_url_credentials=None, code_variables_detect_secrets=None, in_app_modules: list[str] | None = None, enable_exception_autocapture_rate_limiting=False, exception_autocapture_bucket_size=ExceptionCapture.DEFAULT_BUCKET_SIZE, exception_autocapture_refill_rate=ExceptionCapture.DEFAULT_REFILL_RATE, exception_autocapture_refill_interval_seconds=ExceptionCapture.DEFAULT_REFILL_INTERVAL_SECONDS, capture_mode: Optional[Union[CaptureMode, str]] = None, capture_compression: Optional[Union[CaptureCompression, str]] = None, secret_key=None, metrics: Optional[dict] = None, _use_ai_lane=False, _enable_multimodal_capture=False)
 class posthog.consumer.Consumer(queue, api_key, flush_at=100, host=None, on_error=None, flush_interval=5.0, gzip=False, retries=10, timeout=15, historical_migration=False, endpoint=EVENTS_ENDPOINT, max_msg_size=MAX_MSG_SIZE, capture_mode=CaptureMode.V0, capture_compression=CaptureCompression.NONE)
-class posthog.contexts.ContextScope(parent=None, fresh: bool = False, capture_exceptions: bool = True, client: Optional[Client] = None)
+class posthog.contexts.ContextScope(parent=None, fresh: bool = False, capture_exceptions: bool = True, client: Optional[Client] = None, generation: int = 0)
 class posthog.exception_capture.ExceptionCapture(client: Client, rate_limiting_enabled=False, bucket_size=DEFAULT_BUCKET_SIZE, refill_rate=DEFAULT_REFILL_RATE, refill_interval_seconds=DEFAULT_REFILL_INTERVAL_SECONDS)
 class posthog.exception_utils.AnnotatedValue(value, metadata)
 class posthog.exception_utils.VariableSizeLimiter(max_size=DEFAULT_TOTAL_VARIABLES_SIZE_LIMIT)

--- a/references/public_api_snapshot.txt
+++ b/references/public_api_snapshot.txt
@@ -612,7 +612,6 @@ attribute posthog.contexts.ContextScope.code_variables_mask_url_credentials: Opt
 attribute posthog.contexts.ContextScope.device_id: Optional[str] = None
 attribute posthog.contexts.ContextScope.distinct_id: Optional[str] = None
 attribute posthog.contexts.ContextScope.fresh = fresh
-attribute posthog.contexts.ContextScope.generation = generation
 attribute posthog.contexts.ContextScope.parent = parent
 attribute posthog.contexts.ContextScope.session_id: Optional[str] = None
 attribute posthog.contexts.ContextScope.tags: Dict[str, Any] = {}
@@ -911,7 +910,7 @@ class posthog.capture_mode.CaptureMode
 class posthog.capture_v1.CaptureV1Error(status: int | str, message: str, *, retry_after: Optional[float] = None, request_id: Optional[str] = None, attempts: Optional[int] = None, retry_exhausted: Optional[list[str]] = None, drops: Optional[list[tuple[str, Optional[str]]]] = None)
 class posthog.client.Client(project_api_key: str, host=None, debug=False, max_queue_size=10000, send=True, on_error=None, flush_at=100, flush_interval=5.0, gzip=False, max_retries=3, sync_mode=False, timeout=15, thread=1, poll_interval=30, personal_api_key=None, disabled=False, disable_geoip=True, is_server=True, historical_migration=False, feature_flags_request_timeout_seconds=3, feature_flags_request_max_retries=1, super_properties=None, enable_exception_autocapture=False, log_captured_exceptions=False, project_root=None, privacy_mode=False, before_send=None, flag_fallback_cache_url=None, enable_local_evaluation=True, flag_definition_cache_provider: Optional[FlagDefinitionCacheProvider] = None, capture_exception_code_variables=False, code_variables_mask_patterns=None, code_variables_ignore_patterns=None, code_variables_mask_url_credentials=None, code_variables_detect_secrets=None, in_app_modules: list[str] | None = None, enable_exception_autocapture_rate_limiting=False, exception_autocapture_bucket_size=ExceptionCapture.DEFAULT_BUCKET_SIZE, exception_autocapture_refill_rate=ExceptionCapture.DEFAULT_REFILL_RATE, exception_autocapture_refill_interval_seconds=ExceptionCapture.DEFAULT_REFILL_INTERVAL_SECONDS, capture_mode: Optional[Union[CaptureMode, str]] = None, capture_compression: Optional[Union[CaptureCompression, str]] = None, secret_key=None, metrics: Optional[dict] = None, _use_ai_lane=False, _enable_multimodal_capture=False)
 class posthog.consumer.Consumer(queue, api_key, flush_at=100, host=None, on_error=None, flush_interval=5.0, gzip=False, retries=10, timeout=15, historical_migration=False, endpoint=EVENTS_ENDPOINT, max_msg_size=MAX_MSG_SIZE, capture_mode=CaptureMode.V0, capture_compression=CaptureCompression.NONE)
-class posthog.contexts.ContextScope(parent=None, fresh: bool = False, capture_exceptions: bool = True, client: Optional[Client] = None, generation: int = 0)
+class posthog.contexts.ContextScope(parent=None, fresh: bool = False, capture_exceptions: bool = True, client: Optional[Client] = None)
 class posthog.exception_capture.ExceptionCapture(client: Client, rate_limiting_enabled=False, bucket_size=DEFAULT_BUCKET_SIZE, refill_rate=DEFAULT_REFILL_RATE, refill_interval_seconds=DEFAULT_REFILL_INTERVAL_SECONDS)
 class posthog.exception_utils.AnnotatedValue(value, metadata)
 class posthog.exception_utils.VariableSizeLimiter(max_size=DEFAULT_TOTAL_VARIABLES_SIZE_LIMIT)


### PR DESCRIPTION
## :bulb: Motivation and Context

PostHog context stored in `contextvars` is inherited when a process forks. This can leak a parent's distinct ID, session ID, device ID, and tags into child processes.

Reset the active context in forked children while preserving the parent's context.

## :green_heart: How did you test it?

- `/Users/marandaneto/Github/posthog-python/.venv/bin/python -m pytest -q posthog/test/test_contexts.py`
- `/Users/marandaneto/Github/posthog-python/.venv/bin/ruff format --check posthog/contexts.py posthog/test/test_contexts.py`
- `/Users/marandaneto/Github/posthog-python/.venv/bin/ruff check posthog/contexts.py posthog/test/test_contexts.py`
- `git diff --check`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi implemented the targeted fix under human direction. The autoreview report was used to confirm formatting, lint, compilation, and the absence of staged changes before submission. The implementation uses an `os.register_at_fork` child hook plus a generation marker so inherited and copied contexts remain invalid after a fork, including when inherited context managers unwind in the child.
