### PR TITLE
fix: clean up async consumer waiters on cancellation

### DIFF
--- a/.sampo/changesets/async-consumer-cancellation.md
+++ b/.sampo/changesets/async-consumer-cancellation.md
@@ -1,0 +1,5 @@
+---
+pypi/posthog: patch
+---
+
+Clean up queue and flush waiters when the async capture consumer is cancelled.

--- a/posthog/_async_consumer.py
+++ b/posthog/_async_consumer.py
@@ -117,15 +117,17 @@ class _AsyncConsumer:
     async def _get_or_flush(self, timeout: float) -> tuple[Any, bool]:
         get_task = asyncio.create_task(self.queue.get())
         flush_task = asyncio.create_task(self._flush_event.wait())
-        done, pending = await asyncio.wait(
-            {get_task, flush_task},
-            timeout=timeout,
-            return_when=asyncio.FIRST_COMPLETED,
-        )
-        for task in pending:
-            task.cancel()
-        if pending:
-            await asyncio.gather(*pending, return_exceptions=True)
+        try:
+            done, _ = await asyncio.wait(
+                {get_task, flush_task},
+                timeout=timeout,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+        finally:
+            for task in (get_task, flush_task):
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(get_task, flush_task, return_exceptions=True)
 
         if get_task in done:
             return get_task.result(), False

--- a/posthog/test/test_async_consumer.py
+++ b/posthog/test/test_async_consumer.py
@@ -152,3 +152,58 @@ async def test_request_stops_after_configured_retry_limit():
 
     assert batch_post.await_count == 3
     assert [call.args[0] for call in sleep.await_args_list] == [1, 2]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("run_worker", [False, True], ids=["wait", "worker"])
+async def test_get_or_flush_cancels_waiters_on_cancellation(run_worker):
+    consumer = make_consumer(retries=0)
+    consumer.flush_interval = 60
+    wait_started = asyncio.Event()
+    waiters = []
+    real_wait = asyncio.wait
+
+    async def observe_wait(tasks, **kwargs):
+        waiters.extend(tasks)
+        wait_started.set()
+        return await real_wait(tasks, **kwargs)
+
+    with mock.patch("posthog._async_consumer.asyncio.wait", side_effect=observe_wait):
+        task = asyncio.create_task(
+            consumer.run() if run_worker else consumer._get_or_flush(60)
+        )
+        try:
+            await wait_started.wait()
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+            assert len(waiters) == 2
+            assert all(waiter.cancelled() for waiter in waiters)
+        finally:
+            task.cancel()
+            for waiter in waiters:
+                waiter.cancel()
+            await asyncio.gather(task, *waiters, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("queued", "flush"), [(True, False), (False, True), (False, False), (True, True)]
+)
+async def test_get_or_flush_preserves_results_and_cleans_up_waiters(queued, flush):
+    consumer = make_consumer(retries=0)
+    event = {"event": "test"}
+    if queued:
+        consumer.queue.put_nowait(event)
+    if flush:
+        consumer.request_flush()
+    tasks_before = asyncio.all_tasks()
+
+    result = await consumer._get_or_flush(60 if queued or flush else 0)
+
+    assert result == (event if queued else None, flush and not queued)
+    assert consumer._flush_event.is_set() == (queued and flush)
+    assert not (asyncio.all_tasks() - tasks_before)
+    if queued:
+        consumer.queue.task_done()


### PR DESCRIPTION
## :bulb: Motivation and Context

Cancelling `_get_or_flush` while it is inside `asyncio.wait` can leave its queue and flush helper tasks pending. Put the wait in `try/finally`, cancel any unfinished helper tasks, and gather both before propagating cancellation.

## :green_heart: How did you test it?

- Full test suite: 2,488 passed, 15 skipped, 38 subtests passed
- Full mypy check: 230 source files, no issues
- Import smoke test and package build
- Added cancellation and result-preservation coverage for `_get_or_flush` and the worker path

The repository-wide Ruff command currently reports existing formatting and legacy-lint findings in untouched files; the modified Python files pass formatting.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file

An equivalent patch changeset is included at `.sampo/changesets/async-consumer-cancellation.md`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The contributor directed the scope and exact cleanup behavior. Codex helped inspect the repository, apply the bounded change, and run the repository checks; the implementation cancels only unfinished waiter tasks and gathers both to avoid leaked-task warnings.
