### PR TITLE
feat(ai): map openai-agents group_id to $ai_session_id

### DIFF
--- a/.sampo/changesets/openai-agents-group-id-session.md
+++ b/.sampo/changesets/openai-agents-group-id-session.md
@@ -2,4 +2,4 @@
 pypi/posthog: minor
 ---
 
-The OpenAI Agents SDK `group_id` now maps to `$ai_session_id` instead of `$ai_group_id` on `$ai_trace` and span events, so grouped runs show up as sessions in PostHog AI observability.
+The OpenAI Agents SDK `group_id` now also maps to `$ai_session_id` on `$ai_trace` and span events, so grouped runs show up as sessions in PostHog AI observability. `$ai_group_id` is still emitted alongside it.

--- a/.sampo/changesets/openai-agents-group-id-session.md
+++ b/.sampo/changesets/openai-agents-group-id-session.md
@@ -1,0 +1,5 @@
+---
+pypi/posthog: minor
+---
+
+The OpenAI Agents SDK `group_id` now maps to `$ai_session_id` instead of `$ai_group_id` on `$ai_trace` and span events, so grouped runs show up as sessions in PostHog AI observability.

--- a/posthog/ai/openai_agents/processor.py
+++ b/posthog/ai/openai_agents/processor.py
@@ -236,9 +236,10 @@ class PostHogTracingProcessor(TracingProcessor):
             if latency is not None:
                 properties["$ai_latency"] = latency
 
-            # Include group_id for linking related traces (e.g., conversation threads)
+            # The Agents SDK group_id links traces from one conversation, which is
+            # exactly what PostHog calls a session
             if group_id:
-                properties["$ai_group_id"] = group_id
+                properties["$ai_session_id"] = group_id
 
             # Include trace metadata if present
             if metadata:
@@ -476,7 +477,7 @@ class PostHogTracingProcessor(TracingProcessor):
             **error_properties,
         }
         if group_id:
-            properties["$ai_group_id"] = group_id
+            properties["$ai_session_id"] = group_id
         return properties
 
     def _handle_generation_span(

--- a/posthog/ai/openai_agents/processor.py
+++ b/posthog/ai/openai_agents/processor.py
@@ -237,9 +237,11 @@ class PostHogTracingProcessor(TracingProcessor):
                 properties["$ai_latency"] = latency
 
             # The Agents SDK group_id links traces from one conversation, which is
-            # exactly what PostHog calls a session
+            # exactly what PostHog calls a session. $ai_group_id is still emitted
+            # for anyone already querying it.
             if group_id:
                 properties["$ai_session_id"] = group_id
+                properties["$ai_group_id"] = group_id
 
             # Include trace metadata if present
             if metadata:
@@ -478,6 +480,7 @@ class PostHogTracingProcessor(TracingProcessor):
         }
         if group_id:
             properties["$ai_session_id"] = group_id
+            properties["$ai_group_id"] = group_id
         return properties
 
     def _handle_generation_span(

--- a/posthog/test/ai/openai_agents/test_processor.py
+++ b/posthog/test/ai/openai_agents/test_processor.py
@@ -127,6 +127,23 @@ class TestPostHogTracingProcessor:
         assert call_kwargs["properties"]["$ai_framework"] == "openai-agents"
         assert "$ai_latency" in call_kwargs["properties"]
 
+    def test_group_id_becomes_session_id(
+        self, processor, mock_client, mock_trace, mock_span
+    ):
+        """Test that the SDK's group_id lands on trace and span events as $ai_session_id."""
+        processor.on_trace_start(mock_trace)
+
+        mock_span.span_data = GenerationSpanData(model="gpt-4o")
+        processor.on_span_start(mock_span)
+        processor.on_span_end(mock_span)
+        span_kwargs = mock_client.capture.call_args[1]
+
+        processor.on_trace_end(mock_trace)
+        trace_kwargs = mock_client.capture.call_args[1]
+
+        assert span_kwargs["properties"]["$ai_session_id"] == "group_123"
+        assert trace_kwargs["properties"]["$ai_session_id"] == "group_123"
+
     def test_personless_mode_when_no_distinct_id(self, mock_client, mock_trace):
         """Test that trace events use personless mode when no distinct_id is provided."""
         processor = PostHogTracingProcessor(

--- a/posthog/test/ai/openai_agents/test_processor.py
+++ b/posthog/test/ai/openai_agents/test_processor.py
@@ -130,7 +130,7 @@ class TestPostHogTracingProcessor:
     def test_group_id_becomes_session_id(
         self, processor, mock_client, mock_trace, mock_span
     ):
-        """Test that the SDK's group_id lands on trace and span events as $ai_session_id."""
+        """Test that group_id lands on trace and span events as both session and group id."""
         processor.on_trace_start(mock_trace)
 
         mock_span.span_data = GenerationSpanData(model="gpt-4o")
@@ -142,7 +142,9 @@ class TestPostHogTracingProcessor:
         trace_kwargs = mock_client.capture.call_args[1]
 
         assert span_kwargs["properties"]["$ai_session_id"] == "group_123"
+        assert span_kwargs["properties"]["$ai_group_id"] == "group_123"
         assert trace_kwargs["properties"]["$ai_session_id"] == "group_123"
+        assert trace_kwargs["properties"]["$ai_group_id"] == "group_123"
 
     def test_personless_mode_when_no_distinct_id(self, mock_client, mock_trace):
         """Test that trace events use personless mode when no distinct_id is provided."""


### PR DESCRIPTION
## :bulb: Motivation and Context

The OpenAI Agents SDK's `group_id` is documented as a "grouping identifier to link multiple traces from the same conversation or process" — that is exactly a PostHog session. We were writing it only to `$ai_session_id`'s near-namesake `$ai_group_id`, which nothing in AI observability reads, so grouped runs never showed up as sessions.

`group_id` is the only per-conversation channel this integration exposes (`RunConfig(group_id=...)` / `trace(group_id=...)`), and it's already read per trace and threaded into every span event — it just landed under a name with no consumer.

Both properties are now emitted, so anything already querying `$ai_group_id` keeps working.

## :green_heart: How did you test it?

Added `test_group_id_becomes_session_id`, asserting both `$ai_session_id` and `$ai_group_id` on the trace event and on span events. Verified it fails on `main` (`KeyError: '$ai_session_id'`) and passes with the fix. Full `posthog/test/ai/openai_agents/` suite passes (53 tests).

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5). The naming bug surfaced while auditing which PostHog Python AI integrations can carry a session id, comparing `openai_agents` against `claude_agent_sdk`, `langchain`, and the `openai` wrapper. Every integration that works exposes a per-call properties channel; `openai_agents` is the one that reused the framework's own native field instead, which is where the name drifted.

Considered mapping `trace_metadata` instead — rejected, it lands as a nested `$ai_trace_metadata` blob on the trace event only, so it can't act as a session key. Kept the change to the two assignment sites rather than adding a `posthog_properties` kwarg to the processor; that's a larger API addition and `group_id` already covers the use case. Started as a straight rename, then switched to emitting both names so existing `$ai_group_id` queries don't break.

The matching JS fix is in PostHog/posthog-js.
