### PR TITLE
fix(mcp): report the Python package version

### DIFF
--- a/.sampo/changesets/somber-runesinger-tuonetar.md
+++ b/.sampo/changesets/somber-runesinger-tuonetar.md
@@ -1,0 +1,5 @@
+---
+pypi/posthog: patch
+---
+
+Report the Python package version in MCP event metadata and request headers so SDK Health can assess the installed package.

--- a/posthog/mcp/README.md
+++ b/posthog/mcp/README.md
@@ -16,10 +16,10 @@ analytics = instrument(server, posthog)
 Install is just `pip install posthog`. `instrument()` needs the MCP SDK at runtime,
 but anyone wrapping a server already has it.
 
-MCP analytics events report `$lib: "posthog-python-mcp"`. Because `$lib` is a
-client-level identity, `instrument()` relabels every event sent by the client passed
-to it. Use a client dedicated to MCP analytics if the application also captures
-unrelated events.
+MCP analytics events report `$lib: "posthog-python-mcp"` and the installed `posthog` package version in `$lib_version`.
+Request headers use the same identity and package version, so SDK Health can compare MCP traffic with Python SDK releases.
+Because `$lib` is a client-level identity, `instrument()` relabels every event sent by the client passed to it.
+Use a client dedicated to MCP analytics if the application also captures unrelated events.
 
 ## Stateless / multi-pod servers
 

--- a/posthog/mcp/_lib_identity.py
+++ b/posthog/mcp/_lib_identity.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 from ..client import Client
+from ..version import VERSION
 
 from .constants import POSTHOG_MCP_LIB_NAME
-from .version import __version__
 
 
 def apply_mcp_lib_identity(client: Client) -> None:
     """Relabel every event sent by ``client`` as coming from ``posthog.mcp``."""
     set_identity = getattr(client, "_set_library_identity", None)
     if set_identity is not None:
-        set_identity(POSTHOG_MCP_LIB_NAME, __version__)
+        set_identity(POSTHOG_MCP_LIB_NAME, VERSION)

--- a/posthog/test/mcp/test_no_crash.py
+++ b/posthog/test/mcp/test_no_crash.py
@@ -11,8 +11,8 @@ import pytest
 
 from posthog.client import Client
 from posthog.mcp import instrument
-from posthog.mcp.version import __version__ as MCP_VERSION
 from posthog.test.mcp._helpers import MCP_MAJOR, FakeClient
+from posthog.version import VERSION
 
 
 async def test_unsupported_server_returns_noop_handle():
@@ -75,7 +75,7 @@ def test_instrument_relabels_the_host_client():
     client.capture("after instrumentation")
 
     assert captured[0]["properties"]["$lib"] == "posthog-python-mcp"
-    assert captured[0]["properties"]["$lib_version"] == MCP_VERSION
+    assert captured[0]["properties"]["$lib_version"] == VERSION
 
 
 @pytest.mark.parametrize(

--- a/posthog/test/mcp/test_posthog_mcp.py
+++ b/posthog/test/mcp/test_posthog_mcp.py
@@ -4,11 +4,11 @@ from unittest import mock
 
 from posthog.capture_mode import CaptureMode
 from posthog.mcp import PostHogMCP
-from posthog.mcp.version import __version__ as MCP_VERSION
 from posthog.test.mcp._helpers import (
     events_named as _events,
     flush_background as _flush,
 )
+from posthog.version import VERSION
 
 
 def make_client():
@@ -73,7 +73,7 @@ async def test_mcp_events_use_mcp_library_identity():
     assert {event["event"] for event in captured} == {"$mcp_tool_call", "$exception"}
     assert all(
         event["properties"]["$lib"] == "posthog-python-mcp"
-        and event["properties"]["$lib_version"] == MCP_VERSION
+        and event["properties"]["$lib_version"] == VERSION
         for event in captured
     )
 
@@ -86,7 +86,7 @@ def test_mcp_library_identity_reaches_capture_v0_header():
         client.capture("$mcp_custom")
 
     assert post.call_args.kwargs["headers"]["User-Agent"] == (
-        f"posthog-python-mcp/{MCP_VERSION}"
+        f"posthog-python-mcp/{VERSION}"
     )
 
 
@@ -95,10 +95,10 @@ def test_mcp_library_identity_reaches_capture_v1_header():
     with mock.patch("posthog.client._send_v1_batch") as send:
         client.capture("$mcp_custom")
 
-    assert send.call_args.kwargs["sdk_info"] == f"posthog-python-mcp/{MCP_VERSION}"
+    assert send.call_args.kwargs["sdk_info"] == f"posthog-python-mcp/{VERSION}"
     event = send.call_args.args[2][0]
     assert event["properties"]["$lib"] == "posthog-python-mcp"
-    assert event["properties"]["$lib_version"] == MCP_VERSION
+    assert event["properties"]["$lib_version"] == VERSION
 
 
 def test_mcp_library_identity_reaches_feature_flag_requests():
@@ -112,7 +112,7 @@ def test_mcp_library_identity_reaches_feature_flag_requests():
         client.evaluate_flags("user_1")
 
     assert post.call_args.kwargs["headers"]["User-Agent"] == (
-        f"posthog-python-mcp/{MCP_VERSION}"
+        f"posthog-python-mcp/{VERSION}"
     )
 
 
@@ -130,7 +130,7 @@ def test_mcp_library_identity_reaches_feature_flag_definition_requests():
         client.load_feature_flags()
 
     assert get.call_args.kwargs["headers"]["User-Agent"] == (
-        f"posthog-python-mcp/{MCP_VERSION}"
+        f"posthog-python-mcp/{VERSION}"
     )
     client.shutdown()
 
@@ -144,7 +144,7 @@ def test_mcp_library_identity_reaches_remote_config_requests():
         assert client.get_remote_config_payload("flag-key") == "payload"
 
     assert get.call_args.kwargs["headers"]["User-Agent"] == (
-        f"posthog-python-mcp/{MCP_VERSION}"
+        f"posthog-python-mcp/{VERSION}"
     )
 
 


### PR DESCRIPTION
## :bulb: Motivation and Context

Python MCP users need SDK Health to assess their installed Python package, not the bundled integration's independent version.
MCP events and request headers now report the Python package version while keeping the `posthog-python-mcp` identity.

Companion SDK Health support: [PostHog/posthog#95562](https://github.com/PostHog/posthog/pull/95562).
That PR ignores legacy integration versions, so either PR can land first.

## :green_heart: How did you test it?

- Updated existing MCP regressions for event metadata, capture v0/v1 headers, feature flag requests, remote configuration, and instrumented clients.
- Ran the MCP test directory, Ruff, the repository mypy check, and the warnings-as-errors import check.
- No live ingestion testing.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi implemented the fix using bash, read, and edit. Skills: `/pr`, `/autoreview`, `/writing-tests`, `/writing-user-facing-copy`, and `/writing-pr-descriptions`.
The final autoreview found no actionable issues. The change uses public SDK source; no customer material is included.
