### PR TITLE
fix(gemini): normalize tool call/response parts in captured input

### DIFF
--- a/.sampo/changesets/gentle-toolsmith-vellamo.md
+++ b/.sampo/changesets/gentle-toolsmith-vellamo.md
@@ -1,0 +1,5 @@
+---
+pypi/posthog: patch
+---
+
+Normalize Gemini tool calls and tool responses in captured input so they render in traces and reach evaluations

--- a/posthog/ai/gemini/gemini_converter.py
+++ b/posthog/ai/gemini/gemini_converter.py
@@ -55,15 +55,24 @@ def _format_part(part: Any) -> Optional[FormattedContentItem]:
     if "file_data" in plain:
         media = _format_media_payload(plain["file_data"])
         return {"type": _kind_from_mime(media.get("mime_type")), "file_data": media}
+    # Gemini-native function_call/function_response parts are normalized to the
+    # provider-agnostic tool-call/tool-result blocks. Emitting the raw Gemini
+    # shape leaves them unrenderable and invisible to evals.
     if "function_call" in plain:
+        call = to_plain(plain["function_call"]) or {}
         return {
-            "type": "function_call",
-            "function_call": to_plain(plain["function_call"]),
+            "type": "function",
+            "function": {
+                "name": call.get("name"),
+                "arguments": call.get("args"),
+            },
         }
     if "function_response" in plain:
+        response = to_plain(plain["function_response"]) or {}
         return {
-            "type": "function_response",
-            "function_response": to_plain(plain["function_response"]),
+            "type": "function",
+            "tool_name": response.get("name") or "",
+            "content": response.get("response"),
         }
     if not plain:
         return None

--- a/posthog/test/ai/gemini/test_gemini_converter.py
+++ b/posthog/test/ai/gemini/test_gemini_converter.py
@@ -83,9 +83,14 @@ class TestGeminiInputParts:
             ),
         ]
         out = format_gemini_input(contents)
-        assert out[0]["content"][0]["type"] == "function_call"
-        assert out[0]["content"][0]["function_call"]["name"] == "get_weather"
-        assert out[1]["content"][0]["type"] == "function_response"
+        call = out[0]["content"][0]
+        assert call["type"] == "function"
+        assert call["function"] == {"name": "get_weather", "arguments": {"city": "SF"}}
+        result = out[1]["content"][0]
+        assert result["type"] == "function"
+        assert result["tool_name"] == "get_weather"
+        assert result["content"] == {"temp": "18C"}
+        assert "function" not in result
 
     def test_camel_case_dict_part_preserved(self):
         out = format_gemini_input(


### PR DESCRIPTION
## :bulb: Motivation and Context

Fixes #725.

The Gemini wrapper copied function calls and their responses into `$ai_input`, in the raw form the google-genai SDK emits:

```json
{"type": "function_call",     "function_call": {"name": "...", "args": {}}}
{"type": "function_response", "function_response": {"name": "...", "response": {}}}
```

No PostHog consumer knows those two shapes. The trace view matches four other tool-result shapes, so it never showed the tool response. The eval formatter found no `text` key and no `content` key, so it fell back to a raw `repr()` dump. Evals then flagged correct answers as hallucinations.

The response path already emitted the shared shape. That is why a tool call showed in the output, then vanished from the next request's history.

## Changes

`_format_part` now emits the shared shapes:

- `function_call` becomes `{"type": "function", "function": {name, arguments}}`
- `function_response` becomes `{"type": "function", "tool_name": ..., "content": ...}`

Tool results carry `tool_name`, not a call id. Gemini pairs a response to a call by name and has no id to pass through.

`$ai_output_choices` does not change.

### Out of scope

Automatic function calling. google-genai runs that tool loop inside `generate_content`. The turns live only on `response.automatic_function_calling_history`, which this wrapper never reads. I wrote and tested that fix, then dropped it to keep this change small. It needs its own issue.

### Backward compatibility

The old shape shipped in 7.30.1, four days before this fix. Before 7.30.1 the input path dropped these parts. Nothing reads the old shape. The whole `ai_observability` product has no match for `function_response`.

Two points for a reviewer:

- `format_gemini_input` sits in `__all__`, so its return shape is public. The Public API snapshot check still passes, because the signature did not change.
- The new tool result has no nested `function` key. That is what stops `isToolStepItem` from reading it as a call.

## :green_heart: How did you test it?

- I updated `test_function_call_and_response_turns_preserved` for both new shapes.
- `posthog/test/ai/`: 438 pass, 61 skip. I left out `otel/`, which needs two packages my local env lacks.
- I ran `format_gemini_input` over a real `google-genai` function-calling turn.
- I ran the monorepo eval formatter against both shapes. The old shape gave a `repr()` dump. The new shape gives `[FUNCTION]` and the tool output, the same as Anthropic `tool_result`.

I did not test against a live Gemini key or a real project.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file

## Follow-up

PostHog/posthog#76028 teaches the trace view the old shape, so traces already stored render too. That fix covers the view only. Those traces still feed evals a `repr()` dump, because the eval path is a separate Python formatter.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code (Opus 5), directed by @marco-g-pm.

I first assumed a frontend patch would also fix the evals. It does not. Evals run through a separate Python formatter, which I checked by running it against both shapes. That result is what made the SDK the right place to fix this.
