### PR TITLE
fix(celery): respect task filters for exceptions

### DIFF
--- a/.sampo/changesets/cantankerous-stormcaller-vainamoinen.md
+++ b/.sampo/changesets/cantankerous-stormcaller-vainamoinen.md
@@ -1,0 +1,5 @@
+---
+pypi/posthog: patch
+---
+
+Respect Celery task filters for exception capture

--- a/posthog/integrations/celery.py
+++ b/posthog/integrations/celery.py
@@ -365,13 +365,18 @@ class PosthogCeleryIntegration:
             if exception:
                 task_properties["error_type"] = type(exception).__name__
                 task_properties["error_message"] = str(exception)
-                if self.capture_exceptions:
-                    self._capture_exception(exception)
 
             task_name = task_properties.get("celery_task_name")
-            if self.capture_task_lifecycle_events and self._should_track(
-                task_name, task_properties
+            should_track = False
+            if self.capture_task_lifecycle_events or (
+                exception and self.capture_exceptions
             ):
+                should_track = self._should_track(task_name, task_properties)
+
+            if exception and self.capture_exceptions and should_track:
+                self._capture_exception(exception)
+
+            if self.capture_task_lifecycle_events and should_track:
                 self._capture_event(f"celery task {state}", properties=task_properties)
         except Exception:
             logger.exception("Failed to process Celery %s state", state)

--- a/posthog/test/integrations/test_celery_integration.py
+++ b/posthog/test/integrations/test_celery_integration.py
@@ -509,6 +509,55 @@ class TestPosthogCeleryIntegration(unittest.TestCase):
 
         mock_client.capture.assert_not_called()
 
+    def test_task_filter_applies_to_failure_exception_and_lifecycle_event(self):
+        mock_client = Mock()
+        task_filter = Mock(return_value=False)
+        integration = PosthogCeleryIntegration(
+            client=mock_client,
+            task_filter=task_filter,
+        )
+        request = SimpleNamespace(headers={}, delivery_info={})
+        task = SimpleNamespace(name="app.tasks.filtered_failure", request=request)
+        exception = ValueError("task failed")
+        context_before = contexts._get_current_context()
+
+        integration._on_task_prerun(sender=task, task_id="task-filtered-failure")
+        task_filter.reset_mock()
+        integration._on_task_failure(
+            sender=task,
+            task_id="task-filtered-failure",
+            exception=exception,
+        )
+
+        task_filter.assert_called_once()
+        mock_client.capture.assert_not_called()
+        mock_client.capture_exception.assert_not_called()
+        self.assertIs(contexts._get_current_context(), context_before)
+
+    def test_task_filter_applies_to_retry_lifecycle_event(self):
+        mock_client = Mock()
+        task_filter = Mock(return_value=False)
+        integration = PosthogCeleryIntegration(
+            client=mock_client,
+            task_filter=task_filter,
+        )
+        request = SimpleNamespace(headers={}, delivery_info={})
+        task = SimpleNamespace(name="app.tasks.filtered_retry", request=request)
+        context_before = contexts._get_current_context()
+
+        integration._on_task_prerun(sender=task, task_id="task-filtered-retry")
+        task_filter.reset_mock()
+        integration._on_task_retry(
+            sender=task,
+            task_id="task-filtered-retry",
+            reason=ConnectionError("broker down"),
+        )
+
+        task_filter.assert_called_once()
+        mock_client.capture.assert_not_called()
+        mock_client.capture_exception.assert_not_called()
+        self.assertIs(contexts._get_current_context(), context_before)
+
     def test_task_failure_captures_exception_when_lifecycle_events_disabled(self):
         mock_client = Mock()
         integration = PosthogCeleryIntegration(


### PR DESCRIPTION
## :bulb: Motivation and Context

Celery `task_filter` decisions applied to task lifecycle events but not to exception capture, so filtered task failures could still emit exception events. This makes the filter consistently suppress both terminal lifecycle and exception capture.

## :green_heart: How did you test it?

- `python -m pytest posthog/test/integrations/test_celery_integration.py -q` (32 passed)
- `ruff check posthog/integrations/celery.py posthog/test/integrations/test_celery_integration.py`
- `ruff format --check posthog/integrations/celery.py posthog/test/integrations/test_celery_integration.py`
- `git diff --check`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A Pi worker implemented the human-directed scoped fix and regression tests. Pi autoreview reviewed the local diff and reported no actionable findings; the worker kept one filter evaluation per terminal signal and preserved context cleanup.
