### PR TITLE
fix(ai): harden Prompts.get_all against old servers and malformed rows

### DIFF
--- a/.sampo/changesets/prompts-get-all-hardening.md
+++ b/.sampo/changesets/prompts-get-all-hardening.md
@@ -1,0 +1,5 @@
+---
+pypi/posthog: patch
+---
+
+`Prompts.get_all` now fails loudly in two cases it previously papered over: a server that ignores the label filter but happens to have some labels on latest versions no longer produces a silently incomplete result, and a malformed row in the list response now raises the invalid-response error instead of being skipped. A rejected batch also no longer leaves partially cached prompts.

--- a/posthog/ai/prompts.py
+++ b/posthog/ai/prompts.py
@@ -425,6 +425,18 @@ class Prompts:
                 continue
             resolved_rows.append(row)
 
+        if rows and not resolved_rows:
+            # Every returned row was skipped as moved. One moved label is a
+            # mid-request race, but all of them means the server most likely
+            # ignored the label param and served latest versions.
+            compat_error = Exception(
+                f'[PostHog Prompts] The server returned prompts, but none resolve label "{label}". '
+                "It may not support fetching prompts by label on the list endpoint yet. "
+                "Upgrade PostHog, or fetch prompts one by one with get()."
+            )
+            self._maybe_capture_error(compat_error, name="*", version=None, label=label)
+            raise compat_error
+
         now = time.time()
         results: Dict[str, PromptResult] = {}
         for row in resolved_rows:

--- a/posthog/ai/prompts.py
+++ b/posthog/ai/prompts.py
@@ -385,8 +385,16 @@ class Prompts:
         results: Dict[str, PromptResult] = {}
         skipped: List[str] = []
         for row in rows:
-            if not _is_prompt_api_response(row) or not _row_resolves_label(row, label):
-                skipped.append(str(row.get("name")) if isinstance(row, dict) else "?")
+            if not _is_prompt_api_response(row):
+                invalid_error = Exception(
+                    f'[PostHog Prompts] Invalid response format for prompts with label "{label}"'
+                )
+                self._maybe_capture_error(
+                    invalid_error, name="*", version=None, label=label
+                )
+                raise invalid_error
+            if not _row_resolves_label(row, label):
+                skipped.append(row["name"])
                 continue
 
             config = _extract_config(row)

--- a/posthog/ai/prompts.py
+++ b/posthog/ai/prompts.py
@@ -112,22 +112,32 @@ def _is_prompt_api_response(data: Any) -> bool:
     )
 
 
-def _row_resolves_label(row: Dict[str, Any], label: str) -> bool:
-    """Check that the server resolved this list row through the requested label.
+def _row_label_state(
+    row: Dict[str, Any], label: str
+) -> Literal["resolved", "moved", "absent"]:
+    """Classify how a list row relates to the requested label, via all_labels.
 
