### PR TITLE
fix(client): reset registry lock after fork

### DIFF
--- a/.sampo/changesets/resolute-bard-goulven.md
+++ b/.sampo/changesets/resolute-bard-goulven.md
@@ -1,0 +1,5 @@
+---
+pypi/posthog: patch
+---
+
+Reset the client registry lock after fork

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -433,6 +433,7 @@ class Client(object):
 
     log = logging.getLogger("posthog")
     _client_registry_lock = threading.Lock()
+    _client_registry_pid = os.getpid()
     _client_registry: dict[tuple[str, str], weakref.WeakSet] = {}
     _duplicate_client_warnings: set[tuple[str, str]] = set()
 
@@ -1826,12 +1827,26 @@ class Client(object):
             self.log.exception(f"Failed to capture exception: {e}")
             return None
 
+    @classmethod
+    def _reinit_client_registry_after_fork(cls):
+        """Replace the inherited registry lock once in each forked child."""
+        child_pid = os.getpid()
+        if cls._client_registry_pid == child_pid:
+            return
+
+        # The lock may have been held by a parent thread at fork time. Replace it
+        # without acquiring it, while preserving inherited active-client records.
+        cls._client_registry_lock = threading.Lock()
+        cls._client_registry_pid = child_pid
+
     @staticmethod
     def _reinit_after_fork_weak(weak_self):
         """
         Reinitialize the client after a fork.
         Garbage collected if the client is deleted.
         """
+        Client._reinit_client_registry_after_fork()
+
         self = weak_self()
         if self is None:
             return

--- a/posthog/test/test_client_fork.py
+++ b/posthog/test/test_client_fork.py
@@ -238,6 +238,59 @@ class TestClientForkEndToEnd(unittest.TestCase):
         )
         self.assertEqual(result, "ok")
 
+    def test_register_at_fork_replaces_duplicate_registry_lock_in_child_process(self):
+        Client._client_registry.clear()
+        Client._duplicate_client_warnings.clear()
+        host = "https://fork-registry.example.com"
+        registry_key = (FAKE_TEST_API_KEY, host)
+
+        with mock.patch("posthog.client.Consumer.start"):
+            inherited_client = Client(FAKE_TEST_API_KEY, host=host)
+            inherited_lock = Client._client_registry_lock
+
+            def child_probe():
+                # A deadlocked child gets killed by SIGALRM instead of hanging the
+                # test when constructing or unregistering a client.
+                signal.alarm(5)
+                try:
+                    if Client._client_registry_lock is inherited_lock:
+                        return "registry lock was not replaced"
+
+                    child_client = Client(FAKE_TEST_API_KEY, host=host)
+                    clients = Client._client_registry.get(registry_key)
+                    if clients is None or set(clients) != {
+                        inherited_client,
+                        child_client,
+                    }:
+                        return "child client was not registered"
+
+                    child_client.shutdown()
+                    clients = Client._client_registry.get(registry_key)
+                    if clients is None or set(clients) != {inherited_client}:
+                        return "child client was not unregistered"
+
+                    inherited_client.shutdown()
+                    if registry_key in Client._client_registry:
+                        return "inherited client was not unregistered"
+                finally:
+                    signal.alarm(0)
+
+                return "ok"
+
+            inherited_lock.acquire()
+            try:
+                status, result = self._run_fork_probe(child_probe)
+            finally:
+                inherited_lock.release()
+                inherited_client.shutdown()
+                Client._client_registry.clear()
+                Client._duplicate_client_warnings.clear()
+
+        self.assertTrue(
+            os.WIFEXITED(status) and os.WEXITSTATUS(status) == 0, msg=result
+        )
+        self.assertEqual(result, "ok")
+
     def test_register_at_fork_replaces_metrics_locks_in_child_process(self):
         # Locks held at fork time are inherited locked, and their holders don't
         # exist in the child — the metrics path must not deadlock on them.


### PR DESCRIPTION
## :bulb: Motivation and Context

When a multithreaded process forks while the duplicate-client registry lock is held, the child inherits a permanently locked mutex whose owning thread no longer exists. Constructing or shutting down a client in the child can then deadlock.

This change detects a fork by PID and replaces the inherited registry lock once in each child while preserving inherited client bookkeeping.

## :green_heart: How did you test it?

- `/Users/marandaneto/Github/posthog-python/.venv/bin/python -m pytest posthog/test/test_client_fork.py posthog/test/test_client.py -q` (161 passed)
- `/Users/marandaneto/Github/posthog-python/.venv/bin/ruff check posthog/client.py posthog/test/test_client_fork.py`
- `/Users/marandaneto/Github/posthog-python/.venv/bin/ruff format --check posthog/client.py posthog/test/test_client_fork.py`
- `git diff --check`
- The new real-fork regression test holds the parent registry lock across `fork()`, verifies the child receives a replacement lock, and exercises child client registration and shutdown under a deadlock timeout.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A human directed the fix and PR workflow. A Pi worker implemented and validated the targeted fork-safety change; Pi autoreview checked the patch and reported no actionable findings or blockers. The implementation preserves the inherited registry records and only replaces the lock once per child PID.
