### PR TITLE
fix: honor HTTP-date Retry-After in async requests

### DIFF
--- a/.sampo/changesets/async-retry-after-date.md
+++ b/.sampo/changesets/async-retry-after-date.md
@@ -1,0 +1,5 @@
+---
+pypi/posthog: patch
+---
+
+Honor HTTP-date Retry-After headers in asynchronous requests while preserving the existing retry backoff and delay cap.

--- a/posthog/_async_request.py
+++ b/posthog/_async_request.py
@@ -11,7 +11,7 @@ from typing import Any, Optional
 from urllib.parse import quote, urljoin, urlsplit
 
 from .capture_compression import CaptureCompression
-from .capture_v1 import _send_v1_batch
+from .capture_v1 import _parse_retry_after, _send_v1_batch
 from .request import (
     APIError,
     DatetimeSerializer,
@@ -100,21 +100,11 @@ def _serialize_flags_body(
     }
 
 
-def _parse_retry_after(response: Any) -> Optional[float]:
-    value = response.headers.get("Retry-After")
-    if value is None:
-        return None
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        return None
-
-
 def _process_response(response: Any) -> None:
     if response.status_code == 200:
         return
 
-    retry_after = _parse_retry_after(response)
+    retry_after = _parse_retry_after(response.headers.get("Retry-After"))
     try:
         payload = response.json()
         detail = payload["detail"]

--- a/posthog/test/test_async_consumer.py
+++ b/posthog/test/test_async_consumer.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from unittest import mock
 
+import httpx
 import pytest
+from freezegun import freeze_time
 
 from posthog._async_consumer import _AsyncConsumer
 from posthog.capture_compression import CaptureCompression
@@ -58,6 +61,56 @@ async def test_request_retries_transient_failures_until_success(
 
     assert batch_post.await_count == failures + 1
     assert [call.args[0] for call in sleep.await_args_list] == expected_delays
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("retry_after", "expected_delay"),
+    [
+        ("Tue, 08 Sep 2026 00:00:10 GMT", 10),
+        ("Tue, 08 Sep 2026 00:01:00 GMT", 30),
+        ("Mon, 07 Sep 2026 23:59:59 GMT", 1),
+        ("5", 5),
+        ("0", 1),
+        ("-1", 1),
+        ("invalid", 1),
+        (None, 1),
+    ],
+)
+async def test_request_honors_retry_after_from_http_response(
+    retry_after, expected_delay
+):
+    headers = {"Retry-After": retry_after} if retry_after is not None else {}
+    responses = [
+        httpx.Response(503, headers=headers, json={"detail": "temporary"}),
+        httpx.Response(200, json={"ok": True}),
+    ]
+    requests = []
+
+    def handle_request(request):
+        requests.append(request)
+        return responses.pop(0)
+
+    consumer = make_consumer(retries=1)
+    batch = [{"event": "test", "distinct_id": "test-user"}]
+    async with httpx.AsyncClient(
+        base_url="https://example.com", transport=httpx.MockTransport(handle_request)
+    ) as client:
+        consumer.http_client = client
+        with (
+            freeze_time("2026-09-08 00:00:00", real_asyncio=True),
+            mock.patch(
+                "posthog._async_consumer.asyncio.sleep", new=mock.AsyncMock()
+            ) as sleep,
+        ):
+            await consumer.request(batch)
+
+    sleep.assert_awaited_once_with(expected_delay)
+    assert len(requests) == 2
+    assert [json.loads(request.content)["batch"] for request in requests] == [
+        batch,
+        batch,
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## :bulb: Motivation and Context

Async requests now honor `Retry-After` when the server supplies an HTTP date. Previously, a 503 asking the legacy async consumer to wait ten seconds retried after one second because only numeric headers were parsed. Reusing the existing v1 parser keeps the consumer's backoff and 30-second cap intact.

## :green_heart: How did you test it?

- 130 focused tests pass across `test_async_consumer.py`, `test_async_request.py` and `test_capture_v1.py`. Two new date cases fail before the fix. The regression uses real `httpx.MockTransport` responses, frozen time and mocked sleeps.
- Ruff format/lint, mypy baseline, strict import and public API snapshot checks pass.
- Full native Windows run: 2,412 passed, 24 skipped, three failures and eight temporary-directory errors. All 11 reproduce on unchanged `6b0c98f`. The eight fixture errors pass with an isolated `--basetemp`; the remaining failures depend on POSIX path separators or `os.register_at_fork`.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed. No public API documentation change is needed.
- [x] No breaking change or entry added to the changelog. A patch changeset is included.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file. The equivalent `pypi/posthog: patch` changeset was written directly in `.sampo/changesets/`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The author requested additional open-source contributions. Codex (GPT-6) selected this defect, implemented the fix, ran the tests and performed the code review with Git, GitHub CLI, uv, pytest, Ruff and mypy. The implementation reuses the existing parser; the regression exercises the transport-to-consumer path. No shareable session link is available. Maintainer human review is still required.

The human driver/DRI is `Bortlesboat`. GitHub rejected self-assignment for this external contributor (403); a maintainer needs to set the PR assignee.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required; the existing retry limits are preserved and the changed header behavior is covered by deterministic regression tests.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
