### PR TITLE
fix: sanitize None values from event properties before queueing

### DIFF
--- a/posthog/client.py
+++ b/posthog/client.py
@@ -2329,6 +2329,9 @@ class Client(object):
                 k: v for k, v in msg["properties"].items() if k in property_allowlist
             }
 
+        if isinstance(msg.get("properties"), dict):
+            msg["properties"] = {k: v for k, v in msg["properties"].items() if v is not None}
+
         msg["distinct_id"] = stringify_id(msg.get("distinct_id", None))
 
         msg = clean(msg)

--- a/posthog/test/test_client.py
+++ b/posthog/test/test_client.py
@@ -402,6 +402,23 @@ class TestClient(unittest.TestCase):
             assert msg["properties"]["$os"] == mock.ANY
             assert msg["properties"]["$os_version"] == mock.ANY
 
+    def test_capture_sanitizes_none_properties(self):
+        with mock.patch("posthog.client.batch_post") as mock_post:
+            client = Client(FAKE_TEST_API_KEY, on_error=self.set_fail, sync_mode=True)
+            client.capture(
+                "python test event", 
+                distinct_id="distinct_id", 
+                properties={"valid": 123, "invalid": None}
+            )
+            self.assertFalse(self.failed)
+
+            mock_post.assert_called_once()
+            msg = mock_post.call_args[1]["batch"][0]
+            
+            self.assertIn("valid", msg["properties"])
+            self.assertEqual(msg["properties"]["valid"], 123)
+            self.assertNotIn("invalid", msg["properties"])
+
     def test_capture_omits_is_server_when_disabled(self):
         with mock.patch("posthog.client.batch_post") as mock_post:
             client = Client(


### PR DESCRIPTION
### TL;DR
Adds defensive sanitization to the message queueing flow to strip `None` values from event `properties` before they are batched and sent over the network.

### 🔍 Context & Motivation
When developers pass dynamic property dictionaries into `posthog.capture()` (e.g., pulling data from an external API or scraper), keys with `None` values can easily slip in. 

Currently, these null values are queued, serialized into JSON, and sent to the PostHog API. This causes two minor issues:
1. **Network & Storage Inefficiency:** Sending `{ "optional_field": null }` across the wire consumes unnecessary bandwidth and inflates the size of the event payload. 
2. **Dashboard Clutter:** Null properties can clutter the PostHog dashboard UI, showing fields that contain no actionable analytics data.

### 🛠️ Changes Implemented
Added a lightweight dictionary comprehension in `posthog/client.py` during the internal message preparation phase. It checks if `msg.get("properties")` is a dictionary, and if so, it filters out any keys where the value is explicitly `None` right before the `msg` is cleaned and appended to the batch.

*Note: Empty strings, `0`, and `False` are preserved, as they are often valid analytics values.*

### ✅ Verification
- **Unit Test:** Added `test_capture_sanitizes_none_properties` in `posthog/test/test_client.py`. It simulates a `client.capture` call with both valid and `None` properties, mocking the network request to assert the batched payload only retains the valid keys.
- **Local Tests:** Verified using local test suite without breaking existing queueing behavior. 

### 📉 Impact
- **Safe:** 100% backward-compatible. Valid properties remain untouched.
- **Fast:** Standard O(n) Python dictionary comprehension adds negligible overhead to the queueing process.