### PR TITLE
fix(gemini): declare cache reporting as inclusive on generations

### DIFF
--- a/.sampo/changesets/gemini-cache-reporting-exclusive.md
+++ b/.sampo/changesets/gemini-cache-reporting-exclusive.md
@@ -1,0 +1,5 @@
+---
+pypi/posthog: patch
+---
+
+fix: declare Gemini's cache accounting model on generations with cache reads, so ingestion prices cached tokens from `$ai_cache_reporting_exclusive` instead of inferring it from the token counts.

--- a/posthog/ai/gemini/gemini_converter.py
+++ b/posthog/ai/gemini/gemini_converter.py
@@ -513,6 +513,12 @@ def _extract_usage_from_metadata(metadata: Any) -> TokenUsage:
         cache_tokens = metadata.cached_content_token_count
         if cache_tokens and cache_tokens > 0:
             usage["cache_read_input_tokens"] = cache_tokens
+            # Gemini counts cached_content_token_count inside prompt_token_count, so
+            # declare the accounting model rather than leaving ingestion to infer it.
+            # Under explicit context caching the two counts come from separate
+            # measurements and can disagree by a few percent, which makes inference
+            # from the token counts alone unreliable.
+            usage["cache_reporting_exclusive"] = False
 
     # Add reasoning tokens if present (don't add if 0)
     if hasattr(metadata, "thoughts_token_count"):

--- a/posthog/ai/types.py
+++ b/posthog/ai/types.py
@@ -73,6 +73,11 @@ class TokenUsage(TypedDict, total=False):
     cache_creation_input_tokens: Optional[int]
     reasoning_tokens: Optional[int]
     web_search_count: Optional[int]
+    # Whether cache tokens are counted separately from input_tokens. Providers that
+    # report them as a subset of input_tokens set this False. Left unset when the
+    # provider's accounting model is not known, in which case ingestion infers it
+    # from the token counts.
+    cache_reporting_exclusive: Optional[bool]
     raw_usage: Optional[Any]  # Raw provider usage metadata for backend processing
 
 

