### PR TITLE
fix(flags): align local cohort evaluation with backend

### DIFF
--- a/.sampo/changesets/grim-iceseeker-akka.md
+++ b/.sampo/changesets/grim-iceseeker-akka.md
@@ -1,0 +1,5 @@
+---
+pypi/posthog: patch
+---
+
+Fix local evaluation for negated, missing, and malformed cohort definitions

--- a/posthog/feature_flags.py
+++ b/posthog/feature_flags.py
@@ -788,7 +788,7 @@ def match_property_group(
                     "Cohort property group entry must be an object"
                 )
 
-            if "values" in prop or prop.get("type") in ("AND", "OR"):
+            if prop == {} or "values" in prop or prop.get("type") in ("AND", "OR"):
                 matches = match_property_group(
                     prop,
                     property_values,

--- a/posthog/feature_flags.py
+++ b/posthog/feature_flags.py
@@ -769,7 +769,9 @@ def match_property_group(
         raise RequiresServerEvaluation("Cohort property group must be an object")
 
     property_group_type = property_group.get("type")
-    is_and = property_group_type != "OR"
+    if property_group_type not in ("AND", "OR"):
+        raise RequiresServerEvaluation("Cohort property group type must be AND or OR")
+    is_and = property_group_type == "AND"
     properties = property_group.get("values")
     if not isinstance(properties, list):
         raise RequiresServerEvaluation("Cohort property group values must be a list")

--- a/posthog/feature_flags.py
+++ b/posthog/feature_flags.py
@@ -735,7 +735,7 @@ def match_cohort(
         )
 
     property_group = cohort_properties[cohort_id]
-    return match_property_group(
+    matches = match_property_group(
         property_group,
         property_values,
         cohort_properties,
@@ -744,6 +744,13 @@ def match_cohort(
         distinct_id,
         device_id=device_id,
     )
+
+    operator = property.get("operator") or "exact"
+    if operator in ("exact", "in"):
+        return matches
+    if operator == "not_in":
+        return not matches
+    raise InconclusiveMatchError(f"Unsupported cohort operator: {operator}")
 
 
 def match_property_group(
@@ -755,22 +762,31 @@ def match_property_group(
     distinct_id=None,
     device_id=None,
 ) -> bool:
-    if not property_group:
+    # The backend serializes its canonical empty PropertyGroup as {}.
+    if property_group == {}:
         return True
+    if not isinstance(property_group, dict):
+        raise RequiresServerEvaluation("Cohort property group must be an object")
 
     property_group_type = property_group.get("type")
+    is_and = property_group_type != "OR"
     properties = property_group.get("values")
-
-    if not properties or len(properties) == 0:
-        # empty groups are no-ops, always match
+    if not isinstance(properties, list):
+        raise RequiresServerEvaluation("Cohort property group values must be a list")
+    if not properties:
         return True
 
+    decisive_result = None
     error_matching_locally = False
 
-    if "values" in properties[0]:
-        # a nested property group
-        for prop in properties:
-            try:
+    for prop in properties:
+        try:
+            if not isinstance(prop, dict):
+                raise RequiresServerEvaluation(
+                    "Cohort property group entry must be an object"
+                )
+
+            if "values" in prop or prop.get("type") in ("AND", "OR"):
                 matches = match_property_group(
                     prop,
                     property_values,
@@ -780,81 +796,55 @@ def match_property_group(
                     distinct_id,
                     device_id=device_id,
                 )
-                if property_group_type == "AND":
-                    if not matches:
-                        return False
-                else:
-                    # OR group
-                    if matches:
-                        return True
-            except RequiresServerEvaluation:
-                # Immediately propagate - this condition requires server-side data
-                raise
-            except InconclusiveMatchError as e:
-                log.debug(f"Failed to compute property {prop} locally: {e}")
-                error_matching_locally = True
-
-        if error_matching_locally:
-            raise InconclusiveMatchError(
-                "Can't match cohort without a given cohort property value"
-            )
-        # if we get here, all matched in AND case, or none matched in OR case
-        return property_group_type == "AND"
-
-    else:
-        for prop in properties:
-            try:
-                if prop.get("type") == "cohort":
-                    matches = match_cohort(
-                        prop,
-                        property_values,
-                        cohort_properties,
-                        flags_by_key,
-                        evaluation_cache,
-                        distinct_id,
-                        device_id=device_id,
-                    )
-                elif prop.get("type") == "flag":
-                    matches = evaluate_flag_dependency(
-                        prop,
-                        flags_by_key,
-                        evaluation_cache,
-                        distinct_id,
-                        property_values,
-                        cohort_properties,
-                        device_id=device_id,
-                    )
-                else:
-                    matches = match_property(prop, property_values)
-
+                negation = False
+            elif prop.get("type") == "cohort":
+                matches = match_cohort(
+                    prop,
+                    property_values,
+                    cohort_properties,
+                    flags_by_key,
+                    evaluation_cache,
+                    distinct_id,
+                    device_id=device_id,
+                )
+                negation = prop.get("negation", False)
+            elif prop.get("type") == "flag":
+                matches = evaluate_flag_dependency(
+                    prop,
+                    flags_by_key,
+                    evaluation_cache,
+                    distinct_id,
+                    property_values,
+                    cohort_properties,
+                    device_id=device_id,
+                )
+                negation = prop.get("negation", False)
+            else:
+                matches = match_property(prop, property_values)
                 negation = prop.get("negation", False)
 
-                if property_group_type == "AND":
-                    # if negated property, do the inverse
-                    if not matches and not negation:
-                        return False
-                    if matches and negation:
-                        return False
-                else:
-                    # OR group
-                    if matches and not negation:
-                        return True
-                    if not matches and negation:
-                        return True
-            except RequiresServerEvaluation:
-                # Immediately propagate - this condition requires server-side data
-                raise
-            except InconclusiveMatchError as e:
-                log.debug(f"Failed to compute property {prop} locally: {e}")
-                error_matching_locally = True
+            effective_match = matches != bool(negation)
+            if is_and and not effective_match:
+                decisive_result = False
+            elif not is_and and effective_match:
+                decisive_result = True
+        except RequiresServerEvaluation:
+            # Static/missing cohorts and malformed definitions always require server evaluation,
+            # even when another branch would otherwise resolve the group locally.
+            raise
+        except InconclusiveMatchError as e:
+            log.debug(f"Failed to compute property {prop} locally: {e}")
+            error_matching_locally = True
 
-        if error_matching_locally:
-            raise InconclusiveMatchError(
-                "can't match cohort without a given cohort property value"
-            )
+    if decisive_result is not None:
+        return decisive_result
+    if error_matching_locally:
+        raise InconclusiveMatchError(
+            "Can't match cohort without a given cohort property value"
+        )
 
-        # if we get here, all matched in AND case, or none matched in OR case
-        return property_group_type == "AND"
+    # AND: every entry matched. OR: none matched.
+    return is_and
 
 
 def parse_datetime(value: str) -> datetime.datetime:

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -16,7 +16,10 @@ from posthog.feature_flags import (
     PROPERTY_OPERATORS,
     _UNHANDLED_OPERATOR_MESSAGE,
     InconclusiveMatchError,
+    RequiresServerEvaluation,
+    match_cohort,
     match_property,
+    match_property_group,
     parse_datetime,
     relative_date_parse_for_feature_flag_matching,
 )
@@ -35,6 +38,73 @@ pytestmark = [
         r"ignore:send_feature_flag_events is deprecated in get_feature_flag_payload:DeprecationWarning"
     ),
 ]
+
+
+class TestCohortMatching(unittest.TestCase):
+    def setUp(self):
+        self.cohorts = {
+            "1": {
+                "type": "AND",
+                "values": [
+                    {
+                        "key": "country",
+                        "value": "US",
+                        "operator": "exact",
+                        "type": "person",
+                    }
+                ],
+            }
+        }
+
+    def test_cohort_membership_operators(self):
+        for operator in (None, "exact", "in"):
+            with self.subTest(operator=operator):
+                prop = {"value": 1, "operator": operator, "type": "cohort"}
+                self.assertTrue(match_cohort(prop, {"country": "US"}, self.cohorts))
+                self.assertFalse(match_cohort(prop, {"country": "UK"}, self.cohorts))
+
+        not_in = {"value": 1, "operator": "not_in", "type": "cohort"}
+        self.assertFalse(match_cohort(not_in, {"country": "US"}, self.cohorts))
+        self.assertTrue(match_cohort(not_in, {"country": "UK"}, self.cohorts))
+
+    def test_only_canonical_empty_groups_match(self):
+        self.assertTrue(match_property_group({}, {}, {}))
+        self.assertTrue(match_property_group({"type": "AND", "values": []}, {}, {}))
+
+        malformed_groups = [
+            None,
+            "invalid",
+            {"type": "AND"},
+            {"type": "AND", "values": {}},
+        ]
+        for group in malformed_groups:
+            with self.subTest(group=group):
+                with self.assertRaises(RequiresServerEvaluation):
+                    match_property_group(group, {}, {})
+
+    def test_missing_nested_cohort_always_requires_server_evaluation(self):
+        matching_leaf = {
+            "key": "country",
+            "value": "US",
+            "operator": "exact",
+            "type": "person",
+        }
+        missing_cohort = {"key": "id", "value": 999, "type": "cohort"}
+
+        cases = [
+            ("OR", "US", [matching_leaf, missing_cohort]),
+            ("OR", "US", [missing_cohort, matching_leaf]),
+            ("AND", "UK", [matching_leaf, missing_cohort]),
+            ("AND", "UK", [missing_cohort, matching_leaf]),
+        ]
+        for group_type, country, values in cases:
+            with self.subTest(group_type=group_type, values=values):
+                with self.assertRaises(RequiresServerEvaluation):
+                    match_property_group(
+                        {"type": group_type, "values": values},
+                        {"country": country},
+                        {},
+                    )
 
 
 class TestLocalEvaluation(unittest.TestCase):

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -70,6 +70,13 @@ class TestCohortMatching(unittest.TestCase):
     def test_only_canonical_empty_groups_match(self):
         self.assertTrue(match_property_group({}, {}, {}))
         self.assertTrue(match_property_group({"type": "AND", "values": []}, {}, {}))
+        self.assertTrue(
+            match_property_group(
+                {"type": "AND", "values": [{"type": "AND", "values": []}, {}]},
+                {},
+                {},
+            )
+        )
 
         malformed_groups = [
             None,

--- a/posthog/test/test_feature_flags.py
+++ b/posthog/test/test_feature_flags.py
@@ -76,6 +76,8 @@ class TestCohortMatching(unittest.TestCase):
             "invalid",
             {"type": "AND"},
             {"type": "AND", "values": {}},
+            {"values": []},
+            {"type": "INVALID", "values": []},
         ]
         for group in malformed_groups:
             with self.subTest(group=group):


### PR DESCRIPTION
## :bulb: Motivation and Context

The backend returns cohort definitions as nested property groups and omits static cohorts that require server evaluation. Python local evaluation could ignore `not_in`, treat malformed non-empty groups as matching everyone, or skip a missing nested cohort after another branch resolved the group.

This change aligns Python cohort evaluation with the backend response contract and the corresponding Rust SDK work in https://github.com/PostHog/posthog-rs/pull/187.

It now applies cohort membership operators, accepts the backend's canonical empty group representation, rejects malformed groups, and falls back to the server whenever a nested static or missing cohort appears.

## :green_heart: How did you test it?

- `uv run --extra test pytest -q` - 2052 passed, 15 skipped
- `uv run ruff format --check .`
- `uv run ruff check .`
- Autoreview against `origin/main` reported no actionable findings.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi and the autoreview skill were used to compare the Python and Rust SDK behavior with the backend serializer. The implementation preserves valid empty groups while making missing cohorts and malformed definitions fall back to server evaluation regardless of branch order.
