### PR TITLE
chore: add changeset for capture_trace_context

### DIFF
--- a/.sampo/changesets/eager-wayfarer-ahti.md
+++ b/.sampo/changesets/eager-wayfarer-ahti.md
@@ -1,0 +1,5 @@
+---
+pypi/posthog: minor
+---
+
+Add an opt-in `capture_trace_context` client option. When enabled, and a valid OpenTelemetry span is active at capture time, its trace and span IDs are attached to events captured with `capture()` and `capture_ai()` as `$trace_id` and `$span_id`, so they can be correlated with backend traces. Disabled by default, and explicit `$trace_id`/`$span_id` properties take precedence.


### PR DESCRIPTION
## :bulb: Motivation and Context

[#894](https://github.com/PostHog/posthog-python/pull/894) merged without a changeset, so `.sampo/changesets/` is empty and `capture_trace_context` won't be picked up by a release. This adds the missing changeset so the option actually ships.

`minor`, since it adds a new (opt-in, default-off) client option.

## :green_heart: How did you test it?

Changeset-only change, no code. Format and package key (`pypi/posthog`) match the changesets consumed by the v7.43.0 and v7.43.1 releases, and the file is in `.sampo/changesets/` as `RELEASING.md` requires.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes. — N/A, no code change
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file — hand-written in the same format (`sampo` CLI unavailable in this environment)

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Built with Claude Code (PostHog Desktop). Follow-up to #894 after it was pointed out that the merge carried no changeset.
- Bump choice: `minor` rather than `patch` — new public constructor option, backwards compatible. Matches the precedent of `gallant-princess-kalma.md` (minor for an added/changed behavior) over `bold-firebringer-erika.md` (patch for a bug fix).

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
