### PR TITLE
fix(flags): honor false payload overrides

### DIFF
--- a/.sampo/changesets/gallant-wavetamer-nyyrikki.md
+++ b/.sampo/changesets/gallant-wavetamer-nyyrikki.md
@@ -1,0 +1,5 @@
+---
+pypi/posthog: patch
+---
+
+Honor false feature flag payload overrides

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -2578,10 +2578,15 @@ class Client(object):
                 key, lookup_match_value, payload
             )
 
-            # Cache successful local evaluation
-            if self.flag_cache and flag_result:
+            # Cache the local evaluation, not a payload lookup override.
+            cached_flag_result = flag_result
+            if override_match_value is not None:
+                cached_flag_result = FeatureFlagResult.from_value_and_payload(
+                    key, flag_value, self._compute_payload_locally(key, flag_value)
+                )
+            if self.flag_cache and cached_flag_result:
                 self.flag_cache.set_cached_flag(
-                    distinct_id, key, flag_result, self.flag_definition_version
+                    distinct_id, key, cached_flag_result, self.flag_definition_version
                 )
         elif only_evaluate_locally:
             if self.feature_flags is None:

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -2566,7 +2566,9 @@ class Client(object):
         flag_was_locally_evaluated = flag_value is not None
 
         if flag_was_locally_evaluated:
-            lookup_match_value = override_match_value or flag_value
+            lookup_match_value = (
+                override_match_value if override_match_value is not None else flag_value
+            )
             payload = (
                 self._compute_payload_locally(key, lookup_match_value)
                 if lookup_match_value is not None
@@ -3131,11 +3133,11 @@ class Client(object):
         if flag_definition:
             flag_filters = flag_definition.get("filters") or {}
             flag_payloads = flag_filters.get("payloads") or {}
-            # For boolean flags, convert True to "true"
+            # For boolean flags, use lowercase keys ("true" or "false")
             # For multivariate flags, use the variant string as-is
             lookup_value = (
-                "true"
-                if isinstance(match_value, bool) and match_value
+                str(match_value).lower()
+                if isinstance(match_value, bool)
                 else str(match_value)
             )
             payload = flag_payloads.get(lookup_value, None)

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -2565,7 +2565,7 @@ class Client(object):
         )
         flag_was_locally_evaluated = flag_value is not None
 
-        if flag_was_locally_evaluated:
+        if flag_value is not None:
             lookup_match_value = (
                 override_match_value if override_match_value is not None else flag_value
             )

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -19,6 +19,7 @@ from posthog.feature_flags import (
 )
 from posthog.request import APIError, GetResponse
 from posthog.test.test_utils import FAKE_TEST_API_KEY
+from posthog.utils import FlagCache
 
 
 # This module preserves the legacy single-flag API's compatibility behavior;
@@ -3779,6 +3780,7 @@ class TestLocalEvaluation(unittest.TestCase):
             },
         }
         self.client.feature_flags = [basic_flag]
+        self.client.flag_cache = FlagCache()
 
         self.assertEqual(
             self.client.get_feature_flag_payload(
@@ -3807,6 +3809,13 @@ class TestLocalEvaluation(unittest.TestCase):
             ),
             400,
         )
+
+        cached_result = self.client.flag_cache.get_stale_cached_flag(
+            "some-distinct-id", "person-flag"
+        )
+        assert cached_result is not None
+        self.assertIs(cached_result.get_value(), True)
+        self.assertEqual(cached_result.payload, 300)
 
         # Locally evaluated false values use the lowercase "false" payload key.
         self.assertEqual(

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -3775,7 +3775,7 @@ class TestLocalEvaluation(unittest.TestCase):
                         "rollout_percentage": 100,
                     }
                 ],
-                "payloads": {"true": 300},
+                "payloads": {"true": 300, "false": 400},
             },
         }
         self.client.feature_flags = [basic_flag]
@@ -3795,6 +3795,27 @@ class TestLocalEvaluation(unittest.TestCase):
                 person_properties={"region": "USA"},
             ),
             300,
+        )
+
+        # A false override must take precedence over a locally evaluated true value.
+        self.assertEqual(
+            self.client.get_feature_flag_payload(
+                "person-flag",
+                "some-distinct-id",
+                match_value=False,
+                person_properties={"region": "USA"},
+            ),
+            400,
+        )
+
+        # Locally evaluated false values use the lowercase "false" payload key.
+        self.assertEqual(
+            self.client.get_feature_flag_payload(
+                "person-flag",
+                "some-distinct-id",
+                person_properties={"region": "Canada"},
+            ),
+            400,
         )
         self.assertEqual(patch_flags.call_count, 0)
 


### PR DESCRIPTION
## :bulb: Motivation and Context

Feature flag payload lookup treated an explicit `False` match override as absent and fell back to a locally evaluated truthy value. Locally evaluated false boolean values were also converted to `"False"`, which could not match the lowercase `"false"` payload key.

This change preserves explicit false overrides and normalizes both boolean payload lookup keys to lowercase. It adds regression coverage for false overrides and locally evaluated false values.

## :green_heart: How did you test it?

- `uv run --extra test pytest -q posthog/test/test_feature_flags.py::TestLocalEvaluation` (91 passed)
- `uv run ruff check posthog/client.py posthog/test/test_feature_flags.py`
- `uv run ruff format --check posthog/client.py posthog/test/test_feature_flags.py`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog. (A patch changeset is included.)

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The human-directed autoreview workflow used Pi to implement and validate the targeted fix. The chosen change distinguishes an explicit false override from an absent override and uses lowercase boolean payload keys, with focused regression tests; no broader feature flag behavior was changed.

This PR requires human review and will not be self-merged or auto-approved.
