### PR TITLE
fix(capture): handle malformed before_send results

### DIFF
--- a/.sampo/changesets/valorous-witch-ukko.md
+++ b/.sampo/changesets/valorous-witch-ukko.md
@@ -1,0 +1,5 @@
+---
+pypi/posthog: patch
+---
+
+Keep consumers alive after malformed before_send results

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -1946,7 +1946,9 @@ class Client(object):
                 if modified_msg is None:
                     self.log.debug("Event dropped by before_send callback")
                     return None
-                msg = modified_msg
+                if not isinstance(modified_msg, dict):
+                    raise TypeError("before_send must return a dict or None")
+                msg = clean(modified_msg)
             except Exception as e:
                 self.log.exception(f"Error in before_send callback: {e}")
                 # Continue with the original message if callback fails

--- a/posthog/consumer.py
+++ b/posthog/consumer.py
@@ -132,7 +132,16 @@ class Consumer(Thread):
                 break
             try:
                 item = queue.get(block=True, timeout=self.flush_interval - elapsed)
-                item_size = len(json.dumps(item, cls=DatetimeSerializer).encode())
+                try:
+                    item_size = len(json.dumps(item, cls=DatetimeSerializer).encode())
+                except Exception:
+                    # Callback-modified events can still contain invalid mapping
+                    # keys or circular references. Never log the payload here.
+                    self.log.error(
+                        "Unable to serialize queued event for sizing, dropping."
+                    )
+                    queue.task_done()
+                    continue
                 if item_size > self.max_msg_size:
                     # Log only name and size: AI events may carry unredacted
                     # multimodal payloads that must not leak into logs.

--- a/posthog/test/test_before_send.py
+++ b/posthog/test/test_before_send.py
@@ -121,6 +121,70 @@ class TestClient(unittest.TestCase):
             enqueued_msg = batch_data[0]
             self.assertEqual(enqueued_msg["event"], "robust_event")
 
+    def test_before_send_callback_output_is_recleaned(self):
+        marker = object()
+
+        def add_unsupported_value(event):
+            event["properties"]["marker"] = marker
+            return event
+
+        with mock.patch("posthog.client.batch_post") as mock_post:
+            client = Client(
+                FAKE_TEST_API_KEY,
+                before_send=add_unsupported_value,
+                sync_mode=True,
+            )
+            self.assertIsNotNone(client.capture("recleaned", distinct_id="user1"))
+
+        sent_event = mock_post.call_args.kwargs["batch"][0]
+        self.assertIsNone(sent_event["properties"]["marker"])
+
+    def test_before_send_callback_non_dict_output_uses_original_event(self):
+        with (
+            mock.patch("posthog.client.batch_post") as mock_post,
+            mock.patch("posthog.client.Client.log.exception") as mock_log,
+        ):
+            client = Client(
+                FAKE_TEST_API_KEY,
+                before_send=lambda _event: "invalid",
+                sync_mode=True,
+            )
+            self.assertIsNotNone(client.capture("original", distinct_id="user1"))
+
+        sent_event = mock_post.call_args.kwargs["batch"][0]
+        self.assertEqual(sent_event["event"], "original")
+        self.assertIn(
+            "before_send must return a dict or None", mock_log.call_args.args[0]
+        )
+
+    def test_malformed_before_send_event_does_not_stop_consumer_or_shutdown(self):
+        def add_invalid_mapping_key(event):
+            if event["event"] == "malformed":
+                event["properties"][("private-key",)] = "private-value"
+            return event
+
+        client = Client(
+            FAKE_TEST_API_KEY,
+            before_send=add_invalid_mapping_key,
+            flush_at=1,
+            flush_interval=0.01,
+        )
+        with (
+            mock.patch("posthog.consumer.batch_post") as mock_post,
+            self.assertLogs("posthog", level="ERROR") as logs,
+        ):
+            client.capture("malformed", distinct_id="user1")
+            client.capture("valid", distinct_id="user1")
+            client.shutdown()
+
+        mock_post.assert_called_once()
+        sent_batch = mock_post.call_args.kwargs["batch"]
+        self.assertEqual([event["event"] for event in sent_batch], ["valid"])
+        self.assertEqual(client.queue.unfinished_tasks, 0)
+        self.assertTrue(all(not consumer.is_alive() for consumer in client.consumers))
+        self.assertNotIn("private-key", "\n".join(logs.output))
+        self.assertNotIn("private-value", "\n".join(logs.output))
+
     def test_before_send_callback_works_with_all_event_types(self):
         """Test that before_send works with capture, set, etc."""
 


### PR DESCRIPTION
## :bulb: Motivation and Context

A malformed value returned by `before_send` can make queued-event sizing raise in the background consumer. That exception can stop the consumer before acknowledging the queue item, preventing later valid events from being delivered and causing shutdown to hang.

This change validates and re-cleans callback results before enqueueing. If an event still cannot be serialized for sizing, the consumer safely drops and acknowledges only that event without logging its payload, then continues processing the queue.

## :green_heart: How did you test it?

- `python -m pytest -q posthog/test/test_before_send.py posthog/test/test_consumer.py` (37 passed)
- `ruff format --check posthog/client.py posthog/consumer.py posthog/test/test_before_send.py`
- `ruff check posthog/client.py posthog/consumer.py posthog/test/test_before_send.py`
- `python -W error -c "import posthog"`
- `git diff --check`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file

<!-- For more details check RELEASING.md -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A human directed the fix and remains the DRI. A Pi worker implemented the targeted changes and tests; Pi autoreview checked the resulting patch and reported no actionable findings. The implementation preserves the original-event fallback for callback errors while ensuring malformed queued items cannot terminate the consumer or leak payload contents into logs.