--- a/posthog/ai/utils.py
+++ b/posthog/ai/utils.py
@@ -172,6 +172,12 @@ def merge_usage_stats(
             current = target.get("web_search_count") or 0
             target["web_search_count"] = max(current, source_web_search)
 
+        # Carried across, never accumulated: this describes the provider's accounting
+        # model, so it is the same on every chunk.
+        source_exclusive = source.get("cache_reporting_exclusive")
+        if source_exclusive is not None:
+            target["cache_reporting_exclusive"] = source_exclusive
+
         # Merge raw_usage to avoid losing data from earlier events
         # For Anthropic streaming: message_start has input tokens, message_delta has output
         # Note: raw_usage is already serialized by converters, so it's a dict
@@ -199,6 +205,8 @@ def merge_usage_stats(
             target["reasoning_tokens"] = source["reasoning_tokens"]
         if source.get("web_search_count") is not None:
             target["web_search_count"] = source["web_search_count"]
+        if source.get("cache_reporting_exclusive") is not None:
+            target["cache_reporting_exclusive"] = source["cache_reporting_exclusive"]
         # Note: raw_usage is already serialized by converters, so it's a dict
         if source.get("raw_usage") is not None:
             target["raw_usage"] = source["raw_usage"]
@@ -482,6 +490,10 @@ def call_llm_and_track_usage(
             if cache_creation is not None and cache_creation > 0:
                 tag("$ai_cache_creation_input_tokens", cache_creation)
 
+            cache_reporting_exclusive = usage.get("cache_reporting_exclusive")
+            if cache_reporting_exclusive is not None:
+                tag("$ai_cache_reporting_exclusive", cache_reporting_exclusive)
+
             reasoning = usage.get("reasoning_tokens")
             if reasoning is not None and reasoning > 0:
                 tag("$ai_reasoning_tokens", reasoning)
@@ -634,6 +646,10 @@ async def call_llm_and_track_usage_async(
             cache_creation = usage.get("cache_creation_input_tokens")
             if cache_creation is not None and cache_creation > 0:
                 tag("$ai_cache_creation_input_tokens", cache_creation)
+
+            cache_reporting_exclusive = usage.get("cache_reporting_exclusive")
+            if cache_reporting_exclusive is not None:
+                tag("$ai_cache_reporting_exclusive", cache_reporting_exclusive)
 
             reasoning = usage.get("reasoning_tokens")
             if reasoning is not None and reasoning > 0:
@@ -793,6 +809,12 @@ def capture_streaming_event(
             value = event_data["usage_stats"].get(field)
             if value is not None and isinstance(value, int) and value > 0:
                 event_properties[f"$ai_{field}"] = value
+
+    cache_reporting_exclusive = event_data["usage_stats"].get(
+        "cache_reporting_exclusive"
+    )
+    if cache_reporting_exclusive is not None:
+        event_properties["$ai_cache_reporting_exclusive"] = cache_reporting_exclusive
 
     # Add web search count if present (all providers)
     web_search_count = event_data["usage_stats"].get("web_search_count")

--- a/posthog/test/ai/gemini/test_gemini.py
+++ b/posthog/test/ai/gemini/test_gemini.py
@@ -836,6 +836,7 @@ def test_cache_and_reasoning_tokens(mock_client, mock_google_genai_client):
     assert props["$ai_output_tokens"] == 50
     assert props["$ai_cache_read_input_tokens"] == 30
     assert props["$ai_reasoning_tokens"] == 10
+    assert props["$ai_cache_reporting_exclusive"] is False
 
 
 def test_streaming_cache_and_reasoning_tokens(mock_client, mock_google_genai_client):
@@ -899,6 +900,7 @@ def test_streaming_cache_and_reasoning_tokens(mock_client, mock_google_genai_cli
     assert props["$ai_output_tokens"] == 10
     assert props["$ai_cache_read_input_tokens"] == 30
     assert props["$ai_reasoning_tokens"] == 5
+    assert props["$ai_cache_reporting_exclusive"] is False
 
     # Verify raw usage is captured in streaming mode (merged from chunks)
     assert "$ai_usage" in props

--- a/references/public_api_snapshot.txt
+++ b/references/public_api_snapshot.txt
@@ -487,6 +487,7 @@ attribute posthog.ai.types.StreamingEventData.trace_id: Optional[str]
 attribute posthog.ai.types.StreamingEventData.usage_stats: TokenUsage
 attribute posthog.ai.types.TokenUsage.cache_creation_input_tokens: Optional[int]
 attribute posthog.ai.types.TokenUsage.cache_read_input_tokens: Optional[int]
+attribute posthog.ai.types.TokenUsage.cache_reporting_exclusive: Optional[bool]
 attribute posthog.ai.types.TokenUsage.input_tokens: int
 attribute posthog.ai.types.TokenUsage.output_tokens: int
 attribute posthog.ai.types.TokenUsage.raw_usage: Optional[Any]


### PR DESCRIPTION
## :bulb: Motivation and Context

Cache-heavy Gemini generations can be priced wrong in AI observability, because the SDK never tells ingestion how Gemini counts cache tokens.

Gemini counts `cached_content_token_count` inside `prompt_token_count`, so cache reads are a subset of input, not a separate pool. The SDK reports both numbers but declares nothing, so ingestion infers the accounting model from the token counts.

That inference is unreliable for Gemini. Under explicit context caching the two counts come from separate measurements: the cache object is counted when it is created, and the prompt is counted per request. They describe the same tokens but can disagree by a few percent, which puts the cache pool just above the input total and makes the counts look like two separate pools.

This PR sets the flag where the answer is actually known. PostHog/posthog#79781 is the matching ingestion-side change, which stops inferring exclusive accounting from a small overshoot and covers SDK versions that predate this one.

## :green_heart: How did you test it?

- Ran `uv run pytest posthog/test/ai/ --ignore=posthog/test/ai/otel`. 446 passed. Two failures, `test_integration_stop_reason` in the Anthropic and OpenAI suites, need live provider credentials and fail the same way on a clean checkout.
- Extended `test_cache_and_reasoning_tokens` and `test_streaming_cache_and_reasoning_tokens` to assert `$ai_cache_reporting_exclusive is False`. These cover the two capture paths separately, so they catch the flag being dropped in the converter, in the streaming merge, or at either tagging site.
- Did not skip the otel suites for any reason related to this change. Their dependencies are not installed in this sandbox.
- Did not run a live Gemini call.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file

<!-- The changeset was hand-written in the same format as existing ones, since sampo is not installed in this sandbox. -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (the PostHog Slack app, running Claude) traced this from a Slack thread on Gemini cost reconciliation, and a PostHog engineer directed the fix. I did not set an assignee because I could not verify their GitHub handle in session.

The flag is set only on generations that actually report cache reads, so generations without caching do not carry an extra property.

Along the way I checked whether the skew came from our own mapping and concluded it does not: `_extract_usage_from_metadata` copies both counts off a single `usage_metadata` object with no arithmetic. I also found a real asymmetry in `merge_usage_stats`, where cumulative mode overwrites `input_tokens` on every chunk but only writes `cache_read_input_tokens` when it is above zero. That lets the two counts come from different chunks on a streaming call. It is not the cause of the case that prompted this PR, which is non-streaming, and I left it alone rather than widening the diff. It looks worth a separate look.

**Public artifact:** no customer or session material reached this PR.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C087XQ7K9K7/p1786121664214699?thread_ts=1786121664.214699&cid=C087XQ7K9K7)*
