### PR TITLE
fix(ai): only capture terminal, named Responses stop reasons

### DIFF
--- a/.sampo/changesets/responses-terminal-stop-reason.md
+++ b/.sampo/changesets/responses-terminal-stop-reason.md
@@ -1,0 +1,5 @@
+---
+pypi/posthog: patch
+---
+
+Only terminal Responses API statuses become `$ai_stop_reason`: a queued or in-progress background run no longer records a lifecycle state as its stop reason, and an incomplete run is named by what cut it short (`incomplete_details.reason`, e.g. `max_output_tokens`). Streaming runs that end incomplete or failed now carry a stop reason too, and the LangChain callback reads stop reasons from `response_metadata` as well, covering Responses API and Anthropic runs that previously recorded none.

--- a/posthog/ai/langchain/callbacks.py
+++ b/posthog/ai/langchain/callbacks.py
@@ -48,6 +48,7 @@ from posthog.ai.utils import (
     _extract_cache_creation_ttl_breakdown,
     finalize_ai_content,
     get_model_params,
+    _responses_stop_reason,
     with_privacy_mode,
 )
 from posthog.client import Client
@@ -716,14 +717,11 @@ class CallbackHandler(BaseCallbackHandler):
                 finalize_ai_content(completions, self._ph_client),
             )
 
-            # Extract stop reason from generation info
+            # Extract the stop reason from the generation and its metadata
             if output.generations and output.generations[-1]:
