### PR TITLE
ci: remove PostHog upgrade automerge step

### DIFF
--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -119,13 +119,6 @@ jobs:
         run: |
           echo "PostHog pull request for $PACKAGE_NAME version $PACKAGE_VERSION ready: $PR_URL"
 
-      - name: Enable automerge
-        env:
-          GH_TOKEN: ${{ steps.upgrader.outputs.token }}
-          PR_NUMBER: ${{ steps.main-repo-pr.outputs.pull-request-number }}
-        run: |
-          gh pr merge "$PR_NUMBER" --repo PostHog/posthog --auto --squash
-
       - name: Assign reviewers
         env:
           GH_TOKEN: ${{ steps.upgrader.outputs.token }}


### PR DESCRIPTION
## :bulb: Motivation and Context

The PostHog upgrade workflow creates a dependency update pull request in `PostHog/posthog`, then fails while enabling auto-merge because that repository does not allow it. This failure also prevents the workflow from assigning reviewers. See [the failed workflow job](https://github.com/PostHog/posthog-python/actions/runs/31715796322/job/94500073881).

This removes the auto-merge step. The workflow will leave the created pull request open for review and continue to assign the configured reviewer teams.

## :green_heart: How did you test it?

- Ran `actionlint .github/workflows/posthog-upgrade.yml`.
- Parsed the workflow with Ruby's YAML parser.
- Ran `git diff --check`.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi coding agent inspected the failed GitHub Actions job and made the requested workflow-only change. The auto-merge command was removed because `PostHog/posthog` has auto-merge disabled. No SDK code or release behavior changed.
