### PR TITLE
fix(capture): cap v0 retry delays

### DIFF
--- a/.sampo/changesets/majestic-iceseeker-vainamoinen.md
+++ b/.sampo/changesets/majestic-iceseeker-vainamoinen.md
@@ -1,0 +1,5 @@
+---
+pypi/posthog: patch
+---
+
+Cap capture v0 Retry-After delays

--- a/posthog/consumer.py
+++ b/posthog/consumer.py
@@ -7,7 +7,7 @@ from threading import Thread
 from posthog._logging import _configure_posthog_logging
 from posthog.capture_compression import CaptureCompression
 from posthog.capture_mode import CaptureMode
-from posthog.capture_v1 import _send_v1_batch
+from posthog.capture_v1 import _MAX_BACKOFF_SECONDS, _send_v1_batch
 from posthog.request import (
     EVENTS_ENDPOINT,
     APIError,
@@ -209,12 +209,14 @@ class Consumer(Thread):
                 if not is_retryable(e):
                     raise
                 if attempt < self.retries:
-                    # Respect Retry-After header if present, otherwise use exponential backoff
+                    configured_backoff = min(2**attempt, _MAX_BACKOFF_SECONDS)
                     retry_after = getattr(e, "retry_after", None)
-                    if retry_after and retry_after > 0:
-                        time.sleep(retry_after)
-                    else:
-                        time.sleep(min(2**attempt, 30))
+                    clamped_retry_after = (
+                        min(retry_after, _MAX_BACKOFF_SECONDS)
+                        if retry_after and retry_after > 0
+                        else 0
+                    )
+                    time.sleep(max(configured_backoff, clamped_retry_after))
 
         if last_exc:
             raise last_exc

--- a/posthog/consumer.py
+++ b/posthog/consumer.py
@@ -7,7 +7,7 @@ from threading import Thread
 from posthog._logging import _configure_posthog_logging
 from posthog.capture_compression import CaptureCompression
 from posthog.capture_mode import CaptureMode
-from posthog.capture_v1 import _MAX_BACKOFF_SECONDS, _send_v1_batch
+from posthog.capture_v1 import _backoff, _send_v1_batch
 from posthog.request import (
     EVENTS_ENDPOINT,
     APIError,
@@ -209,14 +209,7 @@ class Consumer(Thread):
                 if not is_retryable(e):
                     raise
                 if attempt < self.retries:
-                    configured_backoff = min(2**attempt, _MAX_BACKOFF_SECONDS)
-                    retry_after = getattr(e, "retry_after", None)
-                    clamped_retry_after = (
-                        min(retry_after, _MAX_BACKOFF_SECONDS)
-                        if retry_after and retry_after > 0
-                        else 0
-                    )
-                    time.sleep(max(configured_backoff, clamped_retry_after))
+                    _backoff(attempt, getattr(e, "retry_after", None))
 
         if last_exc:
             raise last_exc

--- a/posthog/test/test_consumer.py
+++ b/posthog/test/test_consumer.py
@@ -1,6 +1,8 @@
 import json
 import time
 import unittest
+from datetime import datetime, timedelta, timezone
+from email.utils import format_datetime
 from typing import Any
 
 from unittest import mock
@@ -230,6 +232,44 @@ class TestConsumer(unittest.TestCase):
                     mock.call(4),  # 2^2
                 ],
             )
+
+    @parameterized.expand(
+        [
+            ("huge_numeric", "1000000000", [30, 30]),
+            ("small_numeric", "0.25", [1, 2]),
+            ("huge_date", "Fri, 01 Jan 2100 00:00:00 GMT", [30, 30]),
+            ("small_date", None, [1, 2]),
+        ]
+    )
+    def test_request_bounds_retry_after_without_reducing_attempts(
+        self, _name: str, retry_after_header: str | None, expected_sleeps: list[int]
+    ) -> None:
+        if retry_after_header is None:
+            retry_after_header = format_datetime(
+                datetime.now(timezone.utc) + timedelta(seconds=1), usegmt=True
+            )
+
+        retry_response = mock.Mock(
+            status_code=503,
+            headers={"Retry-After": retry_after_header},
+            text="Service Unavailable",
+        )
+        retry_response.json.return_value = {"detail": "Service Unavailable"}
+        success_response = mock.Mock(status_code=200)
+        session = mock.Mock()
+        session.post.side_effect = [retry_response, retry_response, success_response]
+
+        consumer = Consumer(None, TEST_API_KEY, retries=2)
+        with (
+            mock.patch("posthog.request._get_session", return_value=session),
+            mock.patch("posthog.consumer.time.sleep") as mock_sleep,
+        ):
+            consumer.request([_track_event()])
+
+        self.assertEqual(session.post.call_count, 3)
+        self.assertEqual(
+            [call.args[0] for call in mock_sleep.call_args_list], expected_sleeps
+        )
 
     def test_request_retries_on_408(self) -> None:
         call_count = [0]


### PR DESCRIPTION
## :bulb: Motivation and Context

Capture v0 treated a positive `Retry-After` response header as an unbounded replacement for its configured exponential backoff. A server-provided numeric value or far-future HTTP date could therefore block the consumer thread for an unexpectedly long time, while a small value could reduce the existing retry delay.

This change aligns v0 with the bounded retry behavior already used by capture v1: both the exponential delay and `Retry-After` use the shared 30-second ceiling, and the actual wait is their maximum.

## :green_heart: How did you test it?

- `/Users/marandaneto/Github/posthog-python/.venv/bin/python -m pytest posthog/test/test_consumer.py -q` (30 passed)
- `/Users/marandaneto/Github/posthog-python/.venv/bin/ruff check posthog/consumer.py posthog/test/test_consumer.py`
- `/Users/marandaneto/Github/posthog-python/.venv/bin/ruff format --check posthog/consumer.py posthog/test/test_consumer.py`
- `git diff --check`

Regression coverage verifies huge and small numeric and HTTP-date `Retry-After` values and confirms the configured number of attempts is preserved.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A human directed the scope and PR requirements. Pi coding agent using GPT-5.6-sol (session `019fb2fd-ad74-70b3-a210-34f28b8ed762`) implemented the bounded delay and regression tests; Pi's autoreview tool independently reported no actionable findings. The implementation reuses capture v1's existing retry ceiling rather than introducing a second constant, and intentionally preserves v0's retry count and retryable-status behavior.

This PR requires human review and is not intended for autonomous merge.
