### PR TITLE
fix(langchain): record tool span input as structured data

### DIFF
--- a/.sampo/changesets/langchain-tool-span-structured-input.md
+++ b/.sampo/changesets/langchain-tool-span-structured-input.md
@@ -1,0 +1,5 @@
+---
+pypi/posthog: patch
+---
+
+Capture LangChain tool inputs on `$ai_span` as structured data rather than a Python `repr` string. `BaseTool.run`/`arun` pass the tool input to `on_tool_start` twice — positionally as `str(tool_input)`, and as the original dict under the `inputs` keyword. The handler was storing the positional value, so a dict input landed in `$ai_input_state` as `{'query': 'SELECT 1'}` (single quotes), which no JSON parser can read: `JSONExtract*` in ClickHouse returns empty, and any downstream consumer has to fall back to substring matching. Tool spans now record the `inputs` dict when LangChain supplies one, matching what `on_chain_start` already does; tools invoked with a plain string are unchanged.

--- a/posthog/ai/langchain/callbacks.py
+++ b/posthog/ai/langchain/callbacks.py
@@ -283,8 +283,15 @@ class CallbackHandler(BaseCallbackHandler):
             "on_tool_start", run_id, parent_run_id, input_str=input_str
         )
         self._set_parent_of_run(run_id, parent_run_id)
+        # LangChain hands us the tool input twice: `input_str` is `str(tool_input)`, which
+        # renders a dict as a Python repr (single quotes) rather than JSON, and the `inputs`
+        # kwarg carries the original dict. Prefer the structured value so `$ai_input_state`
+        # stays machine-readable and consistent with `on_chain_start`; tools invoked with a
+        # plain string have no `inputs` and keep using `input_str`.
+        inputs = kwargs.get("inputs")
+        tool_input = inputs if isinstance(inputs, dict) else input_str
         self._set_trace_or_span_metadata(
-            serialized, input_str, run_id, parent_run_id, **kwargs
+            serialized, tool_input, run_id, parent_run_id, **kwargs
         )
 
     def on_tool_end(

--- a/posthog/test/ai/langchain/test_callbacks.py
+++ b/posthog/test/ai/langchain/test_callbacks.py
@@ -2442,6 +2442,48 @@ def test_agent_action_and_finish_imports():
     assert call_args["event"] == "$ai_span"
 
 
+def test_tool_span_input_state_prefers_structured_inputs(mock_client):
+    """A dict tool input is captured as a dict, not LangChain's `str(tool_input)` repr."""
+    callbacks = CallbackHandler(mock_client)
+    run_id = uuid.uuid4()
+    parent_run_id = uuid.uuid4()
+    tool_input = {"query": "SELECT 1", "truncate": True}
+
+    # Mirrors how langchain_core's BaseTool.run/arun calls on_tool_start: the positional
+    # argument is str(tool_input), while the original dict comes through `inputs`.
+    callbacks.on_tool_start(
+        {"name": "execute_sql"},
+        str(tool_input),
+        run_id=run_id,
+        parent_run_id=parent_run_id,
+        inputs=tool_input,
+    )
+    callbacks.on_tool_end("1", run_id=run_id, parent_run_id=parent_run_id)
+
+    props = mock_client.capture.call_args[1]["properties"]
+    assert props["$ai_input_state"] == tool_input
+
+
+def test_tool_span_input_state_falls_back_to_string(mock_client):
+    """A tool invoked with a plain string still records that string."""
+    callbacks = CallbackHandler(mock_client)
+    run_id = uuid.uuid4()
+    parent_run_id = uuid.uuid4()
+
+    # langchain_core passes inputs=None when tool_input isn't a dict.
+    callbacks.on_tool_start(
+        {"name": "get_weather"},
+        "sf",
+        run_id=run_id,
+        parent_run_id=parent_run_id,
+        inputs=None,
+    )
+    callbacks.on_tool_end("sunny", run_id=run_id, parent_run_id=parent_run_id)
+
+    props = mock_client.capture.call_args[1]["properties"]
+    assert props["$ai_input_state"] == "sf"
+
+
 def test_posthog_properties_field_in_generation_metadata(mock_client):
     """Test that posthog_properties is properly stored in GenerationMetadata."""
     callbacks = CallbackHandler(mock_client)


### PR DESCRIPTION
## :bulb: Motivation and Context

LangChain's `BaseTool.run`/`arun` hand the tool input to `on_tool_start` twice: positionally as `str(tool_input)`, and as the original dict under the `inputs` keyword ([`langchain_core/tools/base.py`](https://github.com/langchain-ai/langchain/blob/master/libs/core/langchain_core/tools/base.py) lines 838/846 and 949/957). `CallbackHandler.on_tool_start` stored the positional one, so a dict tool input landed in `$ai_input_state` as a Python repr:

```
{'query': 'SELECT 1', 'truncate': True}
```

Single quotes, `True` instead of `true` — no JSON parser reads that. In ClickHouse `JSONExtract*` returns empty against the `input_state` column, so anything consuming tool spans has to fall back to substring matching on the raw text, and any analysis that assumed valid JSON silently returns zero rows rather than failing loudly.

`on_chain_start` already stores the real `inputs` dict, so chain spans were fine and only tool spans were affected — which made the gap easy to miss.

This prefers the structured `inputs` dict when LangChain supplies one. Tools invoked with a plain string have no `inputs` and keep recording the string unchanged.

## :green_heart: How did you test it?

Two unit tests driving `on_tool_start`/`on_tool_end` the way `BaseTool.arun` does — one asserting a dict input is recorded as a dict, one asserting a string input still records the string.

`uv run --extra test python -m pytest posthog/test/ai/langchain/test_callbacks.py` — 77 passed, 7 failed. The same 7 fail on an unmodified `main` in this environment (they need `OPENAI_API_KEY`/`ANTHROPIC_API_KEY` and network), so no regressions from this change.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found while investigating whether MCP and Max agents lean on raw SQL where a typed query runner would do. Measuring that needs the query text off the tool span, and every `JSONExtract` against `input_state` came back empty for Max's `execute_sql` spans while the MCP path's spans parsed fine — which is what led back to this handler.

Root-causing went one layer at a time: ruled out the server-side truncation hook in the main repo (it only caps strings that are already strings, and uses `json.dumps` on its one stringifying path), then the SDK's `capture` plumbing (passes properties through untouched), before landing on the positional-vs-keyword argument in `on_tool_start`. The `str()` itself happens in `langchain-core` and can't be changed here; taking the `inputs` kwarg it already passes alongside is the fix on our side.

Considered normalizing the value at query time instead and rejected it — that leaves every existing and future consumer parsing Python repr, and the correct value is already being handed to us.

Note this changes the *shape* of `$ai_input_state` for tool spans from a string to an object. That matches chain spans and is the intended fix, but anyone who built around the repr string will see the type change.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/D0BR0GL23RP/p1788177040639829?thread_ts=1788177040.639829&cid=D0BR0GL23RP)*
