### PR TITLE
fix(flags): use device ID in local evaluation

### DIFF
--- a/.sampo/changesets/doughty-baron-lemminkainen.md
+++ b/.sampo/changesets/doughty-baron-lemminkainen.md
@@ -1,0 +1,5 @@
+---
+pypi/posthog: patch
+---
+
+Use device IDs during local feature flag evaluation

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -3373,6 +3373,7 @@ class Client(object):
             person_properties=local_person_properties,
             group_properties=group_properties,
             flag_keys_to_evaluate=flag_keys,
+            device_id=device_id,
         )
 
         feature_flags_by_key: Dict[str, Any] = self.feature_flags_by_key or {}

--- a/posthog/test/test_evaluate_flags.py
+++ b/posthog/test/test_evaluate_flags.py
@@ -271,6 +271,55 @@ class TestEvaluateFlagsRemote(unittest.TestCase):
         self.assertEqual(len(feature_flag_called), 0)
 
 
+class TestEvaluateFlagsLocalDeviceBucketing(unittest.TestCase):
+    def setUp(self):
+        self.client = Client(FAKE_TEST_API_KEY)
+        self.client.feature_flags = [
+            {
+                "id": 1,
+                "key": "device-bucketed-flag",
+                "active": True,
+                "filters": {
+                    "bucketing_identifier": "device_id",
+                    # user-1 hashes above 50%, while both test device IDs hash below
+                    # 50%, so these assertions prove device bucketing is used.
+                    "groups": [{"properties": [], "rollout_percentage": 50}],
+                },
+            }
+        ]
+
+    def tearDown(self):
+        self.client.shutdown()
+
+    @mock.patch("posthog.client.flags")
+    @mock.patch.object(Client, "capture")
+    def test_explicit_device_id_is_used_for_local_evaluation(
+        self, _patch_capture, patch_flags
+    ):
+        flags = self.client.evaluate_flags(
+            "user-1",
+            device_id="explicit-device",
+            only_evaluate_locally=True,
+        )
+
+        self.assertTrue(flags.get_flag("device-bucketed-flag"))
+        patch_flags.assert_not_called()
+
+    @mock.patch("posthog.client.flags")
+    @mock.patch.object(Client, "capture")
+    def test_context_device_id_is_used_for_local_evaluation(
+        self, _patch_capture, patch_flags
+    ):
+        from posthog.contexts import new_context, set_context_device_id
+
+        with new_context():
+            set_context_device_id("context-device-0")
+            flags = self.client.evaluate_flags("user-1", only_evaluate_locally=True)
+
+        self.assertTrue(flags.get_flag("device-bucketed-flag"))
+        patch_flags.assert_not_called()
+
+
 class TestEvaluateFlagsFiltering(unittest.TestCase):
     def setUp(self):
         self.client = Client(FAKE_TEST_API_KEY)


### PR DESCRIPTION
## :bulb: Motivation and Context

Local `evaluate_flags()` accepted an explicit or context-derived device ID but did not forward it to bulk local evaluation. Flags using `device_id` as their bucketing identifier could therefore disappear in local-only mode or unnecessarily fall back to a network request.

This forwards the resolved device ID through the local evaluation path so device-bucketed flags produce the expected result without a remote call.

## :green_heart: How did you test it?

- Added local-only regression coverage for explicit and context-derived device IDs.
- Ran the complete affected evaluation test module: 31 tests passed.
- Ran focused regressions, Ruff formatting/lint checks, and autoreview; all passed.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi workers implemented and independently autoreviewed this targeted fix under human direction. The final tests use deterministic opposite device buckets to demonstrate that local evaluation uses the device ID rather than the person distinct ID.
