### PR TITLE
test(gemini): assert tool turns reach $ai_input as normalized blocks

### DIFF
--- a/posthog/test/ai/gemini/test_gemini.py
+++ b/posthog/test/ai/gemini/test_gemini.py
@@ -1593,3 +1593,68 @@ def test_ai_lane_client_routes_through_capture_ai(
     mock_client.capture.assert_not_called()
     assert mock_client._capture_ai.call_count == 1
     assert mock_client._capture_ai.call_args[1]["event"] == "$ai_generation"
+
+
+def test_tool_response_turn_captured_in_ai_input(
+    mock_client, mock_google_genai_client, mock_gemini_response
+):
+    """A manual function-calling turn reaches $ai_input as normalized tool blocks.
+
+    Covers the regression in #725: Gemini's own function_call/function_response
+    parts reached the payload unconverted, and no PostHog consumer matched them.
+    Uses real google-genai types, so the whole conversion path runs.
+    """
+    from google.genai import types
+
+    mock_google_genai_client.models.generate_content.return_value = mock_gemini_response
+
+    client = Client(api_key="test-key", posthog_client=mock_client)
+
+    client.models.generate_content(
+        model="gemini-2.5-flash",
+        contents=[
+            types.Content(
+                role="user", parts=[types.Part(text="What is the weather in SF?")]
+            ),
+            types.Content(
+                role="model",
+                parts=[
+                    types.Part(
+                        function_call=types.FunctionCall(
+                            name="get_weather", args={"city": "SF"}
+                        )
+                    )
+                ],
+            ),
+            types.Content(
+                role="user",
+                parts=[
+                    types.Part(
+                        function_response=types.FunctionResponse(
+                            name="get_weather", response={"temp_c": 18}
+                        )
+                    )
+                ],
+            ),
+        ],
+        posthog_distinct_id="test-id",
+    )
+
+    props = mock_client.capture.call_args[1]["properties"]
+    ai_input = props["$ai_input"]
+
+    assert ai_input[0]["content"] == [
+        {"type": "text", "text": "What is the weather in SF?"}
+    ]
+    assert ai_input[1]["content"] == [
+        {
+            "type": "function",
+            "function": {"name": "get_weather", "arguments": {"city": "SF"}},
+        }
+    ]
+    assert ai_input[2]["content"] == [
+        {"type": "function", "tool_name": "get_weather", "content": {"temp_c": 18}}
+    ]
+
+    # The payload has to survive JSON transport to reach PostHog at all.
+    assert json.loads(json.dumps(ai_input)) == ai_input


### PR DESCRIPTION
## :bulb: Motivation and Context

Follow-up to #823, which fixed the Gemini tool block shapes for #725. That PR tested the converter. This one tests the payload PostHog actually receives.

The gap mattered. A converter test proves `format_gemini_input` returns the right dict. It does not prove that dict reaches `$ai_input`, survives the capture path, and stays JSON-serializable.

## Changes

One test. It drives the whole path with a mocked google-genai client and real `types.Content` objects, then reads the `$ai_input` property handed to `capture()`:

- the text turn stays a text block
- the model turn becomes `{"type": "function", "function": {name, arguments}}`
- the tool-response turn becomes `{"type": "function", "tool_name": ..., "content": ...}`
- the whole payload survives a JSON round trip

## :green_heart: How did you test it?

I ran the test against the pre-fix converter to confirm it catches the original bug:

```
At index 0 diff:
  {'type': 'function_call', 'function_call': {'args': {'city': 'SF'}, 'name': 'get_weather'}}
!={'type': 'function',      'function':      {'name': 'get_weather', 'arguments': {'city': 'SF'}}}
```

That is the exact defect from #725. A test that cannot fail is not worth adding.

On current main, `posthog/test/ai/gemini/` gives 74 pass and 5 skip.

I also fed the captured payload through both downstream consumers:

- The trace view guards sort it correctly. The call reads as a tool step. The response reads as a tool result, so `isInternalToolResultUserMessage` hides it instead of letting it leak as a user bubble.
- The eval formatter prints the tool output as `[FUNCTION] {'temp_c': 18}`, which is what the judge needs.

No live Gemini key and no real project.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file

Tests only, so there is nothing to release.

## A gap this test surfaced

The eval formatter still prints a Gemini tool **call** as a raw dict dump. `_format_special_block` returns `None` for `type: "function"` and leaves it to the message-level `tool_calls` field, which this payload does not use. Anthropic `tool_use` and OpenAI `tool_calls` both print a clean call.

This predates #823. The SDK already used that block for `$ai_output_choices`, so Gemini tool calls have always printed this way for the judge. The fix belongs in `message_formatter.py`, not here.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code (Opus 5), directed by @marco-g-pm.

I wrote this after #823 merged, so it lands as its own PR. The end-to-end run is also what surfaced the eval formatter gap above, which no converter test could have shown.