-                last_gen = output.generations[-1][-1]
-                gen_info = getattr(last_gen, "generation_info", None)
-                if isinstance(gen_info, dict):
-                    finish_reason = gen_info.get("finish_reason")
-                    if finish_reason is not None:
-                        event_properties["$ai_stop_reason"] = finish_reason
+                stop_reason = _extract_stop_reason(output.generations[-1][-1])
+                if stop_reason is not None:
+                    event_properties["$ai_stop_reason"] = stop_reason
 
         _capture_ai_event(
             self._ph_client,
@@ -743,6 +741,43 @@ class CallbackHandler(BaseCallbackHandler):
         log.debug(
             f"Event: {event_name}, run_id: {str(run_id)[:5]}, parent_run_id: {str(parent_run_id)[:5]}, kwargs: {kwargs}"
         )
+
+
+def _extract_stop_reason(generation: Any) -> Optional[str]:
+    """
+    Providers spread the stop reason across `generation_info` and
+    `response_metadata` under two spellings, so read every source in priority
+    order. The Responses API reports no finish_reason at all: an incomplete
+    run is named by what cut it short, and only terminal statuses count.
+    """
+    message = getattr(generation, "message", None)
+    message_metadata = getattr(message, "response_metadata", None)
+    if not isinstance(message_metadata, dict):
+        message_metadata = None
+    generation_info = getattr(generation, "generation_info", None)
+    if not isinstance(generation_info, dict):
+        generation_info = None
+    generation_metadata = (
+        generation_info.get("response_metadata") if generation_info else None
+    )
+    if not isinstance(generation_metadata, dict):
+        generation_metadata = None
+
+    for source, key in (
+        (message_metadata, "finish_reason"),
+        (message_metadata, "stop_reason"),
+        (generation_info, "finish_reason"),
+        (generation_metadata, "stop_reason"),
+        (generation_metadata, "finish_reason"),
+        (generation_info, "stop_reason"),
+    ):
+        value = source.get(key) if source else None
+        if value is not None:
+            return str(value)
+
+    return _responses_stop_reason(message_metadata) or _responses_stop_reason(
+        generation_metadata
+    )
 
 
 def _extract_raw_response(last_response):

--- a/posthog/ai/langchain/callbacks.py
+++ b/posthog/ai/langchain/callbacks.py
@@ -750,34 +750,28 @@ def _extract_stop_reason(generation: Any) -> Optional[str]:
     order. The Responses API reports no finish_reason at all: an incomplete
     run is named by what cut it short, and only terminal statuses count.
     """
-    message = getattr(generation, "message", None)
-    message_metadata = getattr(message, "response_metadata", None)
-    if not isinstance(message_metadata, dict):
-        message_metadata = None
-    generation_info = getattr(generation, "generation_info", None)
-    if not isinstance(generation_info, dict):
-        generation_info = None
-    generation_metadata = (
-        generation_info.get("response_metadata") if generation_info else None
+
+    def as_dict(value: Any) -> dict:
+        return value if isinstance(value, dict) else {}
+
+    message = as_dict(
+        getattr(getattr(generation, "message", None), "response_metadata", None)
     )
-    if not isinstance(generation_metadata, dict):
-        generation_metadata = None
+    info = as_dict(getattr(generation, "generation_info", None))
+    nested = as_dict(info.get("response_metadata"))
 
     for source, key in (
-        (message_metadata, "finish_reason"),
-        (message_metadata, "stop_reason"),
-        (generation_info, "finish_reason"),
-        (generation_metadata, "stop_reason"),
-        (generation_metadata, "finish_reason"),
-        (generation_info, "stop_reason"),
+        (message, "finish_reason"),
+        (message, "stop_reason"),
+        (info, "finish_reason"),
+        (nested, "stop_reason"),
+        (nested, "finish_reason"),
+        (info, "stop_reason"),
     ):
-        value = source.get(key) if source else None
-        if value is not None:
-            return str(value)
+        if source.get(key) is not None:
+            return str(source[key])
 
-    return _responses_stop_reason(message_metadata) or _responses_stop_reason(
-        generation_metadata
-    )
+    return _responses_stop_reason(message) or _responses_stop_reason(nested)
 
 
 def _extract_raw_response(last_response):

--- a/posthog/ai/langchain/callbacks.py
+++ b/posthog/ai/langchain/callbacks.py
@@ -745,33 +745,20 @@ class CallbackHandler(BaseCallbackHandler):
 
 def _extract_stop_reason(generation: Any) -> Optional[str]:
     """
-    Providers spread the stop reason across `generation_info` and
-    `response_metadata` under two spellings, so read every source in priority
-    order. The Responses API reports no finish_reason at all: an incomplete
-    run is named by what cut it short, and only terminal statuses count.
+    Providers report the stop reason on the message's `response_metadata` or in
+    `generation_info`, under either spelling. The Responses API reports no
+    finish reason at all, so a terminal status stands in for one.
     """
+    metadata = getattr(getattr(generation, "message", None), "response_metadata", None)
+    info = getattr(generation, "generation_info", None)
 
-    def as_dict(value: Any) -> dict:
-        return value if isinstance(value, dict) else {}
+    for source in (metadata, info):
+        for key in ("finish_reason", "stop_reason"):
+            value = source.get(key) if isinstance(source, dict) else None
+            if value is not None:
+                return str(value)
 
-    message = as_dict(
-        getattr(getattr(generation, "message", None), "response_metadata", None)
-    )
-    info = as_dict(getattr(generation, "generation_info", None))
-    nested = as_dict(info.get("response_metadata"))
-
-    for source, key in (
-        (message, "finish_reason"),
-        (message, "stop_reason"),
-        (info, "finish_reason"),
-        (nested, "stop_reason"),
-        (nested, "finish_reason"),
-        (info, "stop_reason"),
-    ):
-        if source.get(key) is not None:
-            return str(source[key])
-
-    return _responses_stop_reason(message) or _responses_stop_reason(nested)
+    return _responses_stop_reason(metadata)
 
 
 def _extract_raw_response(last_response):

--- a/posthog/ai/openai/_streaming.py
+++ b/posthog/ai/openai/_streaming.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
 from ..types import StreamingEventData, TokenUsage
-from ..utils import merge_usage_stats
+from ..utils import merge_usage_stats, _responses_stop_reason
 from .openai_converter import (
     accumulate_openai_tool_calls,
     extract_openai_content_from_chunk,
@@ -38,10 +38,12 @@ class _ResponsesStreamState:
         if content is not None:
             self.output.extend(content)
 
-        if getattr(chunk, "type", None) == "response.completed" and response:
-            status = getattr(response, "status", None)
-            if status is not None:
-                self.stop_reason = status
+        # A stream can end on response.completed, response.incomplete, or
+        # response.failed; any terminal response names the stop reason.
+        if response:
+            stop_reason = _responses_stop_reason(response)
+            if stop_reason is not None:
+                self.stop_reason = stop_reason
 
 
 @dataclass

--- a/posthog/ai/openai/openai_converter.py
+++ b/posthog/ai/openai/openai_converter.py
@@ -17,7 +17,7 @@ from posthog.ai.types import (
     FormattedTextContent,
     TokenUsage,
 )
-from posthog.ai.utils import serialize_raw_usage
+from posthog.ai.utils import _responses_stop_reason, serialize_raw_usage
 
 
 def _item_attr(item: Any, name: str, default: Any = None) -> Any:
@@ -445,7 +445,7 @@ def extract_openai_stop_reason(response: Any) -> Optional[str]:
         return getattr(response.choices[0], "finish_reason", None)
     # Responses API
     if hasattr(response, "status"):
-        return getattr(response, "status", None)
+        return _responses_stop_reason(response)
     return None
 
 

--- a/posthog/ai/utils.py
+++ b/posthog/ai/utils.py
@@ -319,6 +319,42 @@ def format_response(response, provider: str):
     return []
 
 
+# A Responses API run is only finished on these statuses; `queued` and
+# `in_progress` are lifecycle states a background run passes through.
+_TERMINAL_RESPONSE_STATUSES = frozenset(
+    {"completed", "failed", "cancelled", "incomplete"}
+)
+
+
+def _read_response_field(source: Any, key: str) -> Any:
+    if isinstance(source, dict):
+        return source.get(key)
+    return getattr(source, key, None)
+
+
+def _responses_stop_reason(response: Any) -> Optional[str]:
+    """
+    Map a Responses API outcome to a `$ai_stop_reason`: an incomplete run is
+    named by what cut it short (`incomplete_details.reason`, e.g.
+    `max_output_tokens`), the other terminal statuses stand for themselves,
+    and a non-terminal status yields None. Accepts an SDK response object or
+    a LangChain `response_metadata` dict.
+    """
+    if response is None:
+        return None
+    status = _read_response_field(response, "status")
+    if not isinstance(status, str) or status not in _TERMINAL_RESPONSE_STATUSES:
+        return None
+    if status == "incomplete":
+        details = _read_response_field(response, "incomplete_details")
+        reason = (
+            _read_response_field(details, "reason") if details is not None else None
+        )
+        if isinstance(reason, str) and reason:
+            return reason
+    return status
+
+
 def extract_stop_reason(response: Any, provider: str) -> Optional[str]:
     """Extract stop reason from response based on provider."""
     if provider == "openai":

--- a/posthog/ai/utils.py
+++ b/posthog/ai/utils.py
@@ -327,9 +327,7 @@ _TERMINAL_RESPONSE_STATUSES = frozenset(
 
 
 def _read_response_field(source: Any, key: str) -> Any:
-    if isinstance(source, dict):
-        return source.get(key)
-    return getattr(source, key, None)
+    return source.get(key) if isinstance(source, dict) else getattr(source, key, None)
 
 
 def _responses_stop_reason(response: Any) -> Optional[str]:
@@ -340,18 +338,13 @@ def _responses_stop_reason(response: Any) -> Optional[str]:
     and a non-terminal status yields None. Accepts an SDK response object or
     a LangChain `response_metadata` dict.
     """
-    if response is None:
-        return None
     status = _read_response_field(response, "status")
     if not isinstance(status, str) or status not in _TERMINAL_RESPONSE_STATUSES:
         return None
-    if status == "incomplete":
-        details = _read_response_field(response, "incomplete_details")
-        reason = (
-            _read_response_field(details, "reason") if details is not None else None
-        )
-        if isinstance(reason, str) and reason:
-            return reason
+    details = _read_response_field(response, "incomplete_details")
+    reason = _read_response_field(details, "reason")
+    if status == "incomplete" and isinstance(reason, str) and reason:
+        return reason
     return status
 
 

--- a/posthog/test/ai/langchain/test_callbacks.py
+++ b/posthog/test/ai/langchain/test_callbacks.py
@@ -2918,7 +2918,4 @@ def test_stop_reason_resolution(
     cb._pop_run_and_capture_generation(run_id, None, response)
 
     props = mock_client.capture.call_args.kwargs["properties"]
-    if expected is None:
-        assert "$ai_stop_reason" not in props
-    else:
-        assert props["$ai_stop_reason"] == expected
+    assert props.get("$ai_stop_reason") == expected

--- a/posthog/test/ai/langchain/test_callbacks.py
+++ b/posthog/test/ai/langchain/test_callbacks.py
@@ -2864,3 +2864,61 @@ def test_served_service_tier_merges_into_model_parameters(mock_client):
     props = mock_client.capture.call_args.kwargs["properties"]
     assert props["$ai_model_parameters"]["service_tier"] == "flex"
     assert props["$ai_model_parameters"]["temperature"] == 0.5
+
+
+@pytest.mark.parametrize(
+    "generation_info,response_metadata,expected",
+    [
+        # generation_info finish_reason keeps priority
+        ({"finish_reason": "stop"}, {"status": "completed"}, "stop"),
+        # Responses API: a terminal status carries no finish_reason at all
+        (None, {"status": "completed", "incomplete_details": None}, "completed"),
+        # ... an incomplete run is named by what cut it short
+        (
+            None,
+            {
+                "status": "incomplete",
+                "incomplete_details": {"reason": "max_output_tokens"},
+            },
+            "max_output_tokens",
+        ),
+        # a queued background run has no stop reason yet
+        (None, {"status": "queued", "incomplete_details": None}, None),
+        # Anthropic reports through response_metadata.stop_reason
+        (None, {"stop_reason": "end_turn"}, "end_turn"),
+    ],
+)
+def test_stop_reason_resolution(
+    mock_client, generation_info, response_metadata, expected
+):
+    from langchain_core.outputs import ChatGeneration, LLMResult
+
+    cb = CallbackHandler(mock_client)
+    run_id = uuid.uuid4()
+    cb._set_llm_metadata(
+        serialized={},
+        run_id=run_id,
+        messages=[{"role": "user", "content": "test"}],
+        metadata={"ls_provider": "openai", "ls_model_name": "gpt-4o"},
+    )
+    response = LLMResult(
+        generations=[
+            [
+                ChatGeneration(
+                    message=AIMessage(
+                        content="Response", response_metadata=response_metadata
+                    ),
+                    generation_info=generation_info,
+                )
+            ]
+        ],
+        llm_output={},
+    )
+
+    cb._pop_run_and_capture_generation(run_id, None, response)
+
+    props = mock_client.capture.call_args.kwargs["properties"]
+    if expected is None:
+        assert "$ai_stop_reason" not in props
+    else:
+        assert props["$ai_stop_reason"] == expected

--- a/posthog/test/ai/openai/test_openai_converter.py
+++ b/posthog/test/ai/openai/test_openai_converter.py
@@ -1,3 +1,5 @@
+import types
+
 import pytest
 
 try:
@@ -7,7 +9,11 @@ try:
 except ImportError:
     OPENAI_AVAILABLE = False
 
-from posthog.ai.openai.openai_converter import format_openai_input
+from posthog.ai.openai._streaming import _ResponsesStreamState
+from posthog.ai.openai.openai_converter import (
+    extract_openai_stop_reason,
+    format_openai_input,
+)
 from posthog.test.ai.utils import make_response_usage
 
 pytestmark = pytest.mark.skipif(not OPENAI_AVAILABLE, reason="openai not available")
@@ -200,6 +206,13 @@ def test_chat_streaming_audio_and_refusal_deltas():
     assert refusal_block["refusal"] == "I can't help with that"
 
 
+def _response(status, incomplete_reason=None, **extra):
+    details = (
+        types.SimpleNamespace(reason=incomplete_reason) if incomplete_reason else None
+    )
+    return types.SimpleNamespace(status=status, incomplete_details=details, **extra)
+
+
 @pytest.mark.parametrize(
     "status,incomplete_reason,expected",
     [
@@ -218,63 +231,29 @@ def test_chat_streaming_audio_and_refusal_deltas():
 def test_extract_stop_reason_maps_responses_statuses(
     status, incomplete_reason, expected
 ):
-    import types
-
-    from posthog.ai.openai.openai_converter import extract_openai_stop_reason
-
-    details = (
-        types.SimpleNamespace(reason=incomplete_reason) if incomplete_reason else None
-    )
-    response = types.SimpleNamespace(status=status, incomplete_details=details)
-
-    assert extract_openai_stop_reason(response) == expected
+    assert extract_openai_stop_reason(_response(status, incomplete_reason)) == expected
 
 
-def test_extract_stop_reason_keeps_chat_completions_passthrough():
-    import types
-
-    from posthog.ai.openai.openai_converter import extract_openai_stop_reason
-
-    response = types.SimpleNamespace(
-        choices=[types.SimpleNamespace(finish_reason="stop")]
-    )
-
-    assert extract_openai_stop_reason(response) == "stop"
-
-
-def _lifecycle_chunk(chunk_type, status, incomplete_reason=None):
-    import types
-
-    details = (
-        types.SimpleNamespace(reason=incomplete_reason) if incomplete_reason else None
-    )
-    return types.SimpleNamespace(
-        type=chunk_type,
-        response=types.SimpleNamespace(
-            model="gpt-4o",
-            usage=None,
-            output=[],
-            status=status,
-            incomplete_details=details,
-        ),
-    )
-
-
-def test_responses_stream_records_stop_reason_for_every_terminal_event():
-    from posthog.ai.openai._streaming import _ResponsesStreamState
-
+@pytest.mark.parametrize(
+    "status,incomplete_reason,expected",
+    [
+        ("completed", None, "completed"),
+        ("incomplete", "max_output_tokens", "max_output_tokens"),
+        ("failed", None, "failed"),
+        ("in_progress", None, None),
+    ],
+)
+def test_responses_stream_records_every_terminal_stop_reason(
+    status, incomplete_reason, expected
+):
     state = _ResponsesStreamState()
-    state.process_chunk(_lifecycle_chunk("response.in_progress", "in_progress"))
-    assert state.stop_reason is None
     state.process_chunk(
-        _lifecycle_chunk("response.incomplete", "incomplete", "max_output_tokens")
+        types.SimpleNamespace(
+            type=f"response.{status}",
+            response=_response(
+                status, incomplete_reason, model="gpt-4o", usage=None, output=[]
+            ),
+        )
     )
-    assert state.stop_reason == "max_output_tokens"
 
-    failed = _ResponsesStreamState()
-    failed.process_chunk(_lifecycle_chunk("response.failed", "failed"))
-    assert failed.stop_reason == "failed"
-
-    completed = _ResponsesStreamState()
-    completed.process_chunk(_lifecycle_chunk("response.completed", "completed"))
-    assert completed.stop_reason == "completed"
+    assert state.stop_reason == expected

--- a/posthog/test/ai/openai/test_openai_converter.py
+++ b/posthog/test/ai/openai/test_openai_converter.py
@@ -198,3 +198,83 @@ def test_chat_streaming_audio_and_refusal_deltas():
 
     refusal_block = next(b for b in content if b["type"] == "refusal")
     assert refusal_block["refusal"] == "I can't help with that"
+
+
+@pytest.mark.parametrize(
+    "status,incomplete_reason,expected",
+    [
+        # Terminal statuses stand for themselves
+        ("completed", None, "completed"),
+        ("failed", None, "failed"),
+        ("cancelled", None, "cancelled"),
+        # An incomplete run is named by what cut it short
+        ("incomplete", "max_output_tokens", "max_output_tokens"),
+        ("incomplete", None, "incomplete"),
+        # Lifecycle states of a background run are not stop reasons
+        ("queued", None, None),
+        ("in_progress", None, None),
+    ],
+)
+def test_extract_stop_reason_maps_responses_statuses(
+    status, incomplete_reason, expected
+):
+    import types
+
+    from posthog.ai.openai.openai_converter import extract_openai_stop_reason
+
+    details = (
+        types.SimpleNamespace(reason=incomplete_reason) if incomplete_reason else None
+    )
+    response = types.SimpleNamespace(status=status, incomplete_details=details)
+
+    assert extract_openai_stop_reason(response) == expected
+
+
+def test_extract_stop_reason_keeps_chat_completions_passthrough():
+    import types
+
+    from posthog.ai.openai.openai_converter import extract_openai_stop_reason
+
+    response = types.SimpleNamespace(
+        choices=[types.SimpleNamespace(finish_reason="stop")]
+    )
+
+    assert extract_openai_stop_reason(response) == "stop"
+
+
+def _lifecycle_chunk(chunk_type, status, incomplete_reason=None):
+    import types
+
+    details = (
+        types.SimpleNamespace(reason=incomplete_reason) if incomplete_reason else None
+    )
+    return types.SimpleNamespace(
+        type=chunk_type,
+        response=types.SimpleNamespace(
+            model="gpt-4o",
+            usage=None,
+            output=[],
+            status=status,
+            incomplete_details=details,
+        ),
+    )
+
+
+def test_responses_stream_records_stop_reason_for_every_terminal_event():
+    from posthog.ai.openai._streaming import _ResponsesStreamState
+
+    state = _ResponsesStreamState()
+    state.process_chunk(_lifecycle_chunk("response.in_progress", "in_progress"))
+    assert state.stop_reason is None
+    state.process_chunk(
+        _lifecycle_chunk("response.incomplete", "incomplete", "max_output_tokens")
+    )
+    assert state.stop_reason == "max_output_tokens"
+
+    failed = _ResponsesStreamState()
+    failed.process_chunk(_lifecycle_chunk("response.failed", "failed"))
+    assert failed.stop_reason == "failed"
+
+    completed = _ResponsesStreamState()
+    completed.process_chunk(_lifecycle_chunk("response.completed", "completed"))
+    assert completed.stop_reason == "completed"


### PR DESCRIPTION
## :bulb: Motivation and Context

The Python SDK records raw Responses API statuses as `$ai_stop_reason`, and none of the three surfaces that do it agree with what the PostHog trace view understands:

- The native OpenAI wrapper returns any status, so a `background: true` run records `queued` — a lifecycle state, not a stop reason — and a truncated run records the bare `incomplete` instead of `max_output_tokens`, which the trace view's truncation notice recognizes.
- The streaming accumulator only reads status on `response.completed`, so streams that end `incomplete` or `failed` record no stop reason at all.
- The LangChain callback reads only `generation_info.finish_reason`, so Responses API and Anthropic runs — which report through `response_metadata` — record nothing.

One shared `_responses_stop_reason` helper now does the mapping: non-terminal statuses yield nothing, an incomplete run is named by `incomplete_details.reason`, the other terminal statuses stand for themselves. All three surfaces route through it, and the LangChain callback reads the message's `response_metadata` as well as `generation_info`, under either spelling. (The JS callback also reads `response_metadata` nested inside `generation_info`; Python langchain never populates that, so it is left out.)

Ports [PostHog/posthog-js#4700](https://github.com/PostHog/posthog-js/pull/4700) and [PostHog/posthog-js#4736](https://github.com/PostHog/posthog-js/pull/4736) to Python. (The token-counts sibling was already ported in #906.)

## :green_heart: How did you test it?

- 15 new unit cases: a parametrized table for `extract_openai_stop_reason` (terminal passthrough, `incomplete_details.reason` naming, bare-incomplete fallback, queued/in_progress yielding nothing, Chat Completions passthrough), a streaming test covering all three terminal lifecycle events plus the non-terminal lock, and a parametrized callback table (Responses metadata, Anthropic `stop_reason`, queued, and `generation_info.finish_reason` priority).
- Revert-proven: with the source change stashed, exactly the 7 behavior-changing cases fail; the 8 passing rows are deliberate locks on unchanged behavior.
- Full `posthog/test/ai/openai` + `posthog/test/ai/langchain` suites: no failure that isn't already failing on `main` (the remaining failures are real-API integration tests picking up this sandbox's non-OpenAI key).
- `ruff format --check`, `ruff check`, repo-wide `mypy | mypy-baseline filter` (clean, 226 files), `check_public_api.py` (helper kept underscore-private, so no surface change), `python -W error -c "import posthog"`.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code, directed by a PostHog engineer, as the Python port of the stop-reason fixes that landed in posthog-js. Each of the three gaps was verified against this repo's code before writing: the wrapper and accumulator behavior differs from JS in opposite directions (JS over-fired with the wrong vocabulary, Python under-fires with nothing). The helper is underscore-private rather than public because the JS equivalent is not part of that package's export surface either, and `check_public_api.py` treats any bare name as API commitment. The langchain `response_metadata` shape was pinned against langchain-openai's own tests rather than assumed from the JS shapes. Skills invoked: writing-tests, writing-pr-descriptions.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*