-    An older server ignores the label param on the list endpoint and returns the
-    latest version of every prompt. A row that was resolved through a label
-    carries a matching name and version entry in its all_labels field.
+    'resolved': the row is the version the label points to.
+    'moved': the prompt carries the label, but on another version. Happens when
+    the label moves between the query and the response.
+    'absent': the prompt does not carry the label at any version. A server that
+    filters by label never returns such a row, so this means the server ignored
+    the label param (an older PostHog release) and served latest versions.
     """
     all_labels = row.get("all_labels")
     if not isinstance(all_labels, list):
-        return False
-    return any(
-        isinstance(entry, dict)
-        and entry.get("name") == label
-        and entry.get("version") == row.get("version")
-        for entry in all_labels
+        return "absent"
+    entry = next(
+        (
+            candidate
+            for candidate in all_labels
+            if isinstance(candidate, dict) and candidate.get("name") == label
+        ),
+        None,
     )
+    if entry is None:
+        return "absent"
+    return "resolved" if entry.get("version") == row.get("version") else "moved"
 
 
 def _is_same_origin(url: str, host: str) -> bool:
@@ -381,8 +391,9 @@ class Prompts:
             self._maybe_capture_error(error, name="*", version=None, label=label)
             raise
 
-        now = time.time()
-        results: Dict[str, PromptResult] = {}
+        # Validate every row before caching any, so a rejected batch leaves
+        # the cache untouched.
+        resolved_rows: List[Dict[str, Any]] = []
         skipped: List[str] = []
         for row in rows:
             if not _is_prompt_api_response(row):
@@ -393,10 +404,30 @@ class Prompts:
                     invalid_error, name="*", version=None, label=label
                 )
                 raise invalid_error
-            if not _row_resolves_label(row, label):
+
+            label_state = _row_label_state(row, label)
+            if label_state == "absent":
+                # Even one unlabeled row proves the server did not filter, and
+                # then rows that look resolved are only labels that happen to
+                # point at the latest version. A partial result here would hide
+                # the rest, so fail loudly instead.
+                compat_error = Exception(
+                    f'[PostHog Prompts] The server returned a prompt that does not carry label "{label}". '
+                    "It may not support fetching prompts by label on the list endpoint yet. "
+                    "Upgrade PostHog, or fetch prompts one by one with get()."
+                )
+                self._maybe_capture_error(
+                    compat_error, name="*", version=None, label=label
+                )
+                raise compat_error
+            if label_state == "moved":
                 skipped.append(row["name"])
                 continue
+            resolved_rows.append(row)
 
+        now = time.time()
+        results: Dict[str, PromptResult] = {}
+        for row in resolved_rows:
             config = _extract_config(row)
             self._cache[_cache_key(row["name"], None, label)] = CachedPrompt(
                 prompt=row["prompt"],
@@ -414,19 +445,6 @@ class Prompts:
                 label=label,
                 config=copy.deepcopy(config),
             )
-
-        if rows and not results:
-            # Nothing resolved the label, so the server most likely ignored the
-            # label param and served latest versions. Caching those under the
-            # label would be the silent wrong-version failure labels exist to
-            # prevent, so fail loudly instead.
-            compat_error = Exception(
-                f'[PostHog Prompts] The server returned prompts, but none resolve label "{label}". '
-                "It may not support fetching prompts by label on the list endpoint yet. "
-                "Upgrade PostHog, or fetch prompts one by one with get()."
-            )
-            self._maybe_capture_error(compat_error, name="*", version=None, label=label)
-            raise compat_error
 
         if skipped:
             log.warning(

--- a/posthog/test/ai/test_prompts.py
+++ b/posthog/test/ai/test_prompts.py
@@ -1460,6 +1460,29 @@ class TestPromptsGetAll(TestPrompts):
         self.assertEqual(list(results), ["prompt-b"])
 
     @patch("posthog.ai.prompts._get_session")
+    def test_raises_when_every_row_was_skipped_as_moved(self, mock_get_session):
+        # An old server can serve latest versions while every prompt's label
+        # points at an earlier version. Each row then looks like a moved label;
+        # returning {} would report no labeled prompts despite them existing.
+        mock_get = mock_get_session.return_value.get
+        row_a = {
+            **self.labeled_row("prompt-a", version=2),
+            "all_labels": [{"name": "production", "version": 1}],
+        }
+        row_b = {
+            **self.labeled_row("prompt-b", version=3),
+            "all_labels": [{"name": "production", "version": 2}],
+        }
+        mock_get.return_value = self.list_response([row_a, row_b])
+
+        prompts = Prompts(self.create_mock_posthog())
+
+        with self.assertRaises(Exception) as ctx:
+            prompts.get_all(label="production")
+        self.assertIn("none resolve label", str(ctx.exception))
+        self.assertEqual(prompts._cache, {})
+
+    @patch("posthog.ai.prompts._get_session")
     def test_raises_on_a_malformed_row_and_caches_nothing(self, mock_get_session):
         # A row failing response validation is a server error, not a moved
         # label; returning the valid subset would hide it.

--- a/posthog/test/ai/test_prompts.py
+++ b/posthog/test/ai/test_prompts.py
@@ -1428,18 +1428,19 @@ class TestPromptsGetAll(TestPrompts):
 
     @patch("posthog.ai.prompts._get_session")
     def test_raises_when_the_server_ignores_the_label(self, mock_get_session):
-        # An old server ignores ?label= and returns latest versions; none of the
-        # rows resolve the label, and caching them would serve wrong versions.
+        # An old server ignores ?label= and returns latest versions of every
+        # prompt, including prompts without the label. Even when some labels
+        # happen to point at latest, a partial result would hide the rest.
         mock_get = mock_get_session.return_value.get
-        row = self.labeled_row("prompt-a")
-        row["all_labels"] = []
-        mock_get.return_value = self.list_response([row])
+        looks_resolved = self.labeled_row("prompt-a")
+        unlabeled = {**self.labeled_row("prompt-b"), "all_labels": []}
+        mock_get.return_value = self.list_response([looks_resolved, unlabeled])
 
         prompts = Prompts(self.create_mock_posthog())
 
         with self.assertRaises(Exception) as ctx:
             prompts.get_all(label="production")
-        self.assertIn("none resolve label", str(ctx.exception))
+        self.assertIn("does not carry label", str(ctx.exception))
         self.assertEqual(prompts._cache, {})
 
     @patch("posthog.ai.prompts._get_session")
@@ -1465,7 +1466,7 @@ class TestPromptsGetAll(TestPrompts):
         mock_get = mock_get_session.return_value.get
         malformed = {**self.labeled_row("prompt-a"), "prompt": 42}
         mock_get.return_value = self.list_response(
-            [malformed, self.labeled_row("prompt-b")]
+            [self.labeled_row("prompt-b"), malformed]
         )
 
         prompts = Prompts(self.create_mock_posthog())

--- a/posthog/test/ai/test_prompts.py
+++ b/posthog/test/ai/test_prompts.py
@@ -1459,6 +1459,23 @@ class TestPromptsGetAll(TestPrompts):
         self.assertEqual(list(results), ["prompt-b"])
 
     @patch("posthog.ai.prompts._get_session")
+    def test_raises_on_a_malformed_row_and_caches_nothing(self, mock_get_session):
+        # A row failing response validation is a server error, not a moved
+        # label; returning the valid subset would hide it.
+        mock_get = mock_get_session.return_value.get
+        malformed = {**self.labeled_row("prompt-a"), "prompt": 42}
+        mock_get.return_value = self.list_response(
+            [malformed, self.labeled_row("prompt-b")]
+        )
+
+        prompts = Prompts(self.create_mock_posthog())
+
+        with self.assertRaises(Exception) as ctx:
+            prompts.get_all(label="production")
+        self.assertIn("Invalid response format", str(ctx.exception))
+        self.assertEqual(prompts._cache, {})
+
+    @patch("posthog.ai.prompts._get_session")
     def test_refuses_a_pagination_link_off_the_configured_host(self, mock_get_session):
         mock_get = mock_get_session.return_value.get
         mock_get.return_value = self.list_response(


### PR DESCRIPTION
## :bulb: Motivation and Context

Review of the posthog-js port (PostHog/posthog-js#4903) found two gaps that also exist in the merged `Prompts.get_all` (#938):

- On an old server that ignores the `label` param, prompts whose label happens to point at the latest version still pass the row check. `get_all` then returns that subset as a complete result, silently missing the rest. The old guard only fired when no row passed.
- A malformed row (for example a non-string prompt) was skipped like a moved label, instead of raising the invalid-response error the per-name path raises.

Best to land before `get_all` ships to PyPI, so the first published version has the hardened behavior.

## Changes

- The row check now has three states. A row whose `all_labels` does not contain the label at all can only come from a server that did not filter, so even one such row makes `get_all` raise. A label present at a different version stays the benign mid-request race: skip and warn.
- A malformed row raises instead of being skipped.
- Rows are validated before anything is cached, so a rejected batch leaves the cache untouched.
- Both new failures go through `_maybe_capture_error`, like the other fetch failures.

## :green_heart: How did you test it?

- Updated the old-server test to the partial case: one row that looks resolved next to one unlabeled row now raises, and nothing is cached.
- New test: a malformed row raises and leaves the cache empty, even when a valid row came first.
- Ran the full prompts test file, ruff, mypy (baseline clean), and the public API snapshot check.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed. (No docs exist for get_all yet; coming with the release.)
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Changeset added in `.sampo/changesets/` (written by hand, same format as `sampo add`)

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written with Claude Code, directed by the assignee. Ports posthog-js commits 3d8197f56 and 25a7bd5cd from PostHog/posthog-js#4903 review findings back to Python.
- The `__proto__` fix from that review does not apply here: Python dicts have no prototype.
