### PR TITLE
chore: expand Dependabot ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,9 +27,6 @@ updates:
       - dependency-name: "langchain*"
       - dependency-name: "langgraph"
     open-pull-requests-limit: 1
-    reviewers:
-      - "PostHog/team-client-libraries"
-      - "PostHog/team-llm-analytics"
 
   - package-ecosystem: "pip"
     cooldown:
@@ -58,11 +55,22 @@ updates:
       - dependency-name: "langchain*"
       - dependency-name: "langgraph"
     open-pull-requests-limit: 1
-    reviewers:
-      - "PostHog/team-client-libraries"
-      - "PostHog/team-llm-analytics"
     # Uncomment below to enable auto-merge for minor updates when CI passes
     # pull-request-branch-name:
     #   separator: "/"
     # assignees:
     #   - "PostHog/ai-team"
+
+  - package-ecosystem: "github-actions"
+    cooldown:
+      default-days: 7
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "10:00"
+      timezone: "UTC"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,8 @@ updates:
       - dependency-name: "langchain*"
       - dependency-name: "langgraph"
     open-pull-requests-limit: 1
+    reviewers:
+      - "PostHog/team-llm-analytics"
 
   - package-ecosystem: "pip"
     cooldown:
@@ -55,6 +57,8 @@ updates:
       - dependency-name: "langchain*"
       - dependency-name: "langgraph"
     open-pull-requests-limit: 1
+    reviewers:
+      - "PostHog/team-llm-analytics"
     # Uncomment below to enable auto-merge for minor updates when CI passes
     # pull-request-branch-name:
     #   separator: "/"


### PR DESCRIPTION
## :bulb: Motivation and Context

Dependabot currently updates the root Python dependencies through the `uv` and `pip` ecosystems, but it does not update versions used by GitHub Actions.

This change adds weekly GitHub Actions updates at the repository root. All three ecosystems run on Monday at 10:00 UTC with a seven-day cooldown. The existing Python dependency allow lists, groups, exclusions, pull request limits, and `PostHog/team-llm-analytics` reviewers remain unchanged. The redundant `PostHog/team-client-libraries` reviewers are removed because CODEOWNERS already routes their review.

## :green_heart: How did you test it?

- Parsed `.github/dependabot.yml` with Python PyYAML and Ruby YAML.
- Validated the file against the Dependabot 2.0 JSON schema.
- Ran `uv run ruff format --check .` and `uv run ruff check .`.
- Verified the configured manifests and directories exist and CODEOWNERS covers the file.
- Ran autoreview against `origin/main` for commit `a7854bf` with no actionable findings.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A Pi coding agent made the requested configuration-only change. The agent preserved the LLM analytics reviewers while removing only the client libraries reviewer entries covered by CODEOWNERS. Pi autoreview checked the exact signed commit against `origin/main` and reported no actionable findings.
