### PR TITLE
fix: Honor a default_cache_ttl_seconds of 0 in Prompts

### DIFF
--- a/.sampo/changesets/gallant-queen-vainamoinen.md
+++ b/.sampo/changesets/gallant-queen-vainamoinen.md
@@ -1,0 +1,5 @@
+---
+pypi/posthog: patch
+---
+
+Honor `default_cache_ttl_seconds=0` in AI prompts so callers can disable default prompt caching.

--- a/posthog/ai/prompts.py
+++ b/posthog/ai/prompts.py
@@ -173,7 +173,9 @@ class Prompts:
                 failures are reported to PostHog error tracking via capture_exception().
         """
         self._default_cache_ttl_seconds = (
-            default_cache_ttl_seconds or DEFAULT_CACHE_TTL_SECONDS
+            default_cache_ttl_seconds
+            if default_cache_ttl_seconds is not None
+            else DEFAULT_CACHE_TTL_SECONDS
         )
         self._cache: Dict[PromptCacheKey, CachedPrompt] = {}
         self._has_warned_deprecation = False

--- a/posthog/test/ai/test_prompts.py
+++ b/posthog/test/ai/test_prompts.py
@@ -513,6 +513,26 @@ class TestPromptsGet(TestPrompts):
         self.assertEqual(mock_get.call_count, 2)
 
     @patch("posthog.ai.prompts._get_session")
+    @patch("posthog.ai.prompts.time.time")
+    def test_default_cache_ttl_seconds_zero_disables_caching(
+        self, mock_time, mock_get_session
+    ):
+        """A default TTL of 0 should disable caching, matching the per-call option."""
+        mock_get = mock_get_session.return_value.get
+        mock_get.return_value = MockResponse(json_data=self.mock_prompt_response)
+        mock_time.return_value = 1000.0
+
+        posthog = self.create_mock_posthog()
+        prompts = Prompts(posthog, default_cache_ttl_seconds=0)
+
+        prompts.get("test-prompt", with_metadata=False)
+        self.assertEqual(mock_get.call_count, 1)
+
+        # No time has passed, and a TTL of 0 still means every read refetches.
+        prompts.get("test-prompt", with_metadata=False)
+        self.assertEqual(mock_get.call_count, 2)
+
+    @patch("posthog.ai.prompts._get_session")
     def test_url_encode_prompt_names_with_special_characters(self, mock_get_session):
         """Should URL-encode prompt names with special characters."""
         mock_get = mock_get_session.return_value.get


### PR DESCRIPTION
--- LETTER BELOW THIS LINE ---
`Prompts.__init__` resolves the default cache TTL with `default_cache_ttl_seconds or DEFAULT_CACHE_TTL_SECONDS`, so passing `0` is treated as if nothing was passed and the value becomes 300.

`0` is a meaningful setting here, and the same class already honors it on the other path. `_get_internal` resolves the per-call TTL with `cache_ttl_seconds if cache_ttl_seconds is not None else ...`, and `is_fresh = (now - fetched_at) < ttl` with `ttl=0` means "never serve from cache". So the per-call option lets you disable caching with `0` while the constructor default silently cannot.

Measured against the library, with no network: `Prompts(default_cache_ttl_seconds=0)` reports a TTL of 300. Counting fetch attempts against a seeded cache, the constructor `0` serves from cache (0 fetches) identically to passing no TTL at all, while the per-call `get(cache_ttl_seconds=0)` correctly refetches.

The fix matches the per-call form, +3/-1:

```python
self._default_cache_ttl_seconds = (
    default_cache_ttl_seconds
    if default_cache_ttl_seconds is not None
    else DEFAULT_CACHE_TTL_SECONDS
)
```

I added a regression test that fails on the current code (`AssertionError: 1 != 2`) and passes with the fix. The existing suite is 68 passing before and 69 after, so this path was never covered. They test a TTL of 60. Never 0. `None` still yields 300 and default behavior does not change.

I did not run against a live PostHog instance, so all measurements use the repo's mocked session or a seeded cache.
