### PR TITLE
fix: notify Slack when a release is rejected at the approval gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -545,12 +545,16 @@ jobs:
           REJECTED=$(echo "$RESPONSE" | jq '[.[] | select(.state == "rejected")] | length')
           if [ "$REJECTED" -gt 0 ]; then
             echo "was_rejected=true" >> "$GITHUB_OUTPUT"
-            COMMENT=$(echo "$RESPONSE" | jq -r '.[] | select(.state == "rejected") | .comment // empty' | head -1)
+            COMMENT=$(echo "$RESPONSE" | jq -r 'first(.[] | select(.state == "rejected") | .comment // empty)')
             if [ -n "$COMMENT" ]; then
+              # Random delimiter: a rejection comment is reviewer-controlled text, and a
+              # literal delimiter line inside it would close the block early and let the
+              # rest be parsed as step outputs.
+              DELIMITER="EOF_$(openssl rand -hex 16)"
               {
-                echo 'message<<EOF'
+                echo "message<<$DELIMITER"
                 echo "🚫 Release was rejected: $COMMENT"
-                echo 'EOF'
+                echo "$DELIMITER"
               } >> "$GITHUB_OUTPUT"
             else
               echo "message=🚫 Release was rejected." >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -527,3 +527,44 @@ jobs:
           thread_ts: ${{ needs.notify-approval-needed.outputs.slack_ts }}
           message: "🚀 posthog-python released successfully!"
           emoji_reaction: "rocket"
+
+  notify-rejected:
+    name: Notify Slack - Rejected
+    needs: [version-bump, notify-approval-needed]
+    runs-on: ubuntu-latest
+    if: always() && needs.version-bump.result == 'failure' && needs.notify-approval-needed.outputs.slack_ts != ''
+    permissions:
+      actions: read
+    steps:
+      - name: Check for rejection
+        id: check-rejection
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          RESPONSE=$(gh api /repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/approvals)
+          REJECTED=$(echo "$RESPONSE" | jq '[.[] | select(.state == "rejected")] | length')
+          if [ "$REJECTED" -gt 0 ]; then
+            echo "was_rejected=true" >> "$GITHUB_OUTPUT"
+            COMMENT=$(echo "$RESPONSE" | jq -r '.[] | select(.state == "rejected") | .comment // empty' | head -1)
+            if [ -n "$COMMENT" ]; then
+              {
+                echo 'message<<EOF'
+                echo "🚫 Release was rejected: $COMMENT"
+                echo 'EOF'
+              } >> "$GITHUB_OUTPUT"
+            else
+              echo "message=🚫 Release was rejected." >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "was_rejected=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Notify Slack - Rejected
+        if: steps.check-rejection.outputs.was_rejected == 'true'
+        uses: posthog/.github/.github/actions/slack-thread-reply@cb0979b67dcd585828b61ac45927eef4da8f6287 # main
+        with:
+          slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
+          slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
+          thread_ts: ${{ needs.notify-approval-needed.outputs.slack_ts }}
+          message: "${{ steps.check-rejection.outputs.message }}"
+          emoji_reaction: "no_entry_sign"


### PR DESCRIPTION
## :bulb: Motivation and Context

[Release run 33497521635](https://github.com/PostHog/posthog-python/actions/runs/33497521635) was rejected at the "Release" environment gate and nothing was posted to Slack. `release.yml` notifies on approval needed, approved, failed and released, but there is no job for a rejection, so the thread just goes quiet and nobody watching it knows the release was turned down.

This ports the `notify-rejected` job that every other PostHog SDK already has (ruby, ios, android, js, go, php, dotnet), adapted to this repo. It hangs off `version-bump` (the job carrying `environment: "Release"` here), reads the run's `/approvals` to confirm it was an actual rejection rather than an ordinary failure, and replies in the existing Slack thread with the reviewer's comment when there is one.

Two deliberate differences from the reference files:

- They pin `slack-thread-reply` to `@main`. This repo pins it to a SHA, so the new job reuses the SHA the other four Slack steps here already use.
- Added `permissions: actions: read` on the job, which the siblings do not have. The workflow sets `contents: read` at the top level, so without it the `GITHUB_TOKEN` carries no `actions` scope, the `gh api .../approvals` call 403s, and the job fails with the rejection still silent. Probably worth backporting to the other SDKs.

## :green_heart: How did you test it?

There is no way to exercise this end to end without rejecting a real release, so I verified the logic against the run that prompted it, 33497521635:

- `Bump versions and commit to main` concluded `failure`, so the job's `if` gate fires.
- `GET /actions/runs/33497521635/approvals` returns `{"state": "rejected", "comment": "", "user": "ioannisj"}`, so the check step sets `was_rejected=true`, and with an empty comment it takes the branch that posts the plain "Release was rejected." message.
- No double post. `version-bump`'s own "Notify Slack - Failed" step never runs when the gate rejects, because none of that job's steps execute at all.

I also parsed the workflow and confirmed every `needs.<job>` reference resolves to a job that exists in the file. `actionlint` is not installed locally, so that check did not run.

Two follow-up fixes after review, both in d6087af:

- `head -1` truncated a multiline rejection comment to its first line. It was there to pick the first rejecting reviewer, not the first line, so it moved into jq as `first(...)`. Worth noting the heredoc below it exists only to carry a multiline value, so with `head -1` in front the block could never do anything.
- The heredoc now uses a random delimiter. Now that multiline comments actually reach it, a comment containing a literal `EOF` line would close the block early and the rest would be parsed as step outputs.

Verified both by running the step body against five payloads: multiline comment, empty comment (the path the real run took), approved-only, two rejecters, and a comment containing a literal `EOF` line. The last one now lands as message content instead of setting a separate output key.

All seven sibling SDKs carry the same `head -1` and fixed `EOF` delimiter, so both fixes want backporting.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file

CI-only change with nothing to release, so no changeset.

## 🤖 Agent context

**DRI:** @ioannisj
**Autonomy:** Human-driven (agent-assisted)
